### PR TITLE
Add a NetworkSecurityGroupService class.

### DIFF
--- a/lib/azure/armrest.rb
+++ b/lib/azure/armrest.rb
@@ -35,6 +35,9 @@ require 'azure/armrest/template_deployment_service'
 require 'azure/armrest/resource_service'
 require 'azure/armrest/resource_group_service'
 require 'azure/armrest/resource_provider_service'
+require 'azure/armrest/network/ip_address_service'
+require 'azure/armrest/network/network_interface_service'
+require 'azure/armrest/network/network_security_group_service'
 
 # JSON wrapper classes. The service classes should require their own
 # wrappers from this point on.

--- a/lib/azure/armrest/network/ip_address_service.rb
+++ b/lib/azure/armrest/network/ip_address_service.rb
@@ -1,0 +1,102 @@
+module Azure
+  module Armrest
+    # Class for managing public IP addresss.
+    class IpAddressService < ArmrestService
+
+      # Creates and returns a new IpAddressService instance.
+      #
+      def initialize(_armrest_configuration, options = {})
+        super
+        @provider = options[:provider] || 'Microsoft.Network'
+        set_service_api_version(options, 'publicIPAddresses')
+      end
+
+      # Return information for the given IP address name for the
+      # provided +resource_group+. If no group is specified, it will use
+      # the resource group set in the constructor.
+      #
+      # Example:
+      #
+      #   # Where 'your_ip_name' likely corresponds to a VM name.
+      #   ip.get('your_ip_name', 'your_resource_group')
+      #
+      def get(ip_name, resource_group = armrest_configuration.resource_group)
+        raise ArgumentError, "must specify resource group" unless resource_group
+        url = build_url(resource_group, ip_name)
+        JSON.parse(rest_get(url))
+      end
+
+      # Shortcut method that returns just the IP address for the given public
+      # IP address name.
+      #
+      def get_ip(ip_name, resource_group = armrest_configuration.resource_group)
+        get(ip_name, resource_group)['properties']['ipAddress']
+      end
+
+      # Returns a list of available IP addresss for the given subscription
+      # for the provided +group+, or for all resource groups if no group is specified.
+      #
+      def list(group = nil)
+        if group
+          url = build_url(group)
+          JSON.parse(rest_get(url))['value']
+        else
+          array = []
+          threads = []
+          mutex = Mutex.new
+
+          resource_groups.each do |rg|
+            threads << Thread.new(rg['name']) do |group|
+              url = build_url(group)
+              response = rest_get(url)
+              results = JSON.parse(response)['value']
+              if results && !results.empty?
+                mutex.synchronize{
+                  results.each{ |hash| hash['resourceGroup'] = group }
+                  array << results
+                }
+              end
+            end
+          end
+
+          threads.each(&:join)
+
+          array.flatten
+        end
+      end
+
+      # List all IP addresss for the current subscription.
+      #
+      def list_all_for_subscription
+        sub_id = armrest_configuration.subscription_id
+        url = File.join(
+          Azure::Armrest::COMMON_URI, sub_id, 'providers',
+          @provider, 'publicIPAddresses'
+        )
+        url << "?api-version=#{@api_version}"
+        JSON.parse(rest_get(url))['value']
+      end
+
+      alias list_all list_all_for_subscription
+
+      private
+
+      # Builds a URL based on subscription_id an resource_group and any other
+      # arguments provided, and appends it with the api-version.
+      def build_url(resource_group, *args)
+        url = File.join(
+          Azure::Armrest::COMMON_URI,
+          armrest_configuration.subscription_id,
+          'resourceGroups',
+          resource_group,
+          'providers',
+          @provider,
+          'publicIPAddresses',
+        )
+
+        url = File.join(url, *args) unless args.empty?
+        url << "?api-version=#{@api_version}"
+      end
+    end
+  end
+end

