### PR TITLE
Add custom StorageAccount class with its own methods

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,11 @@
+= 0.0.4 - ???
+* All get/list/list_all methods now return wrapper class instances, e.g.
+  a call to VirtualMachineService#get will return a VirtualMachine instance.
+  These provide a nice OpenStruct wrapper so you can use methods instead
+  of hash references if desired.
+* Now re-raises RestClient exceptions as exceptions that we have defined.
+* The VirtualMachineImage class was overhauled and is now working properly.
+
 = 0.0.3 - 13-Oct-2015
 * Bug fixes for VirtualMachineImageService class.
 * Reorganized and updated SubnetService class.

--- a/azure-armrest.gemspec
+++ b/azure-armrest.gemspec
@@ -20,12 +20,15 @@ behind the scenes.
   EOF
 
   spec.add_dependency 'json'
-  spec.add_dependency 'rest-client', "=2.0.0.rc1"
-  spec.add_dependency 'cache_method', "~> 0.2.7"
+  spec.add_dependency 'rest-client', '=2.0.0.rc1'
+  spec.add_dependency 'cache_method', '~> 0.2.7'
+  spec.add_dependency 'azure-signature', '~> 0.2.0'
+  spec.add_dependency 'activesupport', '>= 1.2.0'
+  spec.add_dependency 'nokogiri', '~> 1.6.0'
 
-  spec.add_development_dependency "bundler"
-  spec.add_development_dependency "rake"
-  spec.add_development_dependency "rspec", "~> 3.0"
-  spec.add_development_dependency "codeclimate-test-reporter"
-  spec.add_development_dependency "timecop", "~> 0.7"
+  spec.add_development_dependency 'bundler'
+  spec.add_development_dependency 'rake'
+  spec.add_development_dependency 'rspec', '~> 3.0'
+  spec.add_development_dependency 'codeclimate-test-reporter'
+  spec.add_development_dependency 'timecop', '~> 0.7'
 end

--- a/lib/azure/armrest/model/base_model.rb
+++ b/lib/azure/armrest/model/base_model.rb
@@ -141,3 +141,5 @@ module Azure
     end
   end
 end
+
+require_relative 'storage_account' 

--- a/lib/azure/armrest/model/storage_account.rb
+++ b/lib/azure/armrest/model/storage_account.rb
@@ -1,0 +1,140 @@
+require 'azure-signature'
+require 'active_support/core_ext/hash/conversions'
+require 'nokogiri'
+
+module Azure
+  module Armrest
+    class StorageAccount < BaseModel
+      # Classes used to wrap container and blob information.
+      class Container < BaseModel; end
+      class Blob < BaseModel; end
+      class BlobServiceProperty < BaseModel; end
+      class BlobServiceStat < BaseModel; end
+      class BlobMetadata < BaseModel; end
+
+      # The version string used in headers sent as part any internal http
+      # request. The default is 2015-02-21.
+      attr_accessor :storage_api_version
+
+      def initialize(json)
+        super
+        @storage_api_version = '2015-02-21'
+      end
+
+      # Return a list of container names for the given storage account +key+.
+      # If no key is provided, it is assumed that the StorageAccount object
+      # includes the key1 property.
+      #
+      def containers(key = nil)
+        key ||= properties.key1
+
+        response = blob_response(key, "comp=list")
+
+        Nokogiri::XML(response.body).xpath('//Containers/Container').map do |element|
+          Container.new(Hash.from_xml(element.to_s)['Container'])
+        end
+      end
+
+      # Return a list of blobs for the given +container+ using the given +key+
+      # or the key1 property of the StorageAccount object.
+      #
+      def blobs(container, key = nil)
+        key ||= properties.key1
+
+        url = File.join(properties.primary_endpoints.blob, container)
+        url += "?restype=container&comp=list"
+
+        headers = build_headers(url, key)
+        response = RestClient.get(url, headers)
+        doc = Nokogiri::XML(response.body)
+
+        doc.xpath('//Blobs/Blob').map do |node|
+          Blob.new(Hash.from_xml(node.to_s)['Blob'])
+        end
+      end
+
+      # Returns an array of all blobs for all containers.
+      #
+      def all_blobs(key = nil)
+        key ||= properties.key1
+        array = []
+        threads = []
+
+        containers.each do |container|
+          threads << Thread.new(container, key){ |c,k| array << blobs(c.name, k) }
+        end
+
+        threads.each(&:join)
+
+        array.flatten
+      end
+
+      # Returns the blob service properties for the current storage account.
+      #
+      def blob_properties(key = nil)
+        key ||= properties.key1
+
+        response = blob_response(key, "restype=service&comp=properties")
+        toplevel = 'StorageServiceProperties'
+
+        doc = Nokogiri::XML(response.body).xpath("//#{toplevel}")
+        BlobServiceProperty.new(Hash.from_xml(doc.to_s)[toplevel])
+      end
+
+      # Return metadata for the given +blob+ within +container+. You may
+      # specify a +date+ to retrieve metadata for a specific snapshot.
+      #
+      def blob_metadata(container, blob, date = nil, key = nil)
+        key ||= properties.key1
+
+        query = "comp=metadata"
+        query << "&snapshot=#{date}" if date
+
+        response = blob_response(key, query, container, blob)
+
+        BlobMetadata.new(response.headers)
+      end
+
+      # Retrieves statistics related to replication for the Blob service. Only
+      # available on the secondary location endpoint when read-access
+      # geo-redundant replication is enabled for the storage account.
+      #
+      def blob_service_stats(key = nil)
+        key ||= properties.key1
+
+        response = blob_response(key, "restype=service&comp=stats")
+        toplevel = 'StorageServiceStats'
+
+        doc = Nokogiri::XML(response.body).xpath("//#{toplevel}")
+        BlobServiceStat.new(Hash.from_xml(doc.to_s)[toplevel])
+      end
+
+      private
+
+      # Using the blob primary endpoint as a base, join any arguments to the
+      # the url and submit an http request.
+      #
+      def blob_response(key, query, *args)
+        url = File.join(properties.primary_endpoints.blob, *args) + "?#{query}"
+        headers = build_headers(url, key)
+        RestClient.get(url, headers)
+      end
+
+      # Set the headers needed, including the Authorization header.
+      #
+      def build_headers(url, key)
+        sig = Signature.new(url, key)
+
+        headers = {
+          'x-ms-date'     => Time.now.httpdate,
+          'x-ms-version'  => @storage_api_version,
+          :auth_string    => true
+        }
+
+        headers['Authorization'] = sig.blob_signature(headers)
+
+        headers
+      end
+    end
+  end
+end

