### PR TITLE
Fix list method, remove subscription_id arguments

### DIFF
--- a/lib/azure/armrest.rb
+++ b/lib/azure/armrest.rb
@@ -1,5 +1,6 @@
 require 'rest-client'
 require 'json'
+require 'thread'
 
 # The Azure module serves as a namespace.
 module Azure


### PR DESCRIPTION
First and most importantly, this fixes a bug in the list method caused by my initial threading implementation. The fix does require the thread library (in the Ruby stdlib), but that's minor, and we'll probably need it elsewhere. Also, rather than grab just the first result, we want to flatten all results. These bugs were discovered by bzwei.

Second, it removes the subscription_id argument for a couple of methods. This is in line with the philosophy of letting users set that as needed, rather than having on deal with it in every method.