### PR TITLE
Add configured? method to ArmrestManager

### DIFF
--- a/lib/azure/armrest/armrest_manager.rb
+++ b/lib/azure/armrest/armrest_manager.rb
@@ -125,6 +125,15 @@ module Azure
         end
       end
 
+      # Detect whether global options have been configured. 
+      #
+      # ArmrestManager.configure only needs to be called once for all
+      # instances of ArmrestManager's subclasses
+      #
+      def self.configured?
+        @@token != nil
+      end
+
       # Do not instantiate directly. This is an abstract base class from which
       # all other manager classes should subclass, and call super within their
       # own constructors.

--- a/spec/armrest_manager_configure_spec.rb
+++ b/spec/armrest_manager_configure_spec.rb
@@ -1,0 +1,24 @@
+########################################################################
+# armrest_manager_configure_spec.rb
+#
+# Test suite for the Azure::Armrest::ArmrestManager class.
+########################################################################
+require 'spec_helper'
+
+describe "ArmrestManager" do
+  context "configuration" do
+    it "detects whether global options have been configured" do
+      expect(Azure::Armrest::ArmrestManager.configured?).to be_false
+
+      expect(RestClient).to receive(:post).with(anything, anything).and_return(
+        '{"access_token":"atoken"}')
+      Azure::Armrest::ArmrestManager.configure(
+        :subscription_id => "sid",
+        :client_id       => "cid",
+        :client_key      => "ckey",
+        :tenant_id       => "tid"
+      )
+      expect(Azure::Armrest::ArmrestManager.configured?).to be_true
+    end
+  end
+end


### PR DESCRIPTION
Add class method `configured?` because ArmrestManager class variables only needs to be initialized once for all manager instances. This method can be used to avoid multiple initialization.