### PR TITLE
Add Resource service classes and specs

### DIFF
--- a/azure-armrest.gemspec
+++ b/azure-armrest.gemspec
@@ -4,27 +4,25 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'azure/armrest/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = 'azure-armrest'
-  spec.version       = Azure::Armrest::VERSION
-  spec.authors       = ['Daniel J. Berger', 'Bronagh Sorota', 'Greg Blomquist']
-  spec.email         = ['dberger@redhat.com', 'bsorota@redhat.com', 'gblomqui@redhat.com']
+  spec.name     = 'azure-armrest'
+  spec.version  = Azure::Armrest::VERSION
+  spec.authors  = ['Daniel J. Berger', 'Bronagh Sorota', 'Greg Blomquist', 'Bill Wei']
+  spec.email    = ['dberger@redhat.com', 'bsorota@redhat.com', 'gblomqui@redhat.com', 'billwei@redhat.com']
+  spec.summary  = 'An interface for ARM/JSON Azure REST API'
+  spec.homepage = 'http://github.com/ManageIQ/azure-armrest'
+  spec.license  = 'Apache 2.0'
+  spec.files    = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
 
-  spec.summary       = 'An interface for ARM/JSON Azure REST API'
-  spec.description   = <<-EOF
+  spec.description = <<-EOF
 This is a Ruby interface for Azure using the newer REST API. This is
 different than the current azure gem, which uses the older (XML) interface
 behind the scenes.
   EOF
-  spec.homepage      = 'http://github.com/ManageIQ/azure-armrest'
-  spec.license       = 'Apache 2.0'
 
-  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
-  spec.bindir        = "exe"
-  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
-  spec.require_paths = ["lib"]
+  spec.add_dependency('cache_method', "~> 0.2.7")
 
   spec.add_development_dependency "bundler"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "codeclimate-test-reporter"
   spec.add_development_dependency "timecop", "~> 0.7"

--- a/lib/azure/armrest.rb
+++ b/lib/azure/armrest.rb
@@ -1,6 +1,7 @@
 require 'rest-client'
 require 'json'
 require 'thread'
+require 'uri'
 
 # The Azure module serves as a namespace.
 module Azure
@@ -31,3 +32,6 @@ require 'azure/armrest/virtual_network_service'
 require 'azure/armrest/subnet_service'
 require 'azure/armrest/event_service'
 require 'azure/armrest/template_deployment_service'
+require 'azure/armrest/resource_service'
+require 'azure/armrest/resource_group_service'
+require 'azure/armrest/resource_provider_service'

--- a/lib/azure/armrest/resource_group_service.rb
+++ b/lib/azure/armrest/resource_group_service.rb
@@ -1,0 +1,86 @@
+module Azure
+  module Armrest
+    class ResourceGroupService < ArmrestService
+      # The provider used in http requests. The default is 'Microsoft.Resources'
+      attr_reader :provider
+
+      # Creates and returns a new ResourceGroupService object.
+      #
+      def initialize(_armrest_configuration, options = {})
+        super
+        @provider = options[:provider] || 'Microsoft.Resources'
+        set_service_api_version(options, 'resourceGroups')
+      end
+
+      # List all the resources for the current subscription. You can optionally
+      # pass :top or :filter options as well to restrict returned results.
+      #
+      # If you pass a :resource_group option, then only resources for that
+      # resource group are returned.
+      #
+      # Examples:
+      #
+      #   rgs = ResourceGroupService.new
+      #   rgs.list(:top => 2)
+      #   rgs.list(:filter => "location eq 'centralus'")
+      #
+      def list(options = {})
+        url = build_url
+        url << "&$top=#{options[:top]}" if options[:top]
+        url << "&$filter=#{options[:filter]}" if options[:filter]
+
+        response = rest_get(URI.escape(url))
+
+        JSON.parse(response.body)["value"]
+      end
+
+      # Creates a new +group+ in +location+ for the current subscription.
+      # You may optionally apply +tags+.
+      #
+      def create(group, location, tags = nil)
+        body = {:location => location, :tags => tags}.to_json
+        url = build_url(group)
+
+        response = rest_put(url, body)
+
+        JSON.parse(response.body)
+      end
+
+      # Delete a resource group from the current subscription.
+      #
+      def delete(group)
+        url = build_url(group)
+        response = rest_delete(url)
+        response.return!
+      end
+
+      # Returns information for the given resource group.
+      #
+      def get(group)
+        url = build_url(group)
+        response = rest_get(url)
+        JSON.parse(response.body)
+      end
+
+      # Updates the tags for the given resource group.
+      #
+      def update(group, tags)
+        body = {:tags => tags}.to_json
+        url = build_url(group)
+        response = rest_patch(url, body)
+        response.return!
+      end
+
+      private
+
+      def build_url(group = nil, *args)
+        id = armrest_configuration.subscription_id
+        url = File.join(Azure::Armrest::COMMON_URI, id, 'resourcegroups')
+        url = File.join(url, group) if group
+        url = File.join(url, *args) unless args.empty?
+        url << "?api-version=#{@api_version}"
+      end 
+
+    end # ResourceGroupService
+  end # Armrest
+end # Azure

