### PR TITLE
fixed #70: provider name is now case insensitive

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,7 +4,7 @@ CodeClimate::TestReporter.start
 $LOAD_PATH.unshift File.expand_path('../lib', __FILE__)
 require 'azure-armrest'
 
-@@providers = {'name' => {}}
+@@providers_hash = {'name' => {}}
 
 def setup_params
   @sub = 'abc-123-def-456'


### PR DESCRIPTION
Now the key in the hash is lower case.

Plus some minor refactoring.

Rename `@@providers` to `@@providers_hash` to avoid some naming confusion because the class has anther `providers` method.