### PR TITLE
New design to cache tokens that considers expiration

### DIFF
--- a/azure-armrest.gemspec
+++ b/azure-armrest.gemspec
@@ -27,6 +27,7 @@ behind the scenes.
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "codeclimate-test-reporter"
+  spec.add_development_dependency "timecop", "~> 0.7"
 
   spec.add_dependency 'json'
   spec.add_dependency 'rest-client'

--- a/spec/armrest_service_config_spec.rb
+++ b/spec/armrest_service_config_spec.rb
@@ -1,0 +1,63 @@
+require 'spec_helper'
+require "timecop"
+
+describe "ArmrestService" do
+  let(:options) do
+    Hash(
+      :client_id  => 'cid' + Time.now.to_f.to_s,
+      :client_key => 'ckey',
+      :tenant_id  => 'tid'
+    )
+  end
+
+  let(:options_with_subscription) do
+    options.merge(:subscription_id => 'sid')
+  end
+
+  let(:token_response) do
+    '{"expires_in":"3599","access_token":"eyJ0eXAiOiJKV1Q"}'
+  end
+
+  context 'token generation' do
+    it 'caches the token to be reused for the same client' do
+      expect(RestClient).to receive(:post).exactly(1).times.and_return(token_response)
+      Azure::Armrest::ArmrestService.configure(options_with_subscription).token
+        .should == "Bearer eyJ0eXAiOiJKV1Q"
+      Azure::Armrest::ArmrestService.configure(options_with_subscription).token
+    end
+
+    it 'generates different tokens for different clients' do
+      expect(RestClient).to receive(:post).exactly(2).times.and_return(token_response)
+      Azure::Armrest::ArmrestService.configure(options_with_subscription).token
+      Azure::Armrest::ArmrestService.configure(options_with_subscription.merge(:client_id => 'cid2')).token
+    end
+
+    it 'regenerates the token if the old token expires' do
+      expect(RestClient).to receive(:post).exactly(2).times.and_return(token_response)
+      conf = Azure::Armrest::ArmrestService.configure(options_with_subscription)
+      conf.token
+      Timecop.freeze(Time.now + 3600) {conf.token}
+    end
+  end
+
+  context 'auto fill attributes' do
+    let(:subscription_response) do
+      '{"value":[{"id":"/subscriptions/4f5a544b","subscriptionId":"4f5a544b"}]}'
+    end
+
+    it 'fills some attributes with default values' do
+      conf = Azure::Armrest::ArmrestService.configure(options_with_subscription)
+      conf.api_version.should_not be_nil
+      conf.grant_type.should_not be_nil
+      conf.content_type.should_not be_nil
+      conf.accept.should_not be_nil
+    end
+
+    it 'finds a subscription id if not given' do
+      expect(RestClient).to receive(:post).exactly(1).times.and_return(token_response)
+      expect(RestClient).to receive(:get).exactly(1).times.and_return(subscription_response)
+      conf = Azure::Armrest::ArmrestService.configure(options)
+      conf.subscription_id.should == '4f5a544b'
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,8 @@ CodeClimate::TestReporter.start
 $LOAD_PATH.unshift File.expand_path('../lib', __FILE__)
 require 'azure-armrest'
 
+@@providers = {'name' => {}}
+
 def setup_params
   @sub = 'abc-123-def-456'
   @res = 'my_resource_group'
@@ -15,12 +17,13 @@ def setup_params
   @ver = "2015-01-01"
 
   @conf = Azure::Armrest::ArmrestService.configure(
-    :subscription_id => @sub,
-    :resource_group  => @res,
-    :client_id       => @cid,
-    :client_key      => @key,
-    :tenant_id       => @ten,
-    :token           => @tok,
+    :subscription_id  => @sub,
+    :resource_group   => @res,
+    :client_id        => @cid,
+    :client_key       => @key,
+    :tenant_id        => @ten,
+    :token            => @tok,
+    :token_expiration => Time.now + 3600
   )
 
 end


### PR DESCRIPTION
This new design validate whether a cached token has expired. Once expired a new token is retrieved and re-cached. 

An actual test shows Azure token expires in one hour after the first API call to use the token, not one hour after the token is generated. Therefore the expiration date is calculated locally, not the moment to call `configure`, but at the first call to method `token`, because most likely the value is used immediately to make API calls.

A new spec test is added to test this feature.