### PR TITLE
Refactor get and list methods to return JSON wrapper objects

### DIFF
--- a/lib/azure/armrest/armrest_service.rb
+++ b/lib/azure/armrest/armrest_service.rb
@@ -157,7 +157,7 @@ module Azure
       def providers
         url = url_with_api_version(armrest_configuration.api_version, @base_url, 'providers')
         resp = rest_get(url)
-        JSON.parse(resp.body)["value"]
+        JSON.parse(resp.body)["value"].map{ |hash| Azure::Armrest::ResourceProvider.new(hash) }
       end
 
       # Returns information about the specific provider +namespace+.
@@ -165,7 +165,7 @@ module Azure
       def provider_info(provider)
         url = url_with_api_version(armrest_configuration.api_version, @base_url, 'providers', provider)
         response = rest_get(url)
-        JSON.parse(response.body)
+        Azure::Armrest::ResourceProvider.new(response)
       end
 
       alias geo_locations provider_info
@@ -190,8 +190,8 @@ module Azure
       #
       def subscriptions
         url = url_with_api_version(armrest_configuration.api_version, @base_url, 'subscriptions')
-        resp = rest_get(url)
-        JSON.parse(resp.body)["value"]
+        response = rest_get(url)
+        JSON.parse(response.body)["value"].map{ |hash| Azure::Armrest::Subscription.new(hash) }
       end
 
       # Return information for the specified subscription ID, or the
@@ -206,8 +206,8 @@ module Azure
           armrest_configuration.subscription_id
         )
 
-        resp = rest_get(url)
-        JSON.parse(resp.body)
+        response = rest_get(url)
+        Azure::Armrest::Subscription.new(response.body)
       end
 
       # Returns a list of resources for the current subscription. If a
@@ -222,7 +222,7 @@ module Azure
         url = url_with_api_version(armrest_configuration.api_version, url_comps)
         response = rest_get(url)
 
-        JSON.parse(response.body)["value"]
+        JSON.parse(response)["value"].map{ |hash| Azure::Armrest::Resource.new(hash) }
       end
 
       # Returns a list of resource groups for the current subscription.
@@ -236,14 +236,14 @@ module Azure
           'resourcegroups'
         )
         response = rest_get(url)
-        JSON.parse(response.body)["value"]
+        JSON.parse(response)["value"].map{ |hash| Azure::Armrest::ResourceGroup.new(hash) }
       end
 
       # Returns information on the specified +resource_group+ for the current
       # subscription, or the resource group specified in the constructor if
       # none is provided.
       #
-      def resource_group_info(resource_group)
+      def resource_group_info(resource_group = armrest_configuration.resource_group)
         url = url_with_api_version(
           armrest_configuration.api_version,
           @base_url,
@@ -253,8 +253,8 @@ module Azure
           resource_group
         )
 
-        resp = rest_get(url)
-        JSON.parse(resp.body)
+        response = rest_get(url)
+        Azure::Armrest::ResourceGroup.new(response.body)
       end
 
       # Returns a list of tags for the current subscription.
@@ -268,7 +268,7 @@ module Azure
           'tagNames'
         )
         resp = rest_get(url)
-        JSON.parse(resp.body)["value"]
+        JSON.parse(resp.body)["value"].map{ |hash| Azure::Armrest::Tag.new(hash) }
       end
 
       # Returns a list of tenants that can be accessed.
@@ -276,7 +276,7 @@ module Azure
       def tenants
         url = url_with_api_version(armrest_configuration.api_version, @base_url, 'tenants')
         resp = rest_get(url)
-        JSON.parse(resp.body)
+        JSON.parse(resp.body)['value'].map{ |hash| Azure::Armrest::Tenant.new(hash) }
       end
 
       private

--- a/lib/azure/armrest/model/base_model.rb
+++ b/lib/azure/armrest/model/base_model.rb
@@ -23,7 +23,8 @@ module Azure
 
       # Constructs and returns a new JSON wrapper class. Pass in a plain
       # JSON string and it will automatically give you accessor methods