--- a/lib/azure/armrest/storage_account_service.rb
+++ b/lib/azure/armrest/storage_account_service.rb
@@ -1,3 +1,5 @@
+require 'azure-signature'
+
 module Azure
   module Armrest
     # Class for managing storage accounts.

--- a/spec/models/storage_account_spec.rb
+++ b/spec/models/storage_account_spec.rb
@@ -1,0 +1,66 @@
+########################################################################
+# storage_account_spec.rb
+#
+# Test suite for the Azure::Armrest::StorageAccount json model class.
+########################################################################
+require 'spec_helper'
+
+describe "StorageAccount" do
+  before {
+    @json = '{
+      "name":"vhds",
+      "properties":{"etag": "12345"}
+    }'
+  }
+
+  let(:storage){ Azure::Armrest::StorageAccount.new(@json) }
+
+  context "constructor" do
+    it "returns a StorageAccount class as expected" do
+      expect(storage).to be_kind_of(Azure::Armrest::StorageAccount)
+    end
+  end
+
+  context "storage classes" do
+    it "defines a Container class" do
+      expect(Azure::Armrest::StorageAccount::Container)
+      expect(Azure::Armrest::StorageAccount::Blob)
+      expect(Azure::Armrest::StorageAccount::BlobServiceProperty)
+      expect(Azure::Armrest::StorageAccount::BlobServiceStat)
+      expect(Azure::Armrest::StorageAccount::BlobMetadata)
+    end
+  end
+
+  context "accessors" do
+    it "defines a storage_api_version accessor that defaults to 2015-02-01" do
+      expect(storage).to respond_to(:storage_api_version)
+      expect(storage.storage_api_version).to eq('2015-02-21')
+    end
+  end
+
+  context "custom methods" do
+    it "defines a containers method" do
+      expect(storage).to respond_to(:containers)
+    end
+
+    it "defines a blobs method" do
+      expect(storage).to respond_to(:blobs)
+    end
+
+    it "defines an all_blobs method" do
+      expect(storage).to respond_to(:all_blobs)
+    end
+
+    it "defines a blob_properties method" do
+      expect(storage).to respond_to(:blob_properties)
+    end
+
+    it "defines a blob_metadata method" do
+      expect(storage).to respond_to(:blob_metadata)
+    end
+
+    it "defines a blob_service_stats method" do
+      expect(storage).to respond_to(:blob_service_stats)
+    end
+  end
+end


### PR DESCRIPTION
This PR defines a custom StorageAccount json wrapper class. This class defines its own methods for getting blob and container information. With this class you can now do something like:

    sas = Azure::Armrest::StorageAccountService.new(conf)
    sa = sas.get('miqazuredan17573', 'miqazure-dan1', true)
    sa.containers.each{ |container| p container.name }
    sa.blobs('vhds').each{ |blob| p blob }

Internally it defines different subclasses such as Container, Blob, BlobServiceProperty, etc.

I've also added some basic specs.
