### PR TITLE
Better api-version handling and other tweaks

### DIFF
--- a/lib/azure/armrest/armrest_manager.rb
+++ b/lib/azure/armrest/armrest_manager.rb
@@ -51,6 +51,7 @@ module Azure
       @@content_type = 'application/json'
       @@accept = 'application/json'
       @@token = nil
+      @@providers = {} # Set in constructor
 
       # Set configuration options globally. If set globally you do not need to
       # pass configuration options to individual manager classes.
@@ -80,9 +81,11 @@ module Azure
       # The other options (grant_type, content_type, accept, token, and
       # api_version) should generally NOT be set by you except in specific
       # circumstances.  Setting them explicitly will likely cause breakage.
+      # The api_version will typically be overridden on a per-provider/resource
+      # basis within subclasses anyway.
       #
       # You may need to associate your application with a subscription using
-      # the portal or the New-AzureRoleAssignment powershell command.
+      # the new portal or the New-AzureRoleAssignment powershell command.
       #
       def self.configure(options)
         options.each do |k,v|
@@ -143,8 +146,8 @@ module Azure
       # * tenant_id - Your Azure tenant ID. Mandatory.
       #
       # * api_version - The REST API version to use for internal REST calls.
-      #     The default is '2015-01-01'. You will typically not set this
-      #     as it could cause breakage.
+      #     The default is '2015-01-01'. In some cases this value is ignored
+      #     in order to get the most recently supported api-version string.
       #
       def initialize(options = {})
         # Mandatory params
@@ -167,6 +170,27 @@ module Azure
 
         # Base URL used for REST calls. Modify within method calls as needed.
         @base_url = Azure::Armrest::RESOURCE
+
+        # Build a one-time lookup table for each provider & resource. This
+        # lets subclasses set api-version strings properly for each method
+        # depending on whichever provider they're using.
+        #
+        # e.g. @@providers['Microsoft.Compute']['virtualMachines']['api_version']
+        #
+        # Note that for methods that don't depend on a resource type should use
+        # the @@api_version class variable instead or set it explicitly as needed.
+        #
+        if @@providers.empty?
+          providers.each do |info|
+            @@providers[info['namespace']] = {}
+            info['resourceTypes'].each do |resource|
+              @@providers[info['namespace']][resource['resourceType']] = {
+                'api_version' => resource['apiVersions'].first,
+                'locations'   => resource['locations'] - [''] # Ignore empty elements
+              }
+            end
+          end
+        end
       end
 
       # Gets an authentication token, which is then used for all other methods.
@@ -202,7 +226,7 @@ module Azure
       # Returns a list of the available resource providers.
       #
       def providers
-        url = url_with_api_version(@api_version, @base_url, 'providers')
+        url = url_with_api_version(@@api_version, @base_url, 'providers')
         resp = rest_get(url)
         JSON.parse(resp.body)["value"]
       end
@@ -210,7 +234,7 @@ module Azure
       # Returns information about the specific provider +namespace+.
       #
       def provider_info(provider)
-        url = url_with_api_version(@api_version, @base_url, 'providers', provider)
+        url = url_with_api_version(@@api_version, @base_url, 'providers', provider)
         response = rest_get(url)
         JSON.parse(response.body)
       end
@@ -224,33 +248,23 @@ module Azure
       # If you need individual details on a per-provider basis, use the
       # provider_info method instead.
       #--
-      # TODO: I think a 7-day cache may be wise here as the overall list of
-      # locations is unlikely to change from day to day.
       #
       def locations(provider = nil)
-        if provider
-          info = provider_info(provider)
-          array = info['resourceTypes'].collect{ |rt| rt['locations'] }
-        else
-          threads = []
-          array = []
+        array = []
 
-          providers.each do |provider_hash|
-            provider = provider_hash['namespace']
-            threads << Thread.new do
-              info = provider_info(provider)
-              array << info['resourceTypes'].collect{ |rt| rt['locations'] }
+        if provider
+          @@providers[provider].each do |key, data|
+            array << data['locations']
+          end
+        else
+          @@providers.each do |provider, resource_types|
+            @@providers[provider].each do |resource_type, data|
+              array << data['locations']
             end
           end
-
-          threads.each(&:join)
         end
 
-        array.flatten!
-        array.uniq!
-        array.delete("") # Seems to pickup blank elements for some reason.
-
-        array
+        array.flatten.uniq
       end
 
       # Returns an array of publishers for the given +region+ and +provider+,