--- a/lib/azure/armrest/network/network_interface_service.rb
+++ b/lib/azure/armrest/network/network_interface_service.rb
@@ -1,0 +1,125 @@
+module Azure
+  module Armrest
+    # Class for managing network interfaces.
+    class NetworkInterfaceService < ArmrestService
+
+      # Creates and returns a new NetworkInterfaceService instance.
+      #
+      def initialize(_armrest_configuration, options = {})
+        super
+        @provider = options[:provider] || 'Microsoft.Network'
+        set_service_api_version(options, 'networkInterfaces')
+      end
+
+      # Return information for the given network interface card for the
+      # provided +resource_group+. If no group is specified, it will use the
+      # resource group set in the constructor.
+      #
+      # Example:
+      #
+      #   nsg.get('your_interface', 'your_resource_group')
+      #
+      def get(interface, resource_group = armrest_configuration.resource_group)
+        raise ArgumentError, "must specify resource group" unless resource_group
+        url = build_url(resource_group, interface)
+        JSON.parse(rest_get(url))
+      end
+
+      # Returns a list of available network interfaces in the current subscription
+      # for the provided +resource_group+.
+      #
+      def list(resource_group = armrest_configuration.resource_group)
+        raise ArgumentError, "no resource group provided" unless resource_group
+        url = build_url(resource_group)
+        JSON.parse(rest_get(url))['value']
+      end
+
+      # List all network interfaces for the current subscription.
+      #
+      def list_all_for_subscription
+        sub_id = armrest_configuration.subscription_id
+        url = File.join(Azure::Armrest::COMMON_URI, sub_id, 'providers', @provider, 'networkInterfaces')
+        url << "?api-version=#{@api_version}"
+        JSON.parse(rest_get(url))['value']
+      end
+
+      alias list_all list_all_for_subscription
+
+      # Delete the given network interface in +resource_group+.
+      #
+      def delete(interface, resource_group = armrest_configuration.resource_group)
+        raise ArgumentError, "must specify resource group" unless resource_group
+
+        url = build_url(group, account_name)
+        response = rest_delete(url)
+        response.return!
+      end
+
+      # Create a new network interface, or update an existing network interface if it
+      # already exists. The first argument is a hash of options.
+      #
+      # - :name # Mandatory
+      # - :location # Mandatory
+      # - :tags
+      # - :properties
+      #   - :networkSecurityGroup
+      #     - :id
+      #   - :ipConfigurations
+      #   [
+      #     - :name # Mandatory
+      #     - :properties
+      #       - :subnet
+      #         - :id # Mandatory
+      #       - :privateIPAddress
+      #       - :privateIPAllocationMethod # Mandatory
+      #       - :publicIPAddress
+      #         - :id
+      #       - :loadBalancerBackendAddressPools
+      #         - :id
+      #       - :loadBalancerInboundNatRules
+      #         - :id
+      #   ]
+      #
+      #   - :dnsSettings
+      #     - :dnsServers[ <ip1>, <ip2>, ... ]
+      #
+      # For convenience, you may also pass the :resource_group as a hash option.
+      #
+      def create(options, resource_group = armrest_configuration.resource_group)
+        resource_group = options.delete(:resource_group) || resource_group
+        name = options.delete(:name)
+
+        raise ArgumentError, "no resource group specified" unless resource_group
+        raise Argument, "no interface name specified" unless name
+
+        body = options.to_json
+
+        url = build_url(resource_group, name)
+
+        response = rest_put(url, body)
+        response.return!
+      end
+
+      alias update create
+
+      private
+
+      # Builds a URL based on subscription_id an resource_group and any other
+      # arguments provided, and appends it with the api-version.
+      def build_url(resource_group, *args)
+        url = File.join(
+          Azure::Armrest::COMMON_URI,
+          armrest_configuration.subscription_id,
+          'resourceGroups',
+          resource_group,
+          'providers',
+          @provider,
+          'networkInterfaces',
+        )
+
+        url = File.join(url, *args) unless args.empty?
+        url << "?api-version=#{@api_version}"
+      end
+    end
+  end
+end

