### PR TITLE
Update get method, fix api-version

### DIFF
--- a/spec/storage_account_service_spec.rb
+++ b/spec/storage_account_service_spec.rb
@@ -62,6 +62,10 @@ describe "StorageAccountService" do
       expect(sas).to respond_to(:list_account_keys)
     end
 
+    it "defines a list_all_for_subscription method" do
+      expect(sas).to respond_to(:list_all_for_subscription)
+    end
+
     it "defines a regenerate_storage_account_keys method" do
       expect(sas).to respond_to(:regenerate_storage_account_keys)
     end


### PR DESCRIPTION
It seems the storage account api is in a bit of flux at the moment, as the api version that we gather dynamically is not actually supported. For now we have to set it to '2015-05-01-preview' as per the docs to get things to work.

I suspect this is tied to a change in the results that are returned by the list_account_keys method. Previously this method returned the keys plus the account info. It seems that now it only returns the key info.

So, I've updated the "get" method to accept an optional 3rd argument that will automatically gather the key information as part of the output if desired. I'm pretty sure we're going to need these keys to get at the metrics table info.

I also added a "list_subscription" method.