@@ -259,13 +273,16 @@ module Azure
       # Examples:
       #
       #   arm.publishers('eastus')
-      #   arm.publishers('eastus', 'Microsoft.ClassicCompute')
       #
       def publishers(region, provider = 'Microsoft.Compute')
-        api = '2015-06-15' # Default api-version won't work
+        unless @@providers[provider].has_key?('locations/publishers')
+          raise ArgumentError, "No publishers for provider '#{provider}'"
+        end
+
+        version = @@providers[provider]['locations/publishers']['api_version']
 
         url = url_with_api_version(
-          api, @base_url, 'subscriptions', subscription_id,
+          version, @base_url, 'subscriptions', subscription_id,
           'providers', provider, 'locations', region, 'publishers'
         )
 
@@ -276,7 +293,7 @@ module Azure
       # Returns a list of subscriptions for the tenant.
       #
       def subscriptions
-        url = url_with_api_version(@api_version, @base_url, 'subscriptions')
+        url = url_with_api_version(@@api_version, @base_url, 'subscriptions')
         resp = rest_get(url)
         JSON.parse(resp.body)["value"]
       end
@@ -286,7 +303,7 @@ module Azure
       # specified.
       #
       def subscription_info(subscription_id = @subscription_id)
-        url = url_with_api_version(@api_version, @base_url, 'subscriptions', subscription_id)
+        url = url_with_api_version(@@api_version, @base_url, 'subscriptions', subscription_id)
         resp = rest_get(url)
         JSON.parse(resp.body)
       end
@@ -298,7 +315,7 @@ module Azure
       def resources(resource_group = nil)
         if resource_group
           url = url_with_api_version(
-            @api_version, @base_url, 'subscriptions', subscription_id,
+            @@api_version, @base_url, 'subscriptions', subscription_id,
             'resourcegroups', resource_group, 'resources'
           )
         else
@@ -314,7 +331,7 @@ module Azure
       #
       def resource_groups
         url = url_with_api_version(
-          @api_version, @base_url, 'subscriptions',
+          @@api_version, @base_url, 'subscriptions',
           subscription_id, 'resourcegroups'
         )
         response = rest_get(url)
@@ -325,9 +342,9 @@ module Azure
       # subscription, or the resource group specified in the constructor if
       # none is provided.
       #
-      def resource_group_info(resource_group = @resource_group)
+      def resource_group_info(resource_group)
         url = url_with_api_version(
-          @api_version, @base_url, 'subscriptions',
+          @@api_version, @base_url, 'subscriptions',
           subscription_id, 'resourcegroups', resource_group
         )
 
@@ -338,7 +355,7 @@ module Azure
       # Returns a list of tags for the current subscription.
       #
       def tags
-        url = url_with_api_version(@api_version, @base_url, 'subscriptions', subscription_id, 'tagNames')
+        url = url_with_api_version(@@api_version, @base_url, 'subscriptions', subscription_id, 'tagNames')
         resp = rest_get(url)
         JSON.parse(resp.body)["value"]
       end
@@ -346,7 +363,7 @@ module Azure
       # Returns a list of tenants that can be accessed.
       #
       def tenants
-        url = url_with_api_version(@api_version, @base_url, 'tenants')
+        url = url_with_api_version(@@api_version, @base_url, 'tenants')
         resp = rest_get(url)
         JSON.parse(resp.body)
       end
@@ -392,7 +409,7 @@ module Azure
       end
 
       # Take an array of URI elements and join the together with the API version.
-      def url_with_api_version(api_version = @api_version, *paths)
+      def url_with_api_version(api_version, *paths)
         File.join(*paths) << "?api-version=#{api_version}"
       end
 

--- a/lib/azure/armrest/armrest_manager.rb
+++ b/lib/azure/armrest/armrest_manager.rb
@@ -202,7 +202,7 @@ module Azure
       # Returns a list of the available resource providers.
       #
       def providers
-        url = url_with_api_version(@base_url, 'providers')
+        url = url_with_api_version(@api_version, @base_url, 'providers')
         resp = rest_get(url)
         JSON.parse(resp.body)["value"]
       end
@@ -210,7 +210,7 @@ module Azure
       # Returns information about the specific provider +namespace+.
       #
       def provider_info(provider)
-        url = url_with_api_version(@base_url, 'providers', provider)
+        url = url_with_api_version(@api_version, @base_url, 'providers', provider)
         response = rest_get(url)
         JSON.parse(response.body)
       end