--- a/lib/azure/armrest/network/network_security_group_service.rb
+++ b/lib/azure/armrest/network/network_security_group_service.rb
@@ -1,0 +1,95 @@
+module Azure
+  module Armrest
+    # Class for managing network security groups.
+    class NetworkSecurityGroupService < ArmrestService
+
+      # Creates and returns a new NetworkSecurityGroupService instance.
+      #
+      def initialize(_armrest_configuration, options = {})
+        super
+        @provider = options[:provider] || 'Microsoft.Network'
+        set_service_api_version(options, 'networkSecurityGroups')
+      end
+
+      # Return information for the given network security group name for the
+      # provided +resource_group+. If no group is specified, it will use the
+      # resource group set in the constructor.
+      #
+      # Example:
+      #
+      #   # Where 'your_security_group' is likely same as the name of a VM.
+      #   nsg.get('your_security_group', 'your_resource_group')
+      #
+      def get(ns_group_name, resource_group = armrest_configuration.resource_group)
+        raise ArgumentError, "must specify resource group" unless resource_group
+        url = build_url(resource_group, ns_group_name)
+        JSON.parse(rest_get(url))
+      end
+
+      # Returns a list of available network security groups for the given subscription
+      # for the provided +group+, or for all resource groups if no group is specified.
+      #
+      def list(group = nil)
+        if group
+          url = build_url(group)
+          JSON.parse(rest_get(url))['value']
+        else
+          array = []
+          threads = []
+          mutex = Mutex.new
+
+          resource_groups.each do |rg|
+            threads << Thread.new(rg['name']) do |group|
+              url = build_url(group)
+              response = rest_get(url)
+              results = JSON.parse(response)['value']
+              if results && !results.empty?
+                mutex.synchronize{
+                  results.each{ |hash| hash['resourceGroup'] = group }
+                  array << results
+                }
+              end
+            end
+          end
+
+          threads.each(&:join)
+
+          array.flatten
+        end
+      end
+
+      # List all network security groups for the current subscription.
+      #
+      def list_all_for_subscription
+        sub_id = armrest_configuration.subscription_id
+        url = File.join(
+          Azure::Armrest::COMMON_URI, sub_id, 'providers',
+          @provider, 'networkSecurityGroups'
+        )
+        url << "?api-version=#{@api_version}"
+        JSON.parse(rest_get(url))['value']
+      end
+
+      alias list_all list_all_for_subscription
+
+      private
+
+      # Builds a URL based on subscription_id an resource_group and any other
+      # arguments provided, and appends it with the api-version.
+      def build_url(resource_group, *args)
+        url = File.join(
+          Azure::Armrest::COMMON_URI,
+          armrest_configuration.subscription_id,
+          'resourceGroups',
+          resource_group,
+          'providers',
+          @provider,
+          'networkSecurityGroups',
+        )
+
+        url = File.join(url, *args) unless args.empty?
+        url << "?api-version=#{@api_version}"
+      end
+    end
+  end
+end

--- a/spec/ip_address_spec.rb
+++ b/spec/ip_address_spec.rb
@@ -1,0 +1,46 @@
+########################################################################
+# ip_address_service_spec.rb
+#
+# Test suite for the Azure::Armrest::ResourceService class.
+########################################################################
+require 'spec_helper'
+
+describe "IpAddressService" do
+  before { setup_params }
+  let(:ip) { Azure::Armrest::IpAddressService.new(@conf) }
+
+  context "inheritance" do
+    it "is a subclass of ArmrestService" do
+      expect(Azure::Armrest::IpAddressService.ancestors).to include(Azure::Armrest::ArmrestService)
+    end
+  end
+
+  context "constructor" do
+    it "returns a ip instance as expected" do
+      expect(ip).to be_kind_of(Azure::Armrest::IpAddressService)
+    end
+  end
+
+  context "instance methods" do
+    it "defines a get method" do
+      expect(ip).to respond_to(:get)
+    end
+
+    it "defines a get_ip method" do
+      expect(ip).to respond_to(:get_ip)
+    end
+
+    it "defines a list method" do
+      expect(ip).to respond_to(:list)
+    end
+
+    it "defines a list_all_for_subscription method" do
+      expect(ip).to respond_to(:list_all_for_subscription)
+    end
+
+    it "defines a list_all alias method" do
+      expect(ip).to respond_to(:list_all)
+      expect(ip.method(:list_all)).to eql(ip.method(:list_all_for_subscription))
+    end
+  end
+end