-      # that make it behave like a typical Ruby object.
+      # that make it behave like a typical Ruby object. You may also pass
+      # in a hash.
       #
       # Example:
       #   class Person < Azure::ArmRest::BaseModel; end
@@ -43,6 +44,7 @@ module Azure
       #   person.json # => Returns original JSON
       #
       def initialize(json)
+        json = json.to_json unless json.is_a?(String)
         @json = json
         @resource_group = nil
         @ostruct = JSON.parse(json, object_class: OpenStruct)
@@ -119,8 +121,11 @@ module Azure
     class ResourceGroup < BaseModel; end
     class ResourceProvider < BaseModel; end
     class StorageAccount < BaseModel; end
+    class Subscription < BaseModel; end
+    class Tag < BaseModel; end
     class TemplateDeployment < BaseModel; end
     class TemplateDeploymentOperation < TemplateDeployment; end
+    class Tenant < BaseModel; end
     class VirtualMachine < BaseModel; end
     class VirtualMachineInstance < VirtualMachine; end
     class VirtualMachineModel < VirtualMachine; end

--- a/lib/azure/armrest/network/network_interface_service.rb
+++ b/lib/azure/armrest/network/network_interface_service.rb
@@ -22,7 +22,8 @@ module Azure
         def get(interface, resource_group = armrest_configuration.resource_group)
           raise ArgumentError, "must specify resource group" unless resource_group
           url = build_url(resource_group, interface)
-          JSON.parse(rest_get(url))
+          response = rest_get(url)
+          Azure::Armrest::Network::NetworkInterface.new(response)
         end
 
         # Returns a list of available network interfaces in the current subscription
@@ -31,19 +32,25 @@ module Azure
         def list(resource_group = armrest_configuration.resource_group)
           raise ArgumentError, "no resource group provided" unless resource_group
           url = build_url(resource_group)
-          JSON.parse(rest_get(url))['value']
+          response = rest_get(url)
+          JSON.parse(response)['value'].map{ |hash|
+            Azure::Armrest::Network::NetworkInterface.new(hash)
+          }
         end
 
         # List all network interfaces for the current subscription.
         #
-        def list_all_for_subscription
+        def list_all
           sub_id = armrest_configuration.subscription_id
           url = File.join(Azure::Armrest::COMMON_URI, sub_id, 'providers', @provider, 'networkInterfaces')
           url << "?api-version=#{@api_version}"
-          JSON.parse(rest_get(url))['value']
-        end
 
-        alias list_all list_all_for_subscription
+          response = rest_get(url)
+
+          JSON.parse(response)['value'].map{ |hash|
+            Azure::Armrest::Network::NetworkInterface.new(hash)
+          }
+        end
 
         # Delete the given network interface in +resource_group+.
         #

--- a/lib/azure/armrest/network/subnet_service.rb
+++ b/lib/azure/armrest/network/subnet_service.rb
@@ -50,7 +50,8 @@ module Azure
         def get(subnet_name, virtual_network, resource_group = armrest_configuration.resource_group)
           raise ArgumentError, "no resource group provided" unless resource_group 
           url = build_url(resource_group, virtual_network, subnet_name)
-          JSON.parse(rest_get(url))
+          response = rest_get(url)
+          Azure::Armrest::Network::Subnet.new(response)
         end
 
         # List available subnets on +virtual_network+ for the given +resource_group+.
@@ -58,7 +59,8 @@ module Azure
         def list(virtual_network, resource_group = armrest_configuration.resource_group)
           raise ArgumentError, "no resource group provided" unless resource_group 
           url = build_url(resource_group, virtual_network)
-          JSON.parse(rest_get(url))['value']
+          response = rest_get(url)
+          JSON.parse(response)['value'].map{ |hash| Azure::Armrest::Network::Subnet.new(hash) }
         end
 
         private

