### PR TITLE
Add provider, resource, tag and tenant methods

### DIFF
--- a/lib/azure/armrest/armrest_manager.rb
+++ b/lib/azure/armrest/armrest_manager.rb
@@ -200,6 +200,16 @@ module Azure
         JSON.parse(resp.body)["value"]
       end
 
+      # Returns information about the specific provider +namespace+.
+      #
+      def provider_info(namespace)
+        url = url_with_api_version(@base_url, 'providers', namespace)
+        response = rest_get(url)
+        JSON.parse(response.body)
+      end
+
+      alias geo_locations provider_info
+
       # Returns a list of subscriptions for the tenant.
       #
       def subscriptions
@@ -218,19 +228,48 @@ module Azure
         JSON.parse(resp.body)
       end
 
+      # Returns a list of resources for the given subscription. If a +resource_group+
+      # is provided, only list resources for that resource group.
+      #
+      def resources(resource_group = nil, subscription_id = @subscription_id)
+        if resource_group
+          url = url_with_api_version(@base_url, 'subscriptions', subscription_id, 'resourcegroups', resource_group, 'resources')
+        else
+          url = url_with_api_version(@base_url, 'subscriptions', subscription_id, 'resources')
+        end
+        response = rest_get(url)
+        JSON.parse(response.body)["value"]
+      end
+
       # Returns a list of resource groups for the given subscription.
       #
       def resource_groups(subscription_id = @subscription_id)
         url = url_with_api_version(@base_url, 'subscriptions', subscription_id, 'resourcegroups')
+        response = rest_get(url)
+        JSON.parse(response.body)["value"]
+      end
+
+      # Returns information on the specified +resource_group+, or the
+      # resource group specified in the constructor if none is provided.
+      #
+      def resource_group_info(resource_group = @resource_group, subscription_id = @subscription_id)
+        url = url_with_api_version(@base_url, 'subscriptions', subscription_id, 'resourcegroups', resource_group)
+        resp = rest_get(url)
+        JSON.parse(resp.body)
+      end
+
+      # Returns a list of tags.
+      #
+      def tags(subscription_id = @subscription_id)
+        url = url_with_api_version(@base_url, 'subscriptions', subscription_id, 'tagNames')
         resp = rest_get(url)
         JSON.parse(resp.body)["value"]
       end
 
-      # Returns information the specified resource group, or the
-      # resource group specified in the constructor if none is provided.
+      # Returns a list of tenants that can be accessed.
       #
-      def resource_group_info(resource_group = @resource_group)
-        url = url_with_api_version(@base_url, 'subscriptions', subscription_id, 'resourcegroups', resource_group)
+      def tenants
+        url = url_with_api_version(@base_url, 'tenants')
         resp = rest_get(url)
         JSON.parse(resp.body)
       end
@@ -273,7 +312,7 @@ module Azure
 
       # Take an array of URI elements and join the together with the API version.
       def url_with_api_version(*paths)
-        path = File.join(*paths) << "?api-version=#{api_version}"
+        File.join(*paths) << "?api-version=#{api_version}"
       end
 
     end # ArmrestManager

--- a/spec/armrest_manager_spec.rb
+++ b/spec/armrest_manager_spec.rb
@@ -3,7 +3,6 @@
 #
 # Test suite for the Azure::Armrest::ArmrestManager class.
 ########################################################################
-
 require 'spec_helper'
 
 describe "ArmrestManager" do
@@ -13,6 +12,49 @@ describe "ArmrestManager" do
   context "constructor" do
     it "returns an armrest manager instance as expected" do
       expect(arm).to be_kind_of(Azure::Armrest::ArmrestManager)
+    end
+  end
+
+  context "methods" do
+    it "defines a providers method" do
+      expect(arm).to respond_to(:providers)
+    end
+
+    it "defines a provider_info method" do
+      expect(arm).to respond_to(:provider_info)
+    end
+
+    it "defines a geo_locations alias for provider_info" do
+      expect(arm).to respond_to(:geo_locations)
+      expect(arm.method(:geo_locations)
+    end
+
+    it "defines a resources method" do
+      expect(arm).to respond_to(:resources)
+    end
+
+    it "defines a resource_groups method" do
+      expect(arm).to respond_to(:resource_groups)
+    end
+
+    it "defines a resource_group_info method" do
+      expect(arm).to respond_to(:resource_group_info)
+    end
+
+    it "defines a subscriptions method" do
+      expect(arm).to respond_to(:subscriptions)
+    end
+
+    it "defines a subscription_info method" do
+      expect(arm).to respond_to(:subscription_info)
+    end
+
+    it "defines a tags method" do
+      expect(arm).to respond_to(:tags)
+    end
+
+    it "defines a tenants method" do
+      expect(arm).to respond_to(:tenants)
     end
   end
 

--- a/spec/armrest_manager_spec.rb
+++ b/spec/armrest_manager_spec.rb
@@ -26,7 +26,7 @@ describe "ArmrestManager" do
 
     it "defines a geo_locations alias for provider_info" do
       expect(arm).to respond_to(:geo_locations)
-      expect(arm.method(:geo_locations)
+      expect(arm.method(:geo_locations)).to eq(arm.method(:provider_info))
     end
 
     it "defines a resources method" do


### PR DESCRIPTION
This PR adds the provider_info, resources, tags and tenants instance methods. I also added some more basic specs.