--- a/lib/azure/armrest/resource_provider_service.rb
+++ b/lib/azure/armrest/resource_provider_service.rb
@@ -1,0 +1,111 @@
+require 'cache_method'
+
+module Azure
+  module Armrest
+    class ResourceProviderService < ArmrestService
+      # The provider used in http requests. The default is 'Microsoft.Resources'
+      attr_reader :provider
+
+      # The amount of time in seconds to cache certain methods. The default is 24 hours.
+      @cache_time = 24 * 60 * 60
+
+      class << self
+        # Get or set the cache time for all methods. The default is 24 hours.
+        attr_accessor :cache_time
+      end
+
+      # Creates and returns a new ResourceProviderService object.
+      #
+      # Note that many ResourceProviderService instance methods are cached. You
+      # can set the cache_time for certain methods in the constructor, but keep in
+      # mind that it is a global setting for the class. You can also set this
+      # at the class level if desired. The default cache time is 24 hours.
+      #
+      # You can also set the provider. The default is 'Microsoft.Resources'.
+      #
+      def initialize(_armrest_configuration, options = {})
+        super
+
+        @provider = options[:provider] || 'Microsoft.Resources'
+
+        if options[:cache_time]
+          @cache_time = options[:cache_time]
+          self.class.send(:cache_time=, @cache_time)
+        end
+
+        set_service_api_version(options, 'resourceGroups')
+      end
+
+      # List all the providers for the current subscription. The results of
+      # this method are cached.
+      #
+      def list
+        url = build_url
+        response = rest_get(url)
+        JSON.parse(response.body)["value"]
+      end
+
+      cache_method(:list, cache_time)
+
+      # Return information about a specific +namespace+ provider. The results
+      # of this method are cached.
+      #
+      def get(namespace)
+        url = build_url(namespace)
+        response = rest_get(url)
+        JSON.parse(response.body)
+      end
+
+      cache_method(:get, cache_time)
+
+      # Returns an array of geo-locations for the given +namespace+ provider.
+      # The results of this method are cached.
+      #
+      def list_geo_locations(namespace)
+        url = build_url(namespace)
+        response = rest_get(url)
+        JSON.parse(response.body)['resourceTypes'].first['locations']
+      end
+
+      cache_method(:list_geo_locations, cache_time)
+
+      # Returns an array of supported api-versions for the given +namespace+ provider.
+      # The results of this method are cached.
+      #
+      def list_api_versions(namespace)
+        url = build_url(namespace)
+        response = rest_get(url)
+        JSON.parse(response.body)['resourceTypes'].first['apiVersions']
+      end
+
+      cache_method(:list_api_versions, cache_time)
+
+      # Register the current subscription with the +namespace+ provider.
+      #
+      def register(namespace)
+        url = build_url(namespace, 'register')
+        response = rest_post(url)
+        response.return!
+      end
+
+      # Unregister the current subscription from the +namespace+ provider.
+      #
+      def unregister(namespace)
+        url = build_url(namespace, 'unregister')
+        response = rest_post(url)
+        response.return!
+      end
+
+      private
+
+      def build_url(namespace = nil, *args)
+        id = armrest_configuration.subscription_id
+        url = File.join(Azure::Armrest::COMMON_URI, id, 'providers')
+        url = File.join(url, namespace) if namespace
+        url = File.join(url, *args) unless args.empty?
+        url << "?api-version=#{@api_version}"
+      end
+
+    end # ResourceGroupService
+  end # Armrest
+end # Azure

