### PR TITLE
Add custom resource_group, tags and inspect methods to BaseModel

### DIFF
--- a/lib/azure/armrest/model/base_model.rb
+++ b/lib/azure/armrest/model/base_model.rb
@@ -33,8 +33,19 @@ module Azure
       #
       def initialize(json)
         @json = json
+        @resource_group = nil
         @ostruct = JSON.parse(json, object_class: OpenStruct)
         __setobj__(@ostruct)
+      end
+
+      # Return the resource group for the current object.
+      def resource_group
+        @resource_group ||= id[/resourceGroups\/(.+?)\//i, 1] rescue nil
+      end
+
+      # Return a hash of tags associated with the resource.
+      def tags
+        @ostruct.tags.to_h
       end
 
       # Returns the original JSON string passed to the constructor.
@@ -50,6 +61,16 @@ module Azure
       # Implicitly convert the object to the original JSON string.
       def to_str
         @json
+      end
+
+      # Custom inspect method that shows the current class and methods.
+      #--
+      # TODO: Make this recursive.
+      def inspect
+        string = "<#{self.class} "
+        method_list = methods(false).select{ |m| !m.to_s.include?('=') }
+        string << method_list.map{ |m| "#{m}=#{send(m)}" }.join(" ")
+        string << ">"
       end
 
       protected
@@ -72,6 +93,7 @@ module Azure
               __setobj__(res) if res.is_a?(OpenStruct)
             end
           end
+
           snake = m.to_s.gsub(/(.)([A-Z])/,'\1_\2').downcase.to_sym
           obj.instance_eval("alias #{snake} #{m}") unless snake == m
         }

--- a/spec/models/base_model_spec.rb
+++ b/spec/models/base_model_spec.rb
@@ -28,6 +28,30 @@ describe "BaseModel" do
     end
   end
 
+  context "custom methods" do
+    it "defines a resource_group method that returns nil by default" do
+      expect(base).to respond_to(:resource_group)
+      expect(base.resource_group).to eq(nil)
+    end
+
+    it "returns the expected value for the resource_group method" do
+      @json = {:id => '/foo/bar/resourceGroups/foo/x/y/z'}.to_json
+      base = Azure::Armrest::BaseModel.new(@json)
+      expect(base.resource_group).to eq('foo')
+    end
+
+    it "defines a tags method that returns an empty hash by default" do
+      expect(base).to respond_to(:tags)
+      expect(base.tags).to eq({})
+    end
+
+    it "returns the expected hash for the tags method when defined" do 
+      @json = {:name => 'test', :tags => {:foo => 1, :bar => 2}}.to_json
+      base = Azure::Armrest::BaseModel.new(@json)
+      expect(base.tags).to eq({:foo => 1, :bar => 2})
+    end
+  end
+
   context "inspection methods" do
     it "defines a to_s method that returns the original json" do
       expect(base.to_s).to eq(@json)
@@ -39,6 +63,13 @@ describe "BaseModel" do
 
     it "defines a to_json method that returns the original json" do
       expect(base.to_json).to eq(@json)
+    end
+
+    it "defines a custom inspect method" do
+      @json = {:name => 'test', :age => 33}.to_json
+      base = Azure::Armrest::BaseModel.new(@json)
+      expected = "<Azure::Armrest::BaseModel name=test age=33>"
+      expect(base.inspect).to eq(expected)
     end
   end
 


### PR DESCRIPTION
This adds a custom resource_group, tags and inspect method to the BaseModel wrapper class.

The resource_group parses the group name from the id field.

The tags method was necessary in order to avoid getting back an OpenStruct. For that particular attribute we want a literal hash.

The inspect method shows nicer output, including the current class name, instead of a vanilla OpenStruct.

I also added some specs.