### PR TITLE
Add locations and publishers methods

### DIFF
--- a/lib/azure/armrest/armrest_manager.rb
+++ b/lib/azure/armrest/armrest_manager.rb
@@ -262,7 +262,7 @@ module Azure
       #   arm.publishers('eastus', 'Microsoft.ClassicCompute')
       #
       def publishers(region, provider = 'Microsoft.Compute', subscription_id = @subscription_id)
-        @api_version = '2015-06-15'
+        @api_version = '2015-06-15' # Default api-version won't work
 
         url = url_with_api_version(
           @base_url, 'subscriptions', subscription_id, 'providers',

--- a/lib/azure/armrest/armrest_manager.rb
+++ b/lib/azure/armrest/armrest_manager.rb
@@ -254,13 +254,15 @@ module Azure
         array
       end
 
-      # Returns a list of publishers for the given +provider+ and +region+.
+      # Returns an array of publishers for the given +region+ and +provider+,
+      # or "Microsoft.Compute" if no provider is given.
       #
-      # Example:
+      # Examples:
       #
-      #   arm.publishers('Microsoft.Compute', 'eastus').each{ |pub| puts pub['name'] }
+      #   arm.publishers('eastus')
+      #   arm.publishers('eastus', 'Microsoft.ClassicCompute')
       #
-      def publishers(provider, region, subscription_id = @subscription_id)
+      def publishers(region, provider = 'Microsoft.Compute', subscription_id = @subscription_id)
         @api_version = '2015-06-15'
 
         url = url_with_api_version(
@@ -269,7 +271,7 @@ module Azure
         )
 
         response = rest_get(url)
-        JSON.parse(response.body)
+        JSON.parse(response.body).map{ |element| element['name'] }
       end
 
       # Returns a list of subscriptions for the tenant.

--- a/lib/azure/armrest/armrest_manager.rb
+++ b/lib/azure/armrest/armrest_manager.rb
@@ -209,13 +209,68 @@ module Azure
 
       # Returns information about the specific provider +namespace+.
       #
-      def provider_info(namespace)
-        url = url_with_api_version(@base_url, 'providers', namespace)
+      def provider_info(provider)
+        url = url_with_api_version(@base_url, 'providers', provider)
         response = rest_get(url)
         JSON.parse(response.body)
       end
 
       alias geo_locations provider_info
+
+      # Returns a list of all locations for all resource types of the given
+      # +provider+. If you do not specify a provider, then the locations for
+      # all providers will be returned.
+      #
+      # If you need individual details on a per-provider basis, use the
+      # provider_info method instead.
+      #--
+      # TODO: I think a 7-day cache may be wise here as the overall list of
+      # locations is unlikely to change from day to day.
+      #
+      def locations(provider = nil)
+        array = []
+
+        if provider
+          info = provider_info(provider)
+          info['resourceTypes'].map{ |rt| array << rt['locations'] }
+        else
+          threads = []
+
+          providers.each do |provider_hash|
+            provider = provider_hash['namespace']
+            threads << Thread.new{
+              info = provider_info(provider)
+              info['resourceTypes'].map{ |rt| array << rt['locations'] }
+            }
+          end
+
+          threads.each(&:join)
+        end
+
+        array.flatten!
+        array.uniq!
+        array.delete("") # Seems to pickup blank elements for some reason.
+
+        array
+      end
+
+      # Returns a list of publishers for the given +provider+ and +region+.
+      #
+      # Example:
+      #
+      #   arm.publishers('Microsoft.Compute', 'eastus').each{ |pub| puts pub['name'] }
+      #
+      def publishers(provider, region, subscription_id = @subscription_id)
+        @api_version = '2015-06-15'
+
+        url = url_with_api_version(
+          @base_url, 'subscriptions', subscription_id, 'providers',
+          provider, 'locations', region, 'publishers'
+        )
+
+        response = rest_get(url)
+        JSON.parse(response.body)
+      end
 
       # Returns a list of subscriptions for the tenant.
       #
@@ -240,7 +295,10 @@ module Azure
       #
       def resources(resource_group = nil, subscription_id = @subscription_id)
         if resource_group
-          url = url_with_api_version(@base_url, 'subscriptions', subscription_id, 'resourcegroups', resource_group, 'resources')
+          url = url_with_api_version(
+            @base_url, 'subscriptions', subscription_id,
+            'resourcegroups', resource_group, 'resources'
+          )
         else
           url = url_with_api_version(@base_url, 'subscriptions', subscription_id, 'resources')
         end
@@ -260,7 +318,10 @@ module Azure
       # resource group specified in the constructor if none is provided.
       #
       def resource_group_info(resource_group = @resource_group, subscription_id = @subscription_id)
-        url = url_with_api_version(@base_url, 'subscriptions', subscription_id, 'resourcegroups', resource_group)
+        url = url_with_api_version(
+          @base_url, 'subscriptions', subscription_id,
+          'resourcegroups', resource_group
+        )
         resp = rest_get(url)
         JSON.parse(resp.body)
       end

--- a/lib/azure/armrest/armrest_manager.rb
+++ b/lib/azure/armrest/armrest_manager.rb
@@ -228,20 +228,19 @@ module Azure
       # locations is unlikely to change from day to day.
       #
       def locations(provider = nil)
-        array = []
-
         if provider
           info = provider_info(provider)
-          info['resourceTypes'].map{ |rt| array << rt['locations'] }
+          array = info['resourceTypes'].collect{ |rt| rt['locations'] }
         else
           threads = []
+          array = []
 
           providers.each do |provider_hash|
             provider = provider_hash['namespace']
-            threads << Thread.new{
+            threads << Thread.new do
               info = provider_info(provider)
-              info['resourceTypes'].map{ |rt| array << rt['locations'] }
-            }
+              array << info['resourceTypes'].collect{ |rt| rt['locations'] }
+            end
           end
 
           threads.each(&:join)

--- a/spec/armrest_manager_spec.rb
+++ b/spec/armrest_manager_spec.rb
@@ -16,12 +16,20 @@ describe "ArmrestManager" do
   end
 
   context "methods" do
+    it "defines a locations method" do
+      expect(arm).to respond_to(:locations)
+    end
+
     it "defines a providers method" do
       expect(arm).to respond_to(:providers)
     end
 
     it "defines a provider_info method" do
       expect(arm).to respond_to(:provider_info)
+    end
+
+    it "defines a publishers method" do
+      expect(arm).to respond_to(:publishers)
     end
 
     it "defines a geo_locations alias for provider_info" do


### PR DESCRIPTION
This adds two new methods, locations and publishers. The locations method returns just a plain array of locations, either on a per-provider basis or the locations for all providers. The publishers method returns a list of publishers (in the form of JSON objects), which can be narrowed by provider and region.