### PR TITLE
Fix bug in build_url method.

### DIFF
--- a/lib/azure/armrest/virtual_machine_image_service.rb
+++ b/lib/azure/armrest/virtual_machine_image_service.rb
@@ -124,7 +124,7 @@ module Azure
         )
 
         url = File.join(url, *args) unless args.empty?
-        url << "?api-version=#{api_version}"
+        url << "?api-version=#{@api_version}"
       end
 
     end # VirtualMachineImageService


### PR DESCRIPTION
Should be "@api_version" (missing '@' symbol) in build_url method.