--- a/lib/azure/armrest/network/virtual_network_service.rb
+++ b/lib/azure/armrest/network/virtual_network_service.rb
@@ -23,7 +23,8 @@ module Azure
         def get(vn_name, resource_group = armrest_configuration.resource_group)
           raise ArgumentError, "must specify resource group" unless resource_group
           url = build_url(resource_group, vn_name)
-          JSON.parse(rest_get(url))
+          response = rest_get(url)
+          Azure::Armrest::Network::VirtualNetwork.new(response)
         end
 
         # Returns a list of available virtual networks in the current subscription
@@ -32,19 +33,19 @@ module Azure
         def list(resource_group = armrest_configuration.resource_group)
           raise ArgumentError, "no resource group provided" unless resource_group
           url = build_url(resource_group)
-          JSON.parse(rest_get(url))['value']
+          response = rest_get(url)
+          JSON.parse(response)['value'].map{ |hash| Azure::Armrest::Network::VirtualNetwork.new(hash) }
         end
 
         # List all virtual networks for the current subscription.
         #
-        def list_all_for_subscription
+        def list_all
           sub_id = armrest_configuration.subscription_id
           url = File.join(Azure::Armrest::COMMON_URI, sub_id, 'providers', @provider, 'virtualNetworks')
           url << "?api-version=#{@api_version}"
-          JSON.parse(rest_get(url))['value']
+          response = rest_get(url)
+          JSON.parse(response)['value'].map{ |hash| Azure::Armrest::Network::VirtualNetwork.new(hash) }
         end
-
-        alias list_all list_all_for_subscription
 
         # Delete the given virtual network in +resource_group+.
         #

--- a/lib/azure/armrest/resource_group_service.rb
+++ b/lib/azure/armrest/resource_group_service.rb
@@ -31,7 +31,7 @@ module Azure
 
         response = rest_get(URI.escape(url))
 
-        JSON.parse(response.body)["value"]
+        JSON.parse(response)["value"].map{ |hash| Azure::Armrest::ResourceGroup.new(hash) }
       end
 
       # Creates a new +group+ in +location+ for the current subscription.
@@ -43,7 +43,7 @@ module Azure
 
         response = rest_put(url, body)
 
-        JSON.parse(response.body)
+        Azure::Armrest::ResourceGroup.new(response)
       end
 
       # Delete a resource group from the current subscription.
@@ -59,7 +59,7 @@ module Azure
       def get(group)
         url = build_url(group)
         response = rest_get(url)
-        JSON.parse(response.body)
+        Azure::Armrest::ResourceGroup.new(response)
       end
 
       # Updates the tags for the given resource group.

--- a/lib/azure/armrest/resource_provider_service.rb
+++ b/lib/azure/armrest/resource_provider_service.rb
@@ -42,7 +42,7 @@ module Azure
       def list
         url = build_url
         response = rest_get(url)
-        JSON.parse(response.body)["value"]
+        JSON.parse(response)["value"].map{ |hash| Azure::Armrest::ResourceProvider.new(hash) }
       end
 
       cache_method(:list, cache_time)
@@ -53,7 +53,7 @@ module Azure
       def get(namespace)
         url = build_url(namespace)
         response = rest_get(url)
-        JSON.parse(response.body)
+        Azure::Armrest::ResourceProvider.new(response)
       end
 
       cache_method(:get, cache_time)
@@ -64,7 +64,7 @@ module Azure
       def list_geo_locations(namespace)
         url = build_url(namespace)
         response = rest_get(url)
-        JSON.parse(response.body)['resourceTypes'].first['locations']
+        JSON.parse(response)['resourceTypes'].first['locations']
       end
 
       cache_method(:list_geo_locations, cache_time)
@@ -75,7 +75,7 @@ module Azure
       def list_api_versions(namespace)
         url = build_url(namespace)
         response = rest_get(url)
