### PR TITLE
Add series and offers method

### DIFF
--- a/lib/azure/armrest/virtual_machine_manager.rb
+++ b/lib/azure/armrest/virtual_machine_manager.rb
@@ -22,6 +22,27 @@ module Azure
         super
       end
 
+      # Return a list of VM image offers from the given publisher and location.
+      #
+      # Example:
+      #
+      #   vmm.offers('Canonical', 'eastus')
+      #
+      #   # Results:
+      #   # ["Ubuntu15.04Snappy", "Ubuntu15.04SnappyDocker", "UbunturollingSnappy", "UbuntuServer"]
+      #
+      def offers(publisher, location, provider = 'Microsoft.Compute', subscription_id = @subscription_id)
+        @api_version = '2015-06-15'
+
+        url = url_with_api_version(
+          @base_url, 'subscriptions', subscription_id, 'providers', provider,
+          'locations', location, 'publishers', publisher, 'artifacttypes',
+          'vmimage', 'offers'
+        )
+
+        JSON.parse(rest_get(url)).map{ |element| element['name'] }
+      end
+
       # Returns a list of available virtual machines for the given subscription
       # for the provided +group+, or all resource groups if none is provided.
       #--

--- a/lib/azure/armrest/virtual_machine_manager.rb
+++ b/lib/azure/armrest/virtual_machine_manager.rb
@@ -43,6 +43,22 @@ module Azure
         JSON.parse(rest_get(url)).map{ |element| element['name'] }
       end
 
+      # Return a list of available VM series (aka sizes, flavors, etc), such
+      # as "Basic_A1", though information is included as well.
+      #
+      def series(location, provider = 'Microsoft.Compute', subscription_id = @subscription_id)
+        @api_version = '2015-06-15'
+
+        url = url_with_api_version(
+          @base_url, 'subscriptions', subscription_id, 'providers',
+          provider, 'locations', location, 'vmSizes'
+        )
+
+        JSON.parse(rest_get(url))
+      end
+
+      alias sizes series
+
       # Returns a list of available virtual machines for the given subscription
       # for the provided +group+, or all resource groups if none is provided.
       #--

--- a/lib/azure/armrest/virtual_machine_manager.rb
+++ b/lib/azure/armrest/virtual_machine_manager.rb
@@ -54,7 +54,7 @@ module Azure
           provider, 'locations', location, 'vmSizes'
         )
 
-        JSON.parse(rest_get(url))
+        JSON.parse(rest_get(url))['value']
       end
 
       alias sizes series


### PR DESCRIPTION
This adds two new methods to the VirtualMachineManager class, series and offers. The offers method returns a list of available VM's from a provider within a specific region.

The series method returns an array of VM series (aka sizes or flavors) available for a given location and optional provider (the default is Microsoft.Compute). These correspond to the MS pricing units you can find here:

http://azure.microsoft.com/en-us/pricing/details/virtual-machines/

So, a single entry would look like this:

```{"name"=>"Basic_A0", "numberOfCores"=>1, "osDiskSizeInMB"=>1047552, "resourceDiskSizeInMB"=>20480, "memoryInMB"=>768, "maxDataDiskCount"=>1}```å