### PR TITLE
Added wrapper for PATCH http requests.

### DIFF
--- a/lib/azure/armrest/armrest_manager.rb
+++ b/lib/azure/armrest/armrest_manager.rb
@@ -361,6 +361,16 @@ module Azure
         )
       end
 
+      def rest_patch(url, body = '')
+        RestClient.patch(
+          url,
+          body,
+          :accept        => @accept,
+          :content_type  => @content_type,
+          :authorization => @token,
+        )
+      end
+
       def rest_delete(url)
         RestClient.delete(
           url,


### PR DESCRIPTION
It turns out there's a PATCH request for HTTP and the Azure REST API uses it for certain things, like updating resource group tags.

This just adds a handy wrapper method for it around restclient to match our other wrappers.