-        JSON.parse(response.body)['resourceTypes'].first['apiVersions']
+        JSON.parse(response)['resourceTypes'].first['apiVersions']
       end
 
       cache_method(:list_api_versions, cache_time)

--- a/lib/azure/armrest/resource_service.rb
+++ b/lib/azure/armrest/resource_service.rb
@@ -42,7 +42,7 @@ module Azure
 
         response = rest_get(URI.escape(url))
 
-        JSON.parse(response.body)["value"]
+        JSON.parse(response)["value"].map{ |hash| Azure::Armrest::Resource.new(hash) }
       end
 
       # Move the resources from +source_group+ under +source_subscription+,

--- a/lib/azure/armrest/template_deployment_service.rb
+++ b/lib/azure/armrest/template_deployment_service.rb
@@ -1,97 +1,108 @@
 module Azure::Armrest
-# Base class for managing templates and deployments
-class TemplateDeploymentService < ArmrestService
+  # Base class for managing templates and deployments
+  class TemplateDeploymentService < ArmrestService
 
-  def initialize(_armrest_configuration, _options = {})
-    super
+    def initialize(_armrest_configuration, options = {})
+      super
+      @provider = options[:provider] || 'Microsoft.Resources'
+      #set_service_api_version(options, 'deploymenttemplates')
+      # Has to be hard coded for now
+      set_service_api_version({'api_version' => '2014-04-01-preview'}, '')
+    end
 
-    # has to be hard coded for now
-    set_service_api_version({'api_version' => '2014-04-01-preview'}, '')
-  end
+    # Get names of all deployments in a resource group
+    def list_names(resource_group = armrest_configuration.resource_group)
+      list(resource_group).map(&:name)
+    end
 
-  # Get names of all deployments in a resource group
-  def list_names(resource_group = armrest_configuration.resource_group)
-    list(resource_group).map {|e| e['name']}
-  end
-
-  # Get all deployments in a resource group
-  # If the resource group is nil, then return deployments in all groups
-  def list(resource_group = armrest_configuration.resource_group)
-    if resource_group
+    # Get all deployments for the current subscription in a resource group
+    def list(resource_group = armrest_configuration.resource_group)
+      raise ArgumentError, "must specify resource group" unless resource_group
       url = build_deployment_url(resource_group)
-      JSON.parse(rest_get(url))['value']
-    else
-      threads = []
+      response = rest_get(url)
+      JSON.parse(response)['value'].map{ |hash| Azure::Armrest::TemplateDeployment.new(hash) }
+    end
+
+    # Get all deployments for the current subscription
+    def list_all
       array = []
+      threads = []
       mutex = Mutex.new
 
       resource_groups.each do |rg|
         threads << Thread.new(rg['name']) do |group|
           url = build_deployment_url(group)
-          results = JSON.parse(rest_get(url))['value']
+          response = rest_get(url)
+
+          results = JSON.parse(response)['value'].map do |hash|
+            hash['resourceGroup'] = group
+            Azure::Armrest::TemplateDeployment.new(hash)
+          end
+
           if results && !results.empty?
-            mutex.synchronize {
-              results.each { |hash| hash['resourceGroup'] = group }
-              array << results
-            }
+            mutex.synchronize{ array << results }
           end
         end
       end
 
       threads.each(&:join)
+
       array.flatten
     end
