### PR TITLE
VirtualMachineManager updates

### DIFF
--- a/lib/azure/armrest/armrest_manager.rb
+++ b/lib/azure/armrest/armrest_manager.rb
@@ -158,7 +158,7 @@ module Azure
       def resource_groups
         url = url_with_api_version(@base_url, 'subscriptions', subscription_id, 'resourcegroups')
         resp = rest_get(url)
-        JSON.parse(resp.body)
+        JSON.parse(resp.body)["value"]
       end
 
       # Returns information the specified resource group, or the
@@ -208,7 +208,7 @@ module Azure
 
       # Take an array of URI elements and join the together with the API version.
       def url_with_api_version(*paths)
-        File.join(*paths, "?api-version=#{api_version}")
+        path = File.join(*paths) << "?api-version=#{api_version}"
       end
 
     end # ArmRestManager

--- a/lib/azure/armrest/armrest_manager.rb
+++ b/lib/azure/armrest/armrest_manager.rb
@@ -155,7 +155,7 @@ module Azure
 
       # Returns a list of resource groups for the given subscription.
       #
-      def resource_groups
+      def resource_groups(subscription_id = @subscription_id)
         url = url_with_api_version(@base_url, 'subscriptions', subscription_id, 'resourcegroups')
         resp = rest_get(url)
         JSON.parse(resp.body)["value"]

--- a/lib/azure/armrest/virtual_machine_manager.rb
+++ b/lib/azure/armrest/virtual_machine_manager.rb
@@ -33,10 +33,8 @@ module Azure
       def list(group = @resource_group)
         set_default_subscription
 
-        # The virtual machine API requires an older api-version at the moment.
-        @api_version = '2014-06-01'
-
         if group
+          @api_version = '2014-06-01'
           url = build_url(@subscription_id, group)
           res = JSON.parse(rest_get(url))['value']
           res.empty? ? res : res.map{ |vm| vm['properties'] }
@@ -44,6 +42,7 @@ module Azure
           arr = []
 
           resource_groups.each{ |group|
+            @api_version = '2014-06-01' # Must be set after resource_groups call
             url = build_url(@subscription_id, group['name'])
             res = JSON.parse(rest_get(url))['value']
             unless res.empty?
@@ -257,6 +256,7 @@ module Azure
 
       private
 
+      # If no default subscription is set, then use the first one found.
       def set_default_subscription
         @subscription_id ||= subscriptions.first['subscriptionId']
       end


### PR DESCRIPTION
This PR revamps the VirtualMachineManager. It updates the list method and adds the list_all method, which will give us all information for all subscription + resource group combinations.

It also no longer assumes a resource group or subscription id is set (and previously it would bomb if they weren't set) so the @base_url instance had to be removed. These must still be optional, so instead I've added a build_url method that instance methods can use to construct url's prior to making requests, and a set_default_subscription private method that will use the first subscription found if not already set.

Lastly, we have to deal with some api_version wonkiness on Microsoft's end, where certain methods currently only work with older api version strings.

Here are some examples:

    vmm = ArmRest::VirtualMachineManager.new

    # List vm's for just one resource group for the current subscription
    p vmm.list('win2k12-test1') 

    # List all vm's for all resource groups for all subscriptions
    p vmm.list_all 