### PR TITLE
Revamped VirtualMachineExtensionService

### DIFF
--- a/lib/azure/armrest/virtual_machine_extension_service.rb
+++ b/lib/azure/armrest/virtual_machine_extension_service.rb
@@ -5,58 +5,132 @@ module Azure
     # Base class for managing virtual machine extensions
     class VirtualMachineExtensionService < VirtualMachineService
 
-      def initialize(_armrest_configuration, _options = {})
+      # Creates and returns a new VirtualMachineExtensionService object.
+      #
+      def initialize(_armrest_configuration, options = {})
         super
+        @provider = options[:provider] || 'Microsoft.Compute'
+        set_service_api_version(options, 'virtualMachines/extensions')
       end
 
-      # Creates a new virtual machine extension for +vmname+ with the given
-      # +extension_name+, and the given +options+. Possible options are:
+      # Creates a new extension for the provided VM with the given +options+.
+      # The possible options are:
       #
-      #   :tags - Optional. A list of key value pairs. Max 10 pairs.
-      #   :publisher - Required. Name of extension publisher.
-      #   :type - Required. The type of extension.
-      #   :type_handler_version - Required. Specifies the extension version.
-      #   :settings - Optional. Public configuration that does not require encryption.
-      #   :protected_settings - Optional. Private configuration that is encrypted.
+      # - :location - The location for the extension. Mandatory.
+      # - :type - The type of compute resource. The default is "Microsoft.Compute/virtualMachines/extensions".
+      # - :tags - A list of key value pairs. Max 10 pairs. Optional.
+      # - :properties
+      #   - :type - The type of extension. Required.
+      #   - :publisher - Name of extension publisher. Default is the provider.
+      #   - :typeHandlerVersion - Optional. Specifies the extension version. Default is "1.*".
+      #   - :settings - Public configuration that does not require encryption. Optional.
+      #     - :fileUris - The script file path.
+      #     - :commandToExecute - The command used to execute the script.
       #
-      def create(vmname, extension_name, options = {})
-        #publisher = options.fetch(:publisher)
-        #type = options.fetch(:type)
-        #type_handler_version = options.fetch(:type_handler_version)
+      # For convenience, you may also specify a :resource_group as an option.
+      #
+      def create(vm_name, ext_name, options = {}, rgroup = nil)
+        rgroup ||= options.delete(:resource_group) || armrest_configuration.resource_group
 
-        url = @uri + "/#{vmname}/extensions/#{extension_name}?#{@api_version}"
-        url
+        raise ArgumentError, "no resource group provided" unless rgroup
+
+        # Optional params with defaults
+        options[:type] ||= "Microsoft.Compute/virtualMachines/extensions"
+        options[:name] ||= ext_name
+        options[:properties][:publisher] ||= @provider
+        options[:properties][:typeHandlerVersion] ||= "1.*"
+
+        url = build_url(rgroup, vm_name, ext_name)
+        body = options.to_json
+
+        response = rest_put(url, body)
+        response.return!
       end
 
       alias update create
 
-      # Delete the given +extension_name+ for +vmname+.
-      #--
-      # DELETE
+      # Delete the given extension for the provided VM and resource group.
       #
-      def delete(vmname, extension_name)
-        url = @uri + "/#{vmname}/extensions/#{extension_name}?#{@api_version}"
-        url
+      def delete(vm_name, ext_name, rgroup = armrest_configuration.resource_group)
+        raise ArgumentError, "no resource group provided" unless rgroup
+        url = build_url(rgroup, vm_name, ext_name)
+        response = rest_delete(url)
+        response.return!
       end
 
-      # Retrieves the settings of an extension. If the +instance_view+ option
-      # is true, it will retrieve instance view information instead.
-      #--
-      # GET
+      # Retrieves the settings of an extension for the provided VM.
+      # If the +instance_view+ option is true, it will retrieve instance
+      # view information instead.
       #
-      def get(vmname, instance_view = false)
-        url = @uri + "/#{vmname}/extensions/#{extension_name}?"
-        url += "$expand=instanceView," if instance_view
-        url += "#{@api_version}"
-        url
+      def get(vm_name, ext_name, rgroup = armrest_configuration.resource_group, instance_view = false)
+        raise ArgumentError, "no resource group provided" unless rgroup
+        url = build_url(rgroup, vm_name, ext_name)
+        url << "&expand=instanceView" if instance_view
+        response = rest_get(url)
+        Azure::Armrest::VirtualMachineExtension.new(response)
       end
 