@@ -265,8 +265,8 @@ module Azure
         @api_version = '2015-06-15' # Default api-version won't work
 
         url = url_with_api_version(
-          @base_url, 'subscriptions', subscription_id, 'providers',
-          provider, 'locations', region, 'publishers'
+          @api_version, @base_url, 'subscriptions', subscription_id,
+          'providers', provider, 'locations', region, 'publishers'
         )
 
         response = rest_get(url)
@@ -276,7 +276,7 @@ module Azure
       # Returns a list of subscriptions for the tenant.
       #
       def subscriptions
-        url = url_with_api_version(@base_url, 'subscriptions')
+        url = url_with_api_version(@api_version, @base_url, 'subscriptions')
         resp = rest_get(url)
         JSON.parse(resp.body)["value"]
       end
@@ -286,7 +286,7 @@ module Azure
       # specified.
       #
       def subscription_info(subscription_id = @subscription_id)
-        url = url_with_api_version(@base_url, 'subscriptions', subscription_id)
+        url = url_with_api_version(@api_version, @base_url, 'subscriptions', subscription_id)
         resp = rest_get(url)
         JSON.parse(resp.body)
       end
@@ -298,7 +298,7 @@ module Azure
       def resources(resource_group = nil)
         if resource_group
           url = url_with_api_version(
-            @base_url, 'subscriptions', subscription_id,
+            @api_version, @base_url, 'subscriptions', subscription_id,
             'resourcegroups', resource_group, 'resources'
           )
         else
@@ -313,7 +313,10 @@ module Azure
       # Returns a list of resource groups for the current subscription.
       #
       def resource_groups
-        url = url_with_api_version(@base_url, 'subscriptions', subscription_id, 'resourcegroups')
+        url = url_with_api_version(
+          @api_version, @base_url, 'subscriptions',
+          subscription_id, 'resourcegroups'
+        )
         response = rest_get(url)
         JSON.parse(response.body)["value"]
       end
@@ -324,8 +327,8 @@ module Azure
       #
       def resource_group_info(resource_group = @resource_group)
         url = url_with_api_version(
-          @base_url, 'subscriptions', subscription_id,
-          'resourcegroups', resource_group
+          @api_version, @base_url, 'subscriptions',
+          subscription_id, 'resourcegroups', resource_group
         )
 
         resp = rest_get(url)
@@ -335,7 +338,7 @@ module Azure
       # Returns a list of tags for the current subscription.
       #
       def tags
-        url = url_with_api_version(@base_url, 'subscriptions', subscription_id, 'tagNames')
+        url = url_with_api_version(@api_version, @base_url, 'subscriptions', subscription_id, 'tagNames')
         resp = rest_get(url)
         JSON.parse(resp.body)["value"]
       end
@@ -343,7 +346,7 @@ module Azure
       # Returns a list of tenants that can be accessed.
       #
       def tenants
-        url = url_with_api_version(@base_url, 'tenants')
+        url = url_with_api_version(@api_version, @base_url, 'tenants')
         resp = rest_get(url)
         JSON.parse(resp.body)
       end
@@ -389,7 +392,7 @@ module Azure
       end
 
       # Take an array of URI elements and join the together with the API version.
-      def url_with_api_version(*paths)
+      def url_with_api_version(api_version = @api_version, *paths)
         File.join(*paths) << "?api-version=#{api_version}"
       end
 

--- a/lib/azure/armrest/armrest_manager.rb
+++ b/lib/azure/armrest/armrest_manager.rb
@@ -262,10 +262,10 @@ module Azure
       #   arm.publishers('eastus', 'Microsoft.ClassicCompute')
       #
       def publishers(region, provider = 'Microsoft.Compute')
-        @api_version = '2015-06-15' # Default api-version won't work
+        api = '2015-06-15' # Default api-version won't work
 
         url = url_with_api_version(
-          @api_version, @base_url, 'subscriptions', subscription_id,
+          api, @base_url, 'subscriptions', subscription_id,
           'providers', provider, 'locations', region, 'publishers'
         )
 

--- a/lib/azure/armrest/virtual_machine_manager.rb
+++ b/lib/azure/armrest/virtual_machine_manager.rb
@@ -18,8 +18,13 @@ module Azure
       #
       def initialize(options = {})
         super
+
         @provider = options[:provider] || 'Microsoft.Compute'
-        @api_version = @@providers[@provider]['virtualMachines']['api_version']
+
+        # Typically only empty in testing.
+        unless @@providers.empty?
+          @api_version = @@providers[@provider]['virtualMachines']['api_version']
+        end
       end
 
       # Set a new provider to use the default for other methods. This may alter