--- a/spec/network_interface_service_spec.rb
+++ b/spec/network_interface_service_spec.rb
@@ -1,0 +1,67 @@
+########################################################################
+# network_interface_service_spec.rb
+#
+# Test suite for the Azure::Armrest::NetworkInterfaceService class.
+########################################################################
+require 'spec_helper'
+
+describe "NetworkInterfaceService" do
+  before { setup_params }
+  let(:sas) { Azure::Armrest::NetworkInterfaceService.new(@conf) }
+
+  context "inheritance" do
+    it "is a subclass of ArmrestService" do
+      expect(Azure::Armrest::NetworkInterfaceService.ancestors).to include(Azure::Armrest::ArmrestService)
+    end
+  end
+
+  context "constructor" do
+    it "returns a SAS instance as expected" do
+      expect(sas).to be_kind_of(Azure::Armrest::NetworkInterfaceService)
+    end
+  end
+
+  context "accessors" do
+    it "defines a base_url accessor" do
+      expect(sas).to respond_to(:base_url)
+      expect(sas).to respond_to(:base_url=)
+    end
+  end
+
+  context "instance methods" do
+    it "defines a create method" do
+      expect(sas).to respond_to(:create)
+    end
+
+    it "defines the update alias" do
+      expect(sas).to respond_to(:update)
+      expect(sas.method(:update)).to eql(sas.method(:create))
+    end
+
+    it "defines a delete method" do
+      expect(sas).to respond_to(:delete)
+    end
+
+    it "defines a get method" do
+      expect(sas).to respond_to(:get)
+    end
+
+    it "defines a list method" do
+      expect(sas).to respond_to(:list)
+    end
+
+    it "defines a list_all_for_subscription method" do
+      expect(sas).to respond_to(:list_all_for_subscription)
+    end
+
+    it "defines a list_all alias for list_all_for_subscription" do
+      expect(sas.method(:list_all)).to eql(sas.method(:list_all_for_subscription))
+    end
+  end
+
+  context "create" do
+    it "requires an interface name" do
+      expect{ sas.create }.to raise_error(ArgumentError)
+    end
+  end
+end

--- a/spec/network_security_group_spec.rb
+++ b/spec/network_security_group_spec.rb
@@ -1,0 +1,42 @@
+########################################################################
+# network_security_group_service_spec.rb
+#
+# Test suite for the Azure::Armrest::ResourceService class.
+########################################################################
+require 'spec_helper'
+
+describe "NetworkSecurityGroupService" do
+  before { setup_params }
+  let(:nsg) { Azure::Armrest::NetworkSecurityGroupService.new(@conf) }
+
+  context "inheritance" do
+    it "is a subclass of ArmrestService" do
+      expect(Azure::Armrest::NetworkSecurityGroupService.ancestors).to include(Azure::Armrest::ArmrestService)
+    end
+  end
+
+  context "constructor" do
+    it "returns a nsg instance as expected" do
+      expect(nsg).to be_kind_of(Azure::Armrest::NetworkSecurityGroupService)
+    end
+  end
+
+  context "instance methods" do
+    it "defines a get method" do
+      expect(nsg).to respond_to(:get)
+    end
+
+    it "defines a list method" do
+      expect(nsg).to respond_to(:list)
+    end
+
+    it "defines a list_all_for_subscription method" do
+      expect(nsg).to respond_to(:list_all_for_subscription)
+    end
+
+    it "defines a list_all alias method" do
+      expect(nsg).to respond_to(:list_all)
+      expect(nsg.method(:list_all)).to eql(nsg.method(:list_all_for_subscription))
+    end
+  end
+end


### PR DESCRIPTION
This is an initial implementation of a wrapper class for gathering NetworkSecurityGroup info. I haven't added create or delete methods yet, but figured we probably won't need that for some time.