+
+    # Get the deployment in a resource group
+    def get(deploy_name, resource_group = armrest_configuration.resource_group)
+      raise ArgumentError, "must specify resource group" unless resource_group
+      url = build_deployment_url(resource_group, deploy_name)
+      response = rest_get(url)
+      Azure::Armrest::TemplateDeployment.new(response)
+    end
+
+    # Get all operations of a deployment in a resource group
+    def list_deployment_operations(deploy_name, resource_group = armrest_configuration.resource_group)
+      raise ArgumentError, "must specify resource group" unless resource_group
+      url = build_deployment_url(resource_group, deploy_name, 'operations')
+      response = rest_get(url)
+      JSON.parse(response)['value'].map{ |hash| TemplateDeploymentOperation.new(hash) }
+    end
+
+    # Get the operation of a deployment in a resource group
+    def get_deployment_operation(deploy_name, op_id, resource_group = armrest_configuration.resource_group)
+      url = build_deployment_url(resource_group, deploy_name, 'operations', op_id)
+      response = rest_get(url)
+      TemplateDeploymentOperation.new(response)
+    end
+
+    # Create a template deployment
+    # The template and parameters should be provided through the options hash
+    def create(deploy_name, options, resource_group = armrest_configuration.resource_group)
+      url = build_deployment_url(resource_group, deploy_name)
+      body = options.has_key?('properties') ? options.to_json : {'properties' => options}.to_json
+      JSON.parse(rest_put(url, body))
+    end
+
+    # Delete a deployment
+    def delete(deploy_name, resource_group = armrest_configuration.resource_group)
+      url = build_deployment_url(resource_group, deploy_name)
+      rest_delete(url)
+    end
+
+    private
+
+    # Builds a URL based on subscription_id an resource_group and any other
+    # arguments provided, and appends it with the api_version.
+    #
+    def build_deployment_url(resource_group, *args)
+      url = File.join(
+        Azure::Armrest::COMMON_URI,
+        armrest_configuration.subscription_id,
+        'resourceGroups',
+        resource_group,
+        'deployments',
+      )
+
+      url = File.join(url, *args) unless args.empty?
+      url << "?api-version=#{@api_version}"
+    end
   end
-
-  # Get the deployment in a resource group
-  def get(deploy_name, resource_group = armrest_configuration.resource_group)
-    url = build_deployment_url(resource_group, deploy_name)
-    JSON.parse(rest_get(url))
-  end
-
-  # Get all operations of a deployment in a resource group
-  def list_deployment_operations(deploy_name, resource_group = armrest_configuration.resource_group)
-    url = build_deployment_url(resource_group, deploy_name, 'operations')
-    JSON.parse(rest_get(url))['value']
-  end
-
-  # Get the operation of a deployment in a resource group
-  def get_deployment_operation(deploy_name, op_id, resource_group = armrest_configuration.resource_group)
-    url = build_deployment_url(resource_group, deploy_name, 'operations', op_id)
-    JSON.parse(rest_get(url))
-  end
-
-  # Create a template deployment
-  # The template and parameters should be provided through the options hash
-  def create(deploy_name, options, resource_group = armrest_configuration.resource_group)
-    url = build_deployment_url(resource_group, deploy_name)
-    body = options.has_key?('properties') ? options.to_json : {'properties' => options}.to_json
-    JSON.parse(rest_put(url, body))
-  end
-
-  # Delete a deployment
-  def delete(deploy_name, resource_group = armrest_configuration.resource_group)
-    url = build_deployment_url(resource_group, deploy_name)
-    rest_delete(url)
-  end
-
-  private
-
-
-  # Builds a URL based on subscription_id an resource_group and any other
-  # arguments provided, and appends it with the api_version.
-  #
-  def build_deployment_url(resource_group, *args)
-    url = File.join(
-      Azure::Armrest::COMMON_URI,
-      armrest_configuration.subscription_id,
-      'resourceGroups',
-      resource_group,
-      'deployments',
-    )
-
-    url = File.join(url, *args) unless args.empty?
-    url << "?api-version=#{@api_version}"
-  end
-end
 end

--- a/spec/ip_address_spec.rb
+++ b/spec/ip_address_spec.rb
@@ -34,13 +34,8 @@ describe "Network::IpAddressService" do
       expect(ip).to respond_to(:list)
     end
 
-    it "defines a list_all_for_subscription method" do
-      expect(ip).to respond_to(:list_all_for_subscription)
-    end
-
-    it "defines a list_all alias method" do
+    it "defines a list_all method" do
       expect(ip).to respond_to(:list_all)