--- a/lib/azure/armrest/virtual_machine_manager.rb
+++ b/lib/azure/armrest/virtual_machine_manager.rb
@@ -5,21 +5,20 @@ module Azure
     # Base class for managing virtual machines
     class VirtualMachineManager < ArmrestManager
 
-      # Valid sizes that may be used when creating or updating a virtual machine.
-      VALID_VM_SIZES = %w[
-        Standard_A0
-        Standard_A1
-        Standard_A2
-        Standard_A3
-        Standard_A4
-      ]
+      # The provider used in requests when gathering VM information.
+      attr_accessor :provider
 
       # Create and return a new VirtualMachineManager (VMM) instance. Most
       # methods for a VMM instance will return one or more VirtualMachine
       # instances.
       #
+      # This subclass accepts the additional :provider option as well. The
+      # default is 'Microsoft.ClassicCompute'. You may need to set this to
+      # 'Microsoft.Compute' for your purposes.
+      #
       def initialize(options = {})
         super
+        @provider = options[:provider] || 'Microsoft.ClassicCompute'
       end
 
       # Return a list of VM image offers from the given publisher and location.
@@ -32,11 +31,11 @@ module Azure
       #   # ["Ubuntu15.04Snappy", "Ubuntu15.04SnappyDocker", "UbunturollingSnappy", "UbuntuServer"]
       #
       def offers(publisher, location, provider = 'Microsoft.Compute')
-        @api_version = '2015-06-15'
+        api = '2015-06-15' # Default won't work
 
         url = url_with_api_version(
-          @base_url, 'subscriptions', subscription_id, 'providers', provider,
-          'locations', location, 'publishers', publisher, 'artifacttypes',
+          api, @base_url, 'subscriptions', subscription_id, 'providers',
+          provider, 'locations', location, 'publishers', publisher, 'artifacttypes',
           'vmimage', 'offers'
         )
 
@@ -47,10 +46,10 @@ module Azure
       # as "Basic_A1", though information is included as well.
       #
       def series(location, provider = 'Microsoft.Compute')
-        @api_version = '2015-06-15'
+        api = '2015-06-15' # Default won't work
 
         url = url_with_api_version(
-          @base_url, 'subscriptions', subscription_id, 'providers',
+          api, @base_url, 'subscriptions', subscription_id, 'providers',
           provider, 'locations', location, 'vmSizes'
         )
 
@@ -76,9 +75,10 @@ module Azure
       # p JSON.parse(resp.body)["value"][0]["properties"]["storageProfile"]
       #
       def list(group = @resource_group)
+        api = '2014-06-01' # Default won't work
+
         if group
-          @api_version = '2014-06-01'
-          url = build_url(@subscription_id, group)
+          url = build_url(api, group)
           JSON.parse(rest_get(url))['value']
         else
           threads = []
@@ -86,8 +86,7 @@ module Azure
           mutex = Mutex.new
 
           resource_groups.each do |group|
-            @api_version = '2014-06-01' # Must be set after resource_groups call
-            url = build_url(@subscription_id, group['name'])
+            url = build_url(api, group['name'])
 
             threads << Thread.new(url) do |thread_url|
               response = rest_get(thread_url)
@@ -103,30 +102,6 @@ module Azure
       end
 
       alias get_vms list
-
-      # Return a list of all vms for all resource groups for every subscription.
-      #
-      def list_all
-        arr = []
-        thr = []
-
-        subscriptions.each do |sub|
-          sub_id = sub['subscriptionId']
-          resource_groups(sub_id).each do |group|
-            @api_version = '2014-06-01'
-            url = build_url(sub_id, group['name'])
-
-            thr << Thread.new{
-              res = JSON.parse(rest_get(url))['value'].first
-              arr << res if res
-            }
-          end
-        end
-
-        thr.each{ |t| t.join }
-
-        arr
-      end
 
       # Captures the +vmname+ and associated disks into a reusable CSM template.
       #--
@@ -266,16 +241,14 @@ module Azure
       # TODO: Figure out why instance view isn't working
       #
       def get(vmname, model_view = true, group = @resource_group)
-        set_default_subscription
-
         raise ArgumentError, "must specify resource group" unless group
 
-        @api_version = '2014-06-01'
+        api = '2014-06-01'
 
         if model_view
-          url = build_url(@subscription_id, group, vmname)
+          url = build_url(api, group, vmname)
         else
