### PR TITLE
Fix list and provider= methods, and other tweaks

### DIFF
--- a/spec/virtual_machine_service_spec.rb
+++ b/spec/virtual_machine_service_spec.rb
@@ -33,9 +33,9 @@ describe "VirtualMachineService" do
       expect(vms).to respond_to(:capture)
     end
 
-    it "defines a create method" do
-      expect(vms).to respond_to(:create)
-    end
+    #it "defines a create method" do
+    #  expect(vms).to respond_to(:create)
+    #end
 
     it "defines a deallocate method" do
       expect(vms).to respond_to(:deallocate)
@@ -53,6 +53,14 @@ describe "VirtualMachineService" do
       expect(vms).to respond_to(:get)
     end
 
+    it "defines a list method" do
+      expect(vms).to respond_to(:list)
+    end
+
+    it "creates a get_vms alias for the list method" do
+      expect(vms.method(:sizes)).to eq(vms.method(:series))
+    end
+
     it "defines an restart method" do
       expect(vms).to respond_to(:restart)
     end
@@ -63,6 +71,18 @@ describe "VirtualMachineService" do
 
     it "defines a stop method" do
       expect(vms).to respond_to(:stop)
+    end
+
+    it "defines a provider= method" do
+      expect(vms).to respond_to(:provider=)
+    end
+
+    it "defines a series method" do
+      expect(vms).to respond_to(:series)
+    end
+
+    it "creates a sizes alias for the series method" do
+      expect(vms.method(:sizes)).to eq(vms.method(:series))
     end
   end
 


### PR DESCRIPTION
This fixes and updates some things in the VirtualMachineService class.

* Fixes the provider= method. This is currently broke.
* The add_network_profile and add_power_status methods blow up when a specific resource group is provided, so they are now only called if no resource group is provided. More on that below.
* We never really went back and updated the way the default resource groups were being set after Bill's configuration PR. This addresses that.
* I commented out the create and update methods, since they aren't actually implemented yet.
* The code now explicitly raises an error in most methods if a resource group is not provided.
* I refactored the list method slightly, only creating a mutex if there's a result. This matches what we do in the other service class list methods.
* I flip-flopped the arguments to the capture method to be in line with other service classes, and now allow the resource_group to be specified as an option.
* I added some more basic specs, and commented out the create spec for now.

Regarding the add_network_profile and add_power_status methods, I feel like this might be a bit of MIQ code needs bleeding into our gem, and wonder if they wouldn't be better suited in the Azure::VM class there instead. But, we can discuss that separately.