### PR TITLE
Fix bugs in capture method.

### DIFF
--- a/lib/azure/armrest/virtual_machine_service.rb
+++ b/lib/azure/armrest/virtual_machine_service.rb
@@ -130,11 +130,11 @@ module Azure
 
         body = {
           :vhdPrefix => prefix,
-          :destinationContainer => container,
+          :destinationContainerName => container,
           :overwriteVhds => overwrite
         }.to_json
 
-        url = build_url(group, 'capture')
+        url = build_url(group, vmname, 'capture')
 
         response = rest_post(url, body)
         response.return!


### PR DESCRIPTION
This fixes two issues with the capture method. First, :destinationContainer should be :destinationContainerName, and second, the vmname was missing from the url.