--- a/lib/azure/armrest/resource_service.rb
+++ b/lib/azure/armrest/resource_service.rb
@@ -1,0 +1,86 @@
+module Azure
+  module Armrest
+    class ResourceService < ArmrestService
+      # The provider used in http requests. The default is 'Microsoft.Resources'
+      attr_reader :provider
+
+      # Creates and returns a new ResourceService object.
+      #
+      def initialize(_armrest_configuration, options = {})
+        super
+
+        @provider = options[:provider] || 'Microsoft.Resources'
+
+        set_service_api_version(options, 'subscriptions')
+      end
+
+      # List all the resources for the current subscription. You can optionally
+      # pass :top or :filter options as well to restrict returned results.
+      #
+      # If you pass a :resource_group option, then only resources for that
+      # resource group are returned.
+      #
+      # Examples:
+      #
+      #   rs = ResourceService.new
+      #   rs.list(:top => 2)
+      #   rs.list(:filter => "location eq 'centralus'")
+      #
+      def list(options = {})
+        if options[:resource_group]
+          url = File.join(
+            Azure::Armrest::COMMON_URI, subscription_id, 'resourcegroups',
+            options[:resource_group], 'resources'
+          )
+        else
+          url = File.join(Azure::Armrest::COMMON_URI, subscription_id, 'resources')
+        end
+
+        url << "?api-version=#{api_version}"
+        url << "&$top=#{options[:top]}" if options[:top]
+        url << "&$filter=#{options[:filter]}" if options[:filter]
+
+        response = rest_get(URI.escape(url))
+
+        JSON.parse(response.body)["value"]
+      end
+
+      # Move the resources from +source_group+  under +source_subscription+,
+      # which may be a different subscription.
+      #
+      def move(source_group, source_subscription = @subscription_id)
+        url = File.join(
+          Azure::Armrest::COMMON_URI, source_subscription,
+          'resourcegroups', source_group, 'moveresources'
+        )
+
+        url << "?api-version=#{api_version}"
+
+        response = rest_post(url)
+        response.return!
+      end
+
+      # Checks to see if the given 'resource_name' and 'resource_type' is allowed.
+      # This returns a JSON string that will indicate the status, including an error
+      # code and message on failure.
+      #
+      # If you want a simple boolean check, use the check_resource? method instead.
+      #
+      def check_resource(resource_name, resource_type)
+        body = JSON.dump(:Name => resource_name, :Type => resource_type)
+        url = File.join(Azure::Armrest::RESOURCE, 'providers', provider, 'checkresourcename')
+        url << "?api-version=#{api_version}"
+
+        response = rest_post(url, body)
+        response.return!
+      end
+
+      # Similar to the check_resource method, but returns a boolean instead.
+      #
+      def check_resource?(resource_name, resource_type)
+        check_resource(resource_name, resource_type)['status'] == 'Allowed'
+      end
+
+    end # ResourceService
+  end # Armrest
+end # Azure

--- a/spec/resource_group_service_spec.rb
+++ b/spec/resource_group_service_spec.rb
@@ -1,0 +1,45 @@
+########################################################################
+# resource_group_service_spec.rb
+#
+# Test suite for the Azure::Armrest::ResourceService class.
+########################################################################
+require 'spec_helper'
+
+describe "ResourceGroupService" do
+  before { setup_params }
+  let(:rgsrv) { Azure::Armrest::ResourceGroupService.new(@conf) }
+
+  context "inheritance" do
+    it "is a subclass of ArmrestService" do
+      expect(Azure::Armrest::ResourceGroupService.ancestors).to include(Azure::Armrest::ArmrestService)
+    end
+  end
+
+  context "constructor" do
+    it "returns a rgsrv instance as expected" do
+      expect(rgsrv).to be_kind_of(Azure::Armrest::ResourceGroupService)
+    end
+  end
+
+  context "instance methods" do
+    it "defines a create method" do
+      expect(rgsrv).to respond_to(:create)
+    end
+
+    it "defines a delete method" do
+      expect(rgsrv).to respond_to(:delete)
+    end
+
+    it "defines a get method" do
+      expect(rgsrv).to respond_to(:get)
+    end
+
+    it "defines a list method" do
+      expect(rgsrv).to respond_to(:list)
+    end
+
+    it "defines an update method" do
+      expect(rgsrv).to respond_to(:update)
+    end
+  end
+end

