### PR TITLE
Refactored AvailabilitySetManager

### DIFF
--- a/lib/azure/armrest/availability_set_manager.rb
+++ b/lib/azure/armrest/availability_set_manager.rb
@@ -4,47 +4,80 @@ module Azure
   module Armrest
     # Base class for managing availability sets.
     class AvailabilitySetManager < ArmrestManager
+      # The provider used in requests when gathering ASM information.
+      attr_reader :provider
 
-      # Create and return a new AvailabilitySetManager (ASM) instance. Most
-      # methods for an ASM instance will return one or more AvailabilitySet
-      # instances.
+      # Create and return a new AvailabilitySetManager (ASM) instance.
       #
       def initialize(options = {})
         super
 
-        @base_url += "resourceGroups/#{@resource_group}/"
-        @base_url += "providers/Microsoft.Compute/availabilitySets"
+        @provider = options[:provider] || 'Microsoft.Compute'
+
+        # Typically only empty in testing.
+        unless @@providers.empty?
+          @api_version = @@providers[@provider]['availabilitySets']['api_version']
+        end
       end
 
-      # Creates a new availability set.
+      # Creates a new availability set with the given name. The optional +tags+
+      # argument should be a hash, if provided.
       #
-      # TODO: The current documentation doesn't seem to list all the possible
-      # options at this time.
-      #--
-      def create(set_name, options = {})
-        url = @uri + "#{set_name}?api-version=#{api_version}"
-        url
+      def create(name, location, tags = nil, resource_group = @resource_group)
+        raise ArgumentError, "No resource group specified" if resource_group.nil?
+
+        url = build_url(resource_group, name)
+        body = {:name => name, :location => location, :tags => tags}.to_json
+        response = rest_put(url, body)
+        response.return!
       end
 
       alias update create
 
-      # Deletes the +set_name+ availability set.
-      def delete(set_name)
-        url = @uri + "#{set_name}?api-version=#{api_version}"
-        url
+      # Deletes the +name+ availability set.
+      #
+      def delete(name, resource_group = @resource_group)
+        raise ArgumentError, "No resource group specified" if resource_group.nil?
+        url = build_url(resource_group, name)
+        response = rest_delete(url)
+        response.return!
       end
 
-      # Retrieves the options of an availability set.
-      def get(set_name)
-        url = @uri + "#{set_name}?api-version=#{api_version}"
-        url
+      # Retrieves the options of an availability set +name+.
+      #
+      def get(name, resource_group = @resource_group)
+        raise ArgumentError, "No resource group specified" if resource_group.nil?
+        url = build_url(resource_group, name)
+        response = rest_get(url)
+        JSON.parse(response.body)
       end
 
       # List availability sets.
-      def list
-        url = @uri + "?api-version=#{api_version}"
-        url
+      #
+      def list(resource_group = @resource_group)
+        raise ArgumentError, "No resource group specified" if resource_group.nil?
+        url = build_url(resource_group)
+        response = rest_get(url)
+        JSON.parse(response.body)['value']
       end
-    end
-  end
-end
+
+      # Builds a URL based on subscription_id an resource_group and any other
+      # arguments provided, and appends it with the api_version.
+      #
+      def build_url(resource_group, *args)
+        url = File.join(
+          Azure::Armrest::COMMON_URI,
+          subscription_id,
+          'resourceGroups',
+          resource_group,
+          'providers',
+          @provider,
+          'availabilitySets',
+        )
+
+        url = File.join(url, *args) unless args.empty?
+        url << "?api-version=#{api_version}"
+      end
+    end # AvailabilitySetManager
+  end # Armrest
+end # Azure

--- a/spec/availability_set_manager_spec.rb
+++ b/spec/availability_set_manager_spec.rb
@@ -19,19 +19,6 @@ describe "AvailabilitySetManager" do
     it "returns an asm instance as expected" do
       expect(asm).to be_kind_of(Azure::Armrest::AvailabilitySetManager)
     end
-
-    it "sets the default uri to the expected value" do
-      expected = "https://management.azure.com"
-      expected << "/resourceGroups/#{@res}/providers/Microsoft.Compute/availabilitySets"
-      expect(asm.base_url).to eq(expected)
-    end
-  end
-
-  context "accessors" do
-    it "defines a base_url accessor" do
-      expect(asm).to respond_to(:base_url)
-      expect(asm).to respond_to(:base_url=)
-    end
   end
 
   context "instance methods" do


### PR DESCRIPTION
This PR refactors the AvailabilitySetManager to use the latest API changes since this was first implemented. A few specs were removed that no longer applied as well.