-      # Retrieves a list of extensions on the VM.
-      def list(vmname, instance_view = false)
-        url = @uri + "/#{vmname}/extensions"
-        url += "$expand=instanceView," if instance_view
-        url += "#{@api_version}"
-        url
+      # Shortcut to get an extension in model view.
+      def get_model_view(vm_name, ext_name, rgroup = armrest_configuration.resource_group)
+        raise ArgumentError, "no resource group provided" unless rgroup
+        get(vm_name, ext_name, rgroup, false)
+      end
+
+      # Shortcut to get an extension in instance view.
+      def get_instance_view(vm_name, ext_name, rgroup = armrest_configuration.resource_group)
+        raise ArgumentError, "no resource group provided" unless rgroup
+        get(vm_name, ext_name, rgroup, true)
+      end
+
+      # Retrieves a list of extensions on the VM in the provided resource group.
+      # If the +instance_view+ option is true, it will retrieve a list of instance
+      # view information instead.
+      #
+      # NOTE: As of August 2015, this is not currently supported because the
+      # MS SDK does not support it.
+      #--
+      # BUG: https://github.com/Azure/azure-xplat-cli/issues/1826
+      #
+      def list(vm_name, rgroup = armrest_configuration.resource_group, instance_view = false)
+        raise ArgumentError, "no resource group provided" unless rgroup
+        url = build_url(rgroup, vm_name)
+        url << "&expand=instanceView" if instance_view
+        response = rest_get(url)
+        JSON.parse(response)['value'].map{ |hash| Azure::Armrest::VirtualMachineExtension.new(hash) }
+      end
+
+      # Shortcut to get a list in model view.
+      def list_model_view(vmname, rgroup = armrest_configuration.resource_group)
+        raise ArgumentError, "no resource group provided" unless rgroup
+        list(vmname, false, rgroup)
+      end
+
+      # Shortcut to get a list in instance view.
+      def list_instance_view(vmname, rgroup = armrest_configuration.resource_group)
+        raise ArgumentError, "no resource group provided" unless rgroup
+        list(vmname, true, rgroup)
+      end
+
+      private
+
+      # Builds a URL based on subscription_id an resource_group and any other
+      # arguments provided, and appends it with the api_version.
+      #
+      def build_url(resource_group, vm, *args)
+        url = File.join(
+          Azure::Armrest::COMMON_URI,
+          armrest_configuration.subscription_id,
+          'resourceGroups',
+          resource_group,
+          'providers',
+          @provider,
+          'virtualMachines',
+          vm,
+          'extensions'
+        )
+
+        url = File.join(url, *args) unless args.empty?
+        url << "?api-version=#{@api_version}"
       end
     end
   end

--- a/spec/virtual_machine_extension_service_spec.rb
+++ b/spec/virtual_machine_extension_service_spec.rb
@@ -8,7 +8,10 @@ require 'spec_helper'
 
 describe "VirtualMachineExtensionService" do
   before { setup_params }
+
   let(:vmes) { Azure::Armrest::VirtualMachineExtensionService.new(@conf) }
+
+  let(:options){ { :type => "test_type" } }
 
   context "inheritance" do
     it "is a subclass of VirtualMachineService" do
@@ -48,8 +51,34 @@ describe "VirtualMachineExtensionService" do
       expect(vmes).to respond_to(:get)
     end
 
+    it "defines a get_model_view method" do
+      expect(vmes).to respond_to(:get_model_view)
+    end
+
+    it "defines a get_instance_view method" do
+      expect(vmes).to respond_to(:get_instance_view)
+    end
+
     it "defines a list method" do
       expect(vmes).to respond_to(:list)
+    end
+
+    it "defines a list_model_view method" do
+      expect(vmes).to respond_to(:list_model_view)
+    end
+
+    it "defines a list_instance_view method" do
+      expect(vmes).to respond_to(:list_instance_view)
+    end
+  end
+
+  context "create" do
+    it "requires a vm_name parameter" do
+      expect{ vmes.create }.to raise_error(ArgumentError)
+    end
+
+    it "requires a ext_name parameter" do
+      expect{ vmes.create('foo') }.to raise_error(ArgumentError)
     end
   end
 end


### PR DESCRIPTION
This revamps the VirtualMachineExtensionService class so that it actually (mostly) works, as the previous code was basically alpha code.

There is a known issue with the list method, and for now it doesn't work because it's not supported by the MS SDK at the moment.  See also https://github.com/Azure/azure-xplat-cli/issues/1826.

Generally speaking we can get extension information out of the VirtualMachineService class methods, but I thought we should at least get this to a better state.