-      expect(ip.method(:list_all)).to eql(ip.method(:list_all_for_subscription))
     end
   end
 end

--- a/spec/network_interface_service_spec.rb
+++ b/spec/network_interface_service_spec.rb
@@ -50,12 +50,8 @@ describe "Network::NetworkInterfaceService" do
       expect(nis).to respond_to(:list)
     end
 
-    it "defines a list_all_for_subscription method" do
-      expect(nis).to respond_to(:list_all_for_subscription)
-    end
-
-    it "defines a list_all alias for list_all_for_subscription" do
-      expect(nis.method(:list_all)).to eql(nis.method(:list_all_for_subscription))
+    it "defines a list_all method" do
+      expect(nis).to respond_to(:list_all)
     end
   end
 

--- a/spec/network_security_group_spec.rb
+++ b/spec/network_security_group_spec.rb
@@ -30,13 +30,8 @@ describe "Network::NetworkSecurityGroupService" do
       expect(nsg).to respond_to(:list)
     end
 
-    it "defines a list_all_for_subscription method" do
-      expect(nsg).to respond_to(:list_all_for_subscription)
-    end
-
-    it "defines a list_all alias method" do
+    it "defines a list_all method" do
       expect(nsg).to respond_to(:list_all)
-      expect(nsg.method(:list_all)).to eql(nsg.method(:list_all_for_subscription))
     end
   end
 end

--- a/spec/storage_account_service_spec.rb
+++ b/spec/storage_account_service_spec.rb
@@ -62,8 +62,8 @@ describe "StorageAccountService" do
       expect(sas).to respond_to(:list_account_keys)
     end
 
-    it "defines a list_all_for_subscription method" do
-      expect(sas).to respond_to(:list_all_for_subscription)
+    it "defines a list_all method" do
+      expect(sas).to respond_to(:list_all)
     end
 
     it "defines a regenerate_storage_account_keys method" do

--- a/spec/template_deployment_service_spec.rb
+++ b/spec/template_deployment_service_spec.rb
@@ -43,7 +43,7 @@ describe "TemplateDeploymentService" do
 
     it "defines a list method" do
       expected_url = "https://management.azure.com/subscriptions/abc-123-def-456/resourceGroups/groupname/deployments?api-version=2014-04-01-preview"
-      expect(RestClient).to receive(:get).with(expected_url, anything).and_return('{}')
+      expect(RestClient).to receive(:get).with(expected_url, anything).and_return('{"value":{}}')
       tds.list('groupname')
     end
 
@@ -55,7 +55,7 @@ describe "TemplateDeploymentService" do
 
     it "defines a list_deployment_operations method" do
       expected_url = "https://management.azure.com/subscriptions/abc-123-def-456/resourceGroups/groupname/deployments/deployname/operations?api-version=2014-04-01-preview"
-      expect(RestClient).to receive(:get).with(expected_url, anything).and_return('{}')
+      expect(RestClient).to receive(:get).with(expected_url, anything).and_return('{"value":{}}')
       tds.list_deployment_operations('deployname', 'groupname')
     end
 

--- a/spec/virtual_network_service_spec.rb
+++ b/spec/virtual_network_service_spec.rb
@@ -45,8 +45,8 @@ describe "Network::VirtualNetworkService" do
       expect(vns).to respond_to(:list)
     end
 
-    it "defines a list_all_for_subscription method" do
-      expect(vns).to respond_to(:list_all_for_subscription)
+    it "defines a list_all" do
+      expect(vns).to respond_to(:list_all)
     end
   end
 end


### PR DESCRIPTION
This PR alters the get/list/list_all methods to return our JSON wrapper classes.

It also removes the threaded code, since the API allows us to get all resources for a given subscription. Please update any +list+ calls with +list_all+ if you want all information.