### PR TITLE
Fix spec warning

### DIFF
--- a/spec/armrest_service_spec.rb
+++ b/spec/armrest_service_spec.rb
@@ -6,7 +6,9 @@
 require 'spec_helper'
 
 describe "ArmrestService" do
+  before(:all){ @@providers = {'name' => {}} }
   before { setup_params }
+
   let(:arm) { Azure::Armrest::ArmrestService.new(@conf, {}) }
 
   context "constructor" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,8 +5,6 @@ $LOAD_PATH.unshift File.expand_path('../lib', __FILE__)
 require 'azure-armrest'
 
 def setup_params
-  @@providers = {'name' => {}}
-
   @sub = 'abc-123-def-456'
   @res = 'my_resource_group'
   @cid = "XXXXX"


### PR DESCRIPTION
This moves the providers class variable into the individual spec so we can dispense with rspec warnings about accessing class variables.