### PR TITLE
Mark some internal methods as private.

### DIFF
--- a/lib/azure/armrest/virtual_machine_manager.rb
+++ b/lib/azure/armrest/virtual_machine_manager.rb
@@ -110,11 +110,33 @@ module Azure
       alias get_vms list
 
       # Captures the +vmname+ and associated disks into a reusable CSM template.
-      #--
-      # POST
-      def capture(vmname, action = 'capture')
-        uri = @uri + "/#{vmname}/#{action}?api-version=#{api_version}"
-        uri
+      # The 3rd argument is a hash of options that supports the following keys:
+      #
+      # * prefix    - The prefix in the name of the blobs.
+      # * container - The name of the container inside which the image will reside.
+      # * overwrite - Boolean that indicates whether or not to overwrite any VHD's
+      #               with the same prefix. The default is false.
+      #
+      # The :prefix and :container options are mandatory.
+      #
+      # Note that this is a long running operation. You are expected to
+      # poll on the client side to check the status of the operation.
+      #
+      def capture(vmname, group = vmname, options = {})
+        prefix = options.fetch(:prefix)
+        container = options.fetch(:container)
+        overwrite = options[:overwrite] || false
+
+        body = {
+          :vhdPrefix => prefix,
+          :destinationContainer => container,
+          :overwriteVhds => overwrite
+        }.to_json
+
+        url = build_url(group, 'capture')
+
+        response = rest_post(url, body)
+        response.return!
       end
 
       # Creates a new virtual machine (or updates an existing one). Pass a hash

--- a/lib/azure/armrest/virtual_machine_manager.rb
+++ b/lib/azure/armrest/virtual_machine_manager.rb
@@ -109,45 +109,6 @@ module Azure
 
       alias get_vms list
 
-      def add_network_profile(vms)
-        vms.each { |vm|
-          vm['properties']['networkProfile']['networkInterfaces'].each { |net|
-            get_nic_profile(net)
-          }
-        }
-      end
-
-      def get_nic_profile(nic)
-        url = File.join(
-          Azure::Armrest::RESOURCE,
-          nic['id'],
-          "?api-version=#{api_version}"
-        )
-
-        nic['properties'] = JSON.parse(rest_get(url))['properties']['ipConfigurations']
-        nic['properties'].each do |n|
-          next if n['properties']['publicIPAddress'].nil?
-
-          # public IP is a URI so we need to make another rest call to get it.
-          url = File.join(
-            Azure::Armrest::RESOURCE,
-            n['properties']['publicIPAddress']['id'],
-            "?api-version=#{api_version}"
-          )
-
-          public_ip = JSON.parse(rest_get(url))['properties']['ipAddress']
-          n['properties']['publicIPAddress'] = public_ip
-        end
-      end
-
-      def add_power_status(vms)
-        vms.each do |vm|
-          i_view            = get_instance_view(vm["name"], vm["resourceGroup"])
-          powerstatus_hash  = i_view["statuses"].find {|h| h["code"].include? "PowerState"}
-          vm["powerStatus"] = powerstatus_hash['displayStatus'] unless powerstatus_hash.nil?
-        end
-      end
-
       # Captures the +vmname+ and associated disks into a reusable CSM template.
       #--
       # POST
@@ -347,6 +308,46 @@ module Azure
       end
 
       private
+
+      def add_network_profile(vms)
+        vms.each { |vm|
+          vm['properties']['networkProfile']['networkInterfaces'].each { |net|
+            get_nic_profile(net)
+          }
+        }
+      end
+
+      def get_nic_profile(nic)
+        url = File.join(
+          Azure::Armrest::RESOURCE,
+          nic['id'],
+          "?api-version=#{api_version}"
+        )
+
+        nic['properties'] = JSON.parse(rest_get(url))['properties']['ipConfigurations']
+        nic['properties'].each do |n|
+          next if n['properties']['publicIPAddress'].nil?
+
+          # public IP is a URI so we need to make another rest call to get it.
+          url = File.join(
+            Azure::Armrest::RESOURCE,
+            n['properties']['publicIPAddress']['id'],
+            "?api-version=#{api_version}"
+          )
+
+          public_ip = JSON.parse(rest_get(url))['properties']['ipAddress']
+          n['properties']['publicIPAddress'] = public_ip
+        end
+      end
+
+      # Sets the power status of each hash based on PowerState. Use in instance view only.
+      def add_power_status(vms)
+        vms.each do |vm|
+          i_view            = get_instance_view(vm["name"], vm["resourceGroup"])
+          powerstatus_hash  = i_view["statuses"].find {|h| h["code"].include? "PowerState"}
+          vm["powerStatus"] = powerstatus_hash['displayStatus'] unless powerstatus_hash.nil?
+        end
+      end
 
       # If no default subscription is set, then use the first one found.
       def set_default_subscription

--- a/spec/virtual_machine_manager_spec.rb
+++ b/spec/virtual_machine_manager_spec.rb
@@ -65,4 +65,13 @@ describe "VirtualMachineManager" do
       expect(vmm).to respond_to(:stop)
     end
   end
+
+  context "private methods" do
+    it "does not make internal methods public" do
+      expect(vmm).not_to respond_to(:add_network_profile)
+      expect(vmm).not_to respond_to(:get_nic_profile)
+      expect(vmm).not_to respond_to(:add_power_status)
+      expect(vmm).not_to respond_to(:build_url)
+    end
+  end
 end


### PR DESCRIPTION
This makes the add_network_profile, get_nic_profile and add_power_status private methods. I also added a few specs to make sure they're not publicly visible.