### PR TITLE
Return a single element rather than a one-element array.

### DIFF
--- a/lib/azure/armrest/virtual_machine_manager.rb
+++ b/lib/azure/armrest/virtual_machine_manager.rb
@@ -32,7 +32,6 @@ module Azure
       #
       def list(group = @resource_group)
         set_default_subscription
-        require 'pp'
 
         if group
           @api_version = '2014-06-01'
@@ -219,17 +218,22 @@ module Azure
       # is false, it will retrieve an instance view. The difference is
       # in the details of the information retrieved.
       #--
-      # GET
+      # TODO: Figure out why instance view isn't working
       #
-      def get(vmname, model_view = true)
+      def get(vmname, model_view = true, group = @resource_group)
+        set_default_subscription
+
+        raise ArgumentError, "must specify resource group" unless group
+
+        @api_version = '2014-06-01'
+
         if model_view
-          uri = url_with_api_version(@base_url, vmname)
+          url = build_url(@subscription_id, group, vmname)
         else
-          uri = url_with_api_version(@base_url, vmname, 'InstanceView')
+          url = build_url(@subscription_id, group, vmname, 'instanceView')
         end
 
-        json = rest_get(uri)
-        VirtualMachine.new(json)
+        JSON.parse(rest_get(url))
       end
 
       # Returns a complete list of operations.
@@ -273,7 +277,7 @@ module Azure
 
       # Builds a URL based on subscription_id an resource_group and any other
       # arguments provided, and appends it with the api-version.
-      def build_url(subscription_id, resource_group, args = nil)
+      def build_url(subscription_id, resource_group, *args)
         url = File.join(
           Azure::ArmRest::COMMON_URI,
           subscription_id,
@@ -284,7 +288,7 @@ module Azure
           'virtualMachines',
         )
 
-        url = File.join(url, *args) if args
+        url = File.join(url, *args) unless args.empty?
         url << "?api-version=#{@api_version}"
       end
     end

--- a/lib/azure/armrest/virtual_machine_manager.rb
+++ b/lib/azure/armrest/virtual_machine_manager.rb
@@ -32,12 +32,12 @@ module Azure
       #
       def list(group = @resource_group)
         set_default_subscription
+        require 'pp'
 
         if group
           @api_version = '2014-06-01'
           url = build_url(@subscription_id, group)
-          res = JSON.parse(rest_get(url))['value']
-          res.empty? ? res : res.map{ |vm| vm['properties'] }
+          JSON.parse(rest_get(url))['value'].first
         else
           arr = []
           thr = []
@@ -47,10 +47,8 @@ module Azure
             url = build_url(@subscription_id, group['name'])
 
             thr << Thread.new{
-              res = JSON.parse(rest_get(url))['value']
-              unless res.empty?
-                arr << res.map{ |vm| vm['properties'] }
-              end
+              res = JSON.parse(rest_get(url))['value'].first
+              arr << res unless res.empty?
             }
           end
 


### PR DESCRIPTION
This also gets rid of the properties shortcut.

First, I realized we needed some information that shortcutting to the 'properties' attribute removed. We need that back

Second, I got irritated with the response returning an array of one element instead of just returning one element. As far as I can tell, a VM cannot have more than one set of properties at the same time. The API docs show it returning a single hash as well, not an array, so I'm not sure why it does that. This could be an api-version issue, but I'm not sure.

Anyway, for now we go with returning a single value per resource rather than one-element arrays, which was getting painful to unravel.