### PR TITLE
Implement JSON base wrapper classes

### DIFF
--- a/lib/azure/armrest.rb
+++ b/lib/azure/armrest.rb
@@ -35,3 +35,7 @@ require 'azure/armrest/template_deployment_service'
 require 'azure/armrest/resource_service'
 require 'azure/armrest/resource_group_service'
 require 'azure/armrest/resource_provider_service'
+
+# JSON wrapper classes. The service classes should require their own
+# wrappers from this point on.
+require_relative 'armrest/model/base_model'

--- a/lib/azure/armrest/armrest_service.rb
+++ b/lib/azure/armrest/armrest_service.rb
@@ -1,3 +1,5 @@
+require_relative 'model/base_model'
+
 module Azure
   module Armrest
     # Abstract base class for the other service classes.

--- a/lib/azure/armrest/model/base_model.rb
+++ b/lib/azure/armrest/model/base_model.rb
@@ -1,0 +1,96 @@
+require 'delegate'
+require 'ostruct'
+
+module Azure
+  module Armrest
+    # Base class for JSON wrapper classes. Each Service class should have
+    # a corresponding class that wraps the JSON it collects, and each of
+    # them should subclass this base class.
+    class BaseModel < Delegator
+      # Access the json instance variable directly.
+      attr_accessor :json
+
+      # Constructs and returns a new JSON wrapper class. Pass in a plain
+      # JSON string and it will automatically give you accessor methods
+      # that make it behave like a typical Ruby object.
+      #
+      # Example:
+      #   class Person < Azure::ArmRest::BaseModel; end
+      #
+      #   json_string = '{"firstname":"jeff", "lastname":"durand",
+      #     "address": { "street":"22 charlotte rd", "zipcode":"01013"}
+      #   }'
+      #
+      #   # Or whatever your subclass happens to be.
+      #   person = Person.new(json_string)
+      #
+      #   # The JSON properties are now available as methods.
+      #   person.firstname        # => 'jeff'
+      #   person.address.zipcode  # => '01013'
+      #
+      #   # Or you can get back the original JSON if necessary.
+      #   person.json # => Returns original JSON
+      #
+      def initialize(json)
+        @json = json
+        @ostruct = JSON.parse(json, object_class: OpenStruct)
+        __setobj__(@ostruct)
+      end
+
+      # Returns the original JSON string passed to the constructor.
+      def to_json
+        @json
+      end
+
+      # Explicitly convert the object to the original JSON string.
+      def to_s
+        @json
+      end
+
+      # Implicitly convert the object to the original JSON string.
+      def to_str
+        @json
+      end
+
+      protected
+
+      # Interface method required to make delegation work. Do
+      # not use this method directly.
+      def __getobj__
+        @ostruct
+      end
+
+      # A custom Delegator interface method that creates snake_case
+      # versions of the camelCase delegate methods.
+      def __setobj__(obj)
+        obj.methods(false).each{ |m|
+          if m.to_s[-1] != '=' # Must deal with nested ostruct's
+            res = obj.send(m)
+            if res.respond_to?(:each)
+              res.each{ |o| __setobj__(o) if o.is_a?(OpenStruct) }
+            else
+              __setobj__(res) if res.is_a?(OpenStruct)
+            end
+          end
+          snake = m.to_s.gsub(/(.)([A-Z])/,'\1_\2').downcase.to_sym
+          obj.instance_eval("alias #{snake} #{m}") unless snake == m
+        }
+      end
+    end
+
+    # Initial class definitions. Reopen these classes as needed.
+
+    class AvailabilitySet < BaseModel; end
+    class Event < BaseModel; end
+    class Resource < BaseModel; end
+    class ResourceGroup < BaseModel; end
+    class ResourceProvider < BaseModel; end
+    class StorageAccount < BaseModel; end
+    class Subnet < BaseModel; end
+    class TemplateDeployment < BaseModel; end
+    class VirtualMachine < BaseModel; end
+    class VirtualMachineExtension < BaseModel; end
+    class VirtualMachineImage < BaseModel; end
+    class VirtualNetwork < BaseModel; end
+  end
+end

--- a/spec/models/base_model_spec.rb
+++ b/spec/models/base_model_spec.rb
@@ -1,0 +1,83 @@
+########################################################################
+# base_model_spec.rb
+#
+# Test suite for the Azure::Armrest::BaseModel json model class.
+########################################################################
+require 'spec_helper'
+
+describe "BaseModel" do
+  before {
+    @json = '{
+      "firstName":"jeff",
+      "lastName":"durand",
+      "address": {"street":"22 charlotte rd", "zipcode":"01013"}
+    }'
+  }
+
+  let(:base){ Azure::Armrest::BaseModel.new(@json) }
+
+  context "constructor" do
+    it "returns a BaseModel class as expected" do
+      expect(base).to be_kind_of(Azure::Armrest::BaseModel)
+    end
+  end
+
+  context "accessors" do
+    it "defines a json accessor that returns the original json" do
+      expect(base.json).to eq(@json)
+    end
+  end
+
+  context "inspection methods" do
+    it "defines a to_s method that returns the original json" do
+      expect(base.to_s).to eq(@json)
+    end
+
+    it "defines a to_str method that returns the original json" do
+      expect(base.to_str).to eq(@json)
+    end
+
+    it "defines a to_json method that returns the original json" do
+      expect(base.to_json).to eq(@json)
+    end
+  end
+
+  context "dynamic method generation" do
+    it "defines a method for each json property" do
+      expect(base).to respond_to(:firstName)
+      expect(base).to respond_to(:lastName)
+      expect(base).to respond_to(:address)
+    end
+
+    it "defines snake_case aliases for each dynamic method" do
+      expect(base).to respond_to(:first_name)
+      expect(base).to respond_to(:last_name)
+      expect(base).to respond_to(:address)
+    end
+
+    it "allows you to chain dynamic methods" do
+      expect(base.address).to respond_to(:street)
+      expect(base.address).to respond_to(:zipcode)
+    end
+  end
+
+  context "dynamic accessors" do
+    it "returns expected value for firstName method" do
+      expect(base.firstName).to eq('jeff')
+      expect(base.first_name).to eq('jeff')
+    end
+
+    it "returns expected value for lastName method" do
+      expect(base.lastName).to eq('durand')
+      expect(base.last_name).to eq('durand')
+    end
+
+    it "returns expected value for address method" do
+      expect(base.address).to be_kind_of(OpenStruct)
+    end
+
+    it "returns expected value for zipcode method" do
+      expect(base.address.zipcode).to eq('01013')
+    end
+  end
+end


### PR DESCRIPTION
This replaces https://github.com/ManageIQ/azure-armrest/pull/21

With JSON wrapper classes we can get real classes back instead of plain hashes, and add custom methods to them as we see fit.

This PR does not modify the service classes. They still return hashes for now, but you can still use these wrapper classes by calling .to_json first. Basically, I wanted this first step reviewed before altering other code.

Some sample code:

    vmm = Azure::Armrest::VirtualMachineService.new(conf)
    json = vmm.get('miqazure-win2k8', 'miqazure-dan1', true).to_json
    vm = Azure::Armrest::VirtualMachine.new(json)

    p vm.properties.hardware_profile.vm_size # => "Standard_A1"
    p vm.properties.storage_profile.os_disk.os_type # => "Windows"
    p vm.properties.os_profile.computer_name # => "miqazure-win2k8"