### PR TITLE
Skip network information gathering for anything but Microsoft.Compute.

### DIFF
--- a/lib/azure/armrest/virtual_machine_manager.rb
+++ b/lib/azure/armrest/virtual_machine_manager.rb
@@ -96,7 +96,9 @@ module Azure
           array = array.flatten
         end
 
-        add_network_profile(array)
+        add_network_profile(array) if provider.downcase == 'microsoft.compute'
+
+        array
       end
 
       alias get_vms list


### PR DESCRIPTION
This addresses https://github.com/ManageIQ/azure-armrest/issues/44 (failure when getting classic compute info).