### PR TITLE
Add resourceGroup hash key

### DIFF
--- a/lib/azure/armrest/virtual_machine_manager.rb
+++ b/lib/azure/armrest/virtual_machine_manager.rb
@@ -87,7 +87,12 @@ module Azure
             threads << Thread.new(url) do |thread_url|
               response = rest_get(thread_url)
               result = JSON.parse(response)['value']
-              mutex.synchronize{ array << result if result }
+              mutex.synchronize{
+                if result
+                  result.each{ |hash| hash['resourceGroup'] = group['name'] }
+                  array << result
+                end
+              }
             end
           end
 


### PR DESCRIPTION
The REST API for Azure doesn't provide resource group information for a VM. Since we're explicitly iterating over each group in the list method, we can insert it ourselves into the hash.

It's handy to have, and we need this information for various operations within ManageIQ.