--- a/spec/resource_provider_spec.rb
+++ b/spec/resource_provider_spec.rb
@@ -1,0 +1,59 @@
+########################################################################
+# resource_provider_service_spec.rb
+#
+# Test suite for the Azure::Armrest::ResourceProviderService class.
+########################################################################
+require 'spec_helper'
+
+describe "ResourceProviderService" do
+  before { setup_params }
+  let(:rpsrv) { Azure::Armrest::ResourceProviderService.new(@conf) }
+
+  context "inheritance" do
+    it "is a subclass of ArmrestService" do
+      expect(Azure::Armrest::ResourceProviderService.ancestors).to include(Azure::Armrest::ArmrestService)
+    end
+  end
+
+  context "constructor" do
+    it "returns a rpsrv instance as expected" do
+      expect(rpsrv).to be_kind_of(Azure::Armrest::ResourceProviderService)
+    end
+  end
+
+  context "accessors" do
+    it "defines a provider method" do
+      expect(rpsrv).to respond_to(:provider)
+    end
+
+    it "sets the default provider to the expected value" do
+      expect(rpsrv.provider).to eq "Microsoft.Resources"
+    end
+  end
+
+  context "instance methods" do
+    it "defines a list method" do
+      expect(rpsrv).to respond_to(:list)
+    end
+
+    it "defines a get method" do
+      expect(rpsrv).to respond_to(:get)
+    end
+
+    it "defines a list_geo_locations method" do
+      expect(rpsrv).to respond_to(:list_geo_locations)
+    end
+
+    it "defines a list_api_versions method" do
+      expect(rpsrv).to respond_to(:list_api_versions)
+    end
+
+    it "defines a register method" do
+      expect(rpsrv).to respond_to(:register)
+    end
+
+    it "defines an unregister method" do
+      expect(rpsrv).to respond_to(:unregister)
+    end
+  end
+end

--- a/spec/resource_service_spec.rb
+++ b/spec/resource_service_spec.rb
@@ -1,0 +1,51 @@
+########################################################################
+# resource_service_spec.rb
+#
+# Test suite for the Azure::Armrest::ResourceService class.
+########################################################################
+require 'spec_helper'
+
+describe "ResourceService" do
+  before { setup_params }
+  let(:rsrv) { Azure::Armrest::ResourceService.new(@conf) }
+
+  context "inheritance" do
+    it "is a subclass of ArmrestService" do
+      expect(Azure::Armrest::ResourceService.ancestors).to include(Azure::Armrest::ArmrestService)
+    end
+  end
+
+  context "constructor" do
+    it "returns a rsrv instance as expected" do
+      expect(rsrv).to be_kind_of(Azure::Armrest::ResourceService)
+    end
+  end
+
+  context "accessors" do
+    it "defines a provider method" do
+      expect(rsrv).to respond_to(:provider)
+    end
+
+    it "sets the default provider to the expected value" do
+      expect(rsrv.provider).to eq "Microsoft.Resources"
+    end
+  end
+
+  context "instance methods" do
+    it "defines a list method" do
+      expect(rsrv).to respond_to(:list)
+    end
+
+    it "defines a move method" do
+      expect(rsrv).to respond_to(:move)
+    end
+
+    it "defines a check_resource method" do
+      expect(rsrv).to respond_to(:check_resource)
+    end
+
+    it "defines a check_resource? method" do
+      expect(rsrv).to respond_to(:check_resource?)
+    end
+  end
+end


### PR DESCRIPTION
This adds separate classes for resources, resource groups and resource providers.

Supersedes https://github.com/ManageIQ/azure-armrest/pull/50