-          url = build_url(@subscription_id, group, vmname, 'instanceView')
+          url = build_url(api, group, vmname, 'instanceView')
         end
 
         JSON.parse(rest_get(url))
@@ -321,20 +294,21 @@ module Azure
       end
 
       # Builds a URL based on subscription_id an resource_group and any other
-      # arguments provided, and appends it with the api-version.
-      def build_url(subscription_id, resource_group, *args)
+      # arguments provided, and appends it with the api_version.
+      #
+      def build_url(api_version, resource_group, *args)
         url = File.join(
           Azure::Armrest::COMMON_URI,
           subscription_id,
           'resourceGroups',
           resource_group,
           'providers',
-          'Microsoft.ClassicCompute',
+          @provider,
           'virtualMachines',
         )
 
         url = File.join(url, *args) unless args.empty?
-        url << "?api-version=#{@api_version}"
+        url << "?api-version=#{api_version}"
       end
     end
   end

--- a/spec/armrest_module_spec.rb
+++ b/spec/armrest_module_spec.rb
@@ -3,33 +3,32 @@
 #
 # Test suite for the base Azure::Armrest module.
 ########################################################################
-
 require 'spec_helper'
 
 describe "Armrest" do
   context "module" do
     it "is a module, not a class" do
-      Azure::Armrest.should be_a_kind_of(Module)
+      expect(Azure::Armrest).to be_a_kind_of(Module)
     end
   end
 
   context "constants" do
     it "defines the AUTHORITY constant" do
-      Azure::Armrest::AUTHORITY.should_not be_nil
-      Azure::Armrest::AUTHORITY.should be_a_kind_of(String)
-      Azure::Armrest::AUTHORITY.should eql("https://login.windows.net/")
+      expect(Azure::Armrest::AUTHORITY).not_to be_nil
+      expect(Azure::Armrest::AUTHORITY).to be_a_kind_of(String)
+      expect(Azure::Armrest::AUTHORITY).to eql("https://login.windows.net/")
     end
 
     it "defines the RESOURCE constant" do
-      Azure::Armrest::RESOURCE.should_not be_nil
-      Azure::Armrest::RESOURCE.should be_a_kind_of(String)
-      Azure::Armrest::RESOURCE.should eql("https://management.azure.com/")
+      expect(Azure::Armrest::RESOURCE).not_to be_nil
+      expect(Azure::Armrest::RESOURCE).to be_a_kind_of(String)
+      expect(Azure::Armrest::RESOURCE).to eql("https://management.azure.com/")
     end
 
     it "defines the COMMON_URI constant" do
-      Azure::Armrest::COMMON_URI.should_not be_nil
-      Azure::Armrest::COMMON_URI.should be_a_kind_of(String)
-      Azure::Armrest::COMMON_URI.should eql("https://management.azure.com/subscriptions/")
+      expect(Azure::Armrest::COMMON_URI).not_to be_nil
+      expect(Azure::Armrest::COMMON_URI).to be_a_kind_of(String)
+      expect(Azure::Armrest::COMMON_URI).to eql("https://management.azure.com/subscriptions/")
     end
   end
 end

--- a/spec/virtual_machine_manager_spec.rb
+++ b/spec/virtual_machine_manager_spec.rb
@@ -22,14 +22,6 @@ describe "VirtualMachineManager" do
     end
   end
 
-  context "constants" do
-    it "defines VALID_VM_SIZES" do
-      Azure::Armrest::VirtualMachineManager::VALID_VM_SIZES.should_not be_nil
-      Azure::Armrest::VirtualMachineManager::VALID_VM_SIZES.should be_a_kind_of(Array)
-      Azure::Armrest::VirtualMachineManager::VALID_VM_SIZES.size.should eql(5)
-    end
-  end
-
   context "accessors" do
     it "defines a base_url accessor" do
       vmm.should respond_to(:base_url)


### PR DESCRIPTION
The primary change in the PR is that the private methods that build URL strings now accept a local api-version string as the first argument. The problem with setting the api_version instance variable directly is that subsequent method calls could fail if the version wasn't sufficient for that particular method. Still a nuisance, but at least it doesn't break code.

Another change here is the ability to set a provider in the constructor, which lets users set 'Microsoft.Compute' or 'Microsoft.ClassicCompute'. It will use ClassicCompute by default, but at least it's configurable now, whereas it was hardcoded to Classic before.

There was also a minor change where I removed the VALID_VM_SIZES constant, since we can get that information from the series method now.