### PR TITLE
Rename list and list_with_details

### DIFF
--- a/lib/azure/armrest/template_deployment_service.rb
+++ b/lib/azure/armrest/template_deployment_service.rb
@@ -10,13 +10,13 @@ class TemplateDeploymentService < ArmrestService
   end
 
   # Get names of all deployments in a resource group
-  def list(resource_group = armrest_configuration.resource_group)
-    list_with_details(resource_group).map {|e| e['name']}
+  def list_names(resource_group = armrest_configuration.resource_group)
+    list(resource_group).map {|e| e['name']}
   end
 
   # Get all deployments in a resource group
   # If the resource group is nil, then return deployments in all groups
-  def list_with_details(resource_group = armrest_configuration.resource_group)
+  def list(resource_group = armrest_configuration.resource_group)
     if resource_group
       url = build_deployment_url(resource_group)
       JSON.parse(rest_get(url))['value']

--- a/spec/template_deployment_service_spec.rb
+++ b/spec/template_deployment_service_spec.rb
@@ -34,17 +34,17 @@ describe "TemplateDeploymentService" do
       tds.delete('deployname', 'groupname')
     end
 
-    it "defines a list method" do
+    it "defines a list_names method" do
       expected_url = "https://management.azure.com/subscriptions/abc-123-def-456/resourceGroups/groupname/deployments?api-version=2014-04-01-preview"
       expected_return = '{"value":[{"name":"deployname"}]}'
       expect(RestClient).to receive(:get).with(expected_url, anything).and_return(expected_return)
-      tds.list('groupname')
+      tds.list_names('groupname')
     end
 
-    it "defines a list_with_details method" do
+    it "defines a list method" do
       expected_url = "https://management.azure.com/subscriptions/abc-123-def-456/resourceGroups/groupname/deployments?api-version=2014-04-01-preview"
       expect(RestClient).to receive(:get).with(expected_url, anything).and_return('{}')
-      tds.list_with_details('groupname')
+      tds.list('groupname')
     end
 
     it "defines a get method" do


### PR DESCRIPTION
To be consistent with other services, two methods are renamed

`list` => `list_names`, a short version that returns deployment names only 
`list_with_details` => `list`, a full version that returns bulk information for all deployments.