### PR TITLE
Simplify implementation with ResourceGroupBasedService base class(2)

### DIFF
--- a/lib/azure/armrest/network/subnet_service.rb
+++ b/lib/azure/armrest/network/subnet_service.rb
@@ -14,8 +14,8 @@ module Azure
         #   - :routeTable
         #     - :id
         #
-        def create(subnet_name, virtual_network, options = {}, resource_group = armrest_configuration.resource_group)
-          super(combine(virtual_network, subnet_name), resource_group)
+        def create(subnet_name, virtual_network, resource_group = armrest_configuration.resource_group, options = {})
+          super(combine(virtual_network, subnet_name), resource_group, options)
         end
 
         alias update create

--- a/lib/azure/armrest/resource_group_based_service.rb
+++ b/lib/azure/armrest/resource_group_based_service.rb
@@ -1,7 +1,7 @@
 module Azure::Armrest
   # Base class for services that needs to run in a resource group
   class ResourceGroupBasedService < ArmrestService
-    def create(name, options = {}, rgroup = armrest_configuration.resource_group)
+    def create(name, rgroup = armrest_configuration.resource_group, options = {})
       raise ArgumentError, "must specify resource group" unless rgroup
       raise ArgumentError, "must specify name of the resource" unless name
 

--- a/lib/azure/armrest/template_deployment_service.rb
+++ b/lib/azure/armrest/template_deployment_service.rb
@@ -31,7 +31,7 @@ module Azure::Armrest
     end
 
     # Get the operation of a deployment in a resource group
-    def get_deployment_operation(deploy_name, op_id, resource_group = armrest_configuration.resource_group)
+    def get_deployment_operation(op_id, deploy_name, resource_group = armrest_configuration.resource_group)
       raise ArgumentError, "must specify resource group" unless resource_group
       raise ArgumentError, "must specify name of the resource" unless deploy_name
       raise ArgumentError, "must specify operation id" unless op_id

--- a/spec/storage_account_service_spec.rb
+++ b/spec/storage_account_service_spec.rb
@@ -71,18 +71,15 @@ describe "StorageAccountService" do
   end
 
   context "create" do
-    it "requires both an account name and a location" do
-      expect{ sas.create(nil) }.to raise_error(KeyError)
-      expect{ sas.create("test", {}) }.to raise_error(KeyError)
-    end
-
     it "requires a valid account name" do
-      expect{ sas.create("xx", :location => "West US") }.to raise_error(ArgumentError)
-      expect{ sas.create("^&123***", :location => "West US") }.to raise_error(ArgumentError)
+      options = {:location => "West US", :properties => {:accountType => "Standard_GRS"}}
+      expect{ sas.create("xx", options) }.to raise_error(ArgumentError)
+      expect{ sas.create("^&123***", options) }.to raise_error(ArgumentError)
     end
 
     it "requires a valid account type" do
-      expect{ sas.create("test", :location => "West US", :type => "bogus") }.to raise_error(ArgumentError)
+      options = {:location => "West US", :properties => {:accountType => "bogus"}}
+      expect{sas.create("test", options)}.to raise_error(ArgumentError)
     end
   end
 end

--- a/spec/template_deployment_service_spec.rb
+++ b/spec/template_deployment_service_spec.rb
@@ -63,7 +63,7 @@ describe "TemplateDeploymentService" do
     it "defines a get_deployment_operation method" do
       expected_url = url_prefix + "/deployname/operations/opid?api-version=2014-04-01-preview"
       expect(RestClient).to receive(:get).with(expected_url, anything).and_return('{}')
-      tds.get_deployment_operation('deployname', 'opid', 'groupname')
+      tds.get_deployment_operation('opid', 'deployname', 'groupname')
     end
   end
 end

--- a/spec/template_deployment_service_spec.rb
+++ b/spec/template_deployment_service_spec.rb
@@ -26,7 +26,7 @@ describe "TemplateDeploymentService" do
     it "defines a create method" do
       expected_url = url_prefix + "/deployname?api-version=2014-04-01-preview"
       expect(RestClient).to receive(:put).with(expected_url, anything, anything).and_return('{}')
-      tds.create('deployname', {}, 'groupname')
+      tds.create('deployname', 'groupname', {})
     end
 
     it "defines a delete method" do


### PR DESCRIPTION
This is a continuation of #88 
Mainly `VirtualMachineService` and `StorageAccountService` are refactored based on `ResourceGroupBasedService`.

It follows the guideline http://talk.manageiq.org/t/armrest-gem-guideline/973