### PR TITLE
Refactor to encapuslate all attributes to be BaseModel or Hash based

### DIFF
--- a/lib/azure/armrest/armrest_service.rb
+++ b/lib/azure/armrest/armrest_service.rb
@@ -409,13 +409,13 @@ module Azure
 
         providers.each do |info|
           provider_info = {}
-          info['resourceTypes'].each do |resource|
-            provider_info[resource['resourceType']] = {
-              'api_version' => resource['apiVersions'].first,
-              'locations'   => resource['locations'] - [''] # Ignore empty elements
+          info.resource_types.each do |resource|
+            provider_info[resource.resource_type] = {
+              'api_version' => resource.api_versions.first,
+              'locations'   => resource.locations - [''] # Ignore empty elements
             }
           end
-          @@providers_hash[info['namespace'].downcase] = provider_info
+          @@providers_hash[info.namespace.downcase] = provider_info
         end
       end
 

--- a/lib/azure/armrest/model/base_model.rb
+++ b/lib/azure/armrest/model/base_model.rb
@@ -7,19 +7,19 @@ module Azure
     # a corresponding class that wraps the JSON it collects, and each of
     # them should subclass this base class.
     class BaseModel < Delegator
-
-      # Declare that a method should return a plain hash instead of an
-      # OpenStruct instance.
-      #--
-      # TODO: Handle nested properties.
-      def self.hash_properties(method)
-        define_method(method){ @ostruct[method].to_h }
+      def self.excl_list
+        # initially inherit the exclusion list from parent class or create an empty Set
+        @excl_list ||= superclass.respond_to?(:excl_list, true) ? superclass.send(:excl_list) : Set.new
       end
+      private_class_method :excl_list
 
-      hash_properties :tags
+      def self.attr_hash(*attrs)
+        # merge the declared exclusive attributes to the existing list
+        @excl_list = excl_list | Set.new(attrs.map(&:to_s))
+      end
+      private_class_method :attr_hash
 
-      # Access the json instance variable directly.
-      attr_accessor :json
+      attr_hash :tags
 
       # Constructs and returns a new JSON wrapper class. Pass in a plain
       # JSON string and it will automatically give you accessor methods
@@ -41,43 +41,55 @@ module Azure
       #   person.address.zipcode  # => '01013'
       #
       #   # Or you can get back the original JSON if necessary.
-      #   person.json # => Returns original JSON
+      #   person.to_json # => Returns original JSON
       #
       def initialize(json)
-        json = json.to_json unless json.is_a?(String)
-        @json = json
-        @resource_group = nil
-        @ostruct = JSON.parse(json, object_class: OpenStruct)
-        __setobj__(@ostruct)
+        # Find the exclusion list for the model of next level (@embedModel)
+        # '#' is the separator between levels. Remove attributes
+        # before the first separator.
+        child_excl_list = self.class.send(:excl_list).map do |e|
+          e.index('#') ? e[e.index('#') + 1 .. -1] : ''
+        end
+        @embedModel = Class.new(BaseModel) do
+          attr_hash *child_excl_list
+        end
+
+        if json.is_a?(Hash)
+          hash = json
+          @json = json.to_json
+        else
+          hash = JSON.parse(json)
+          @json = json
+        end
+
+        @ostruct = OpenStruct.new(hash)
+        super(@ostruct)
       end
 
-      # Return the resource group for the current object.
       def resource_group
         @resource_group ||= id[/resourceGroups\/(.+?)\//i, 1] rescue nil
       end
 
-      # Returns the original JSON string passed to the constructor.
+      def resource_group=(rg)
+        @resource_group = rg
+      end
+
       def to_json
         @json
       end
 
-      # Explicitly convert the object to the original JSON string.
       def to_s
         @json
       end
 
-      # Implicitly convert the object to the original JSON string.
       def to_str
         @json
       end
 
-      # Custom inspect method that shows the current class and methods.
-      #--
-      # TODO: Make this recursive.
       def inspect
         string = "<#{self.class} "
         method_list = methods(false).select{ |m| !m.to_s.include?('=') }
-        string << method_list.map{ |m| "#{m}=#{send(m)}" }.join(" ")
+        string << method_list.map{ |m| "#{m}=#{send(m).inspect}" }.join(", ")
         string << ">"
       end
 
@@ -92,20 +104,22 @@ module Azure
       # A custom Delegator interface method that creates snake_case
       # versions of the camelCase delegate methods.
       def __setobj__(obj)
+        excl_list = self.class.send(:excl_list)
         obj.methods(false).each{ |m|
-          if m.to_s[-1] != '=' # Must deal with nested ostruct's
+          if m.to_s[-1] != '=' && !excl_list.include?(m.to_s) # Must deal with nested models
             res = obj.send(m)
-            if res.respond_to?(:each)
-              res.each{ |o| __setobj__(o) if o.is_a?(OpenStruct) }
-            else
-              __setobj__(res) if res.is_a?(OpenStruct)
+            if res.is_a?(Array)
+              newval = res.map { |elem| elem.is_a?(Hash) ? @embedModel.new(elem) : elem }
+              obj.send("#{m}=", newval)
+            elsif res.is_a?(Hash)
+              obj.send("#{m}=", @embedModel.new(res))
             end
           end
 
           snake = m.to_s.gsub(/(.)([A-Z])/,'\1_\2').downcase.to_sym
 
           begin
-            obj.instance_eval("alias #{snake} #{m}") unless snake == m
+            obj.instance_eval("alias #{snake} #{m}; undef :#{m}") unless snake == m
           rescue SyntaxError
             next
           end
@@ -123,7 +137,9 @@ module Azure
     class StorageAccount < BaseModel; end
     class Subscription < BaseModel; end
     class Tag < BaseModel; end
-    class TemplateDeployment < BaseModel; end
+    class TemplateDeployment < BaseModel
+      attr_hash 'properties#parameters'
+    end
     class TemplateDeploymentOperation < TemplateDeployment; end
     class Tenant < BaseModel; end
     class VirtualMachine < BaseModel; end

--- a/spec/models/base_model_spec.rb
+++ b/spec/models/base_model_spec.rb
@@ -6,25 +6,24 @@
 require 'spec_helper'
 
 describe "BaseModel" do
-  before {
-    @json = '{
+  let(:json) do
+    '{
       "firstName":"jeff",
       "lastName":"durand",
       "address": {"street":"22 charlotte rd", "zipcode":"01013"}
     }'
-  }
-
-  let(:base){ Azure::Armrest::BaseModel.new(@json) }
-
-  context "constructor" do
-    it "returns a BaseModel class as expected" do
-      expect(base).to be_kind_of(Azure::Armrest::BaseModel)
-    end
   end
 
-  context "accessors" do
-    it "defines a json accessor that returns the original json" do
-      expect(base.json).to eq(@json)
+  let(:base) { Azure::Armrest::BaseModel.new(json) }
+
+  context "constructor" do
+    it "constructs a BaseModel instance from a JSON string" do
+      expect(base).to be_kind_of(Azure::Armrest::BaseModel)
+    end
+
+    it "constructs a BaseModel instance from a Hash object" do
+      base = Azure::Armrest::BaseModel.new(JSON.parse(json))
+      expect(base).to be_kind_of(Azure::Armrest::BaseModel)
     end
   end
 
@@ -35,55 +34,80 @@ describe "BaseModel" do
     end
 
     it "returns the expected value for the resource_group method" do
-      @json = {:id => '/foo/bar/resourceGroups/foo/x/y/z'}.to_json
-      base = Azure::Armrest::BaseModel.new(@json)
+      json = {:id => '/foo/bar/resourceGroups/foo/x/y/z'}
+      base = Azure::Armrest::BaseModel.new(json)
       expect(base.resource_group).to eq('foo')
     end
+  end
 
-    it "defines a tags method that returns an empty hash by default" do
-      expect(base).to respond_to(:tags)
-      expect(base.tags).to eq({})
+  context "reserved hashes" do
+    it "returns the expected hash for the tags method when defined" do
+      json = {:name => 'test', :tags => {:foo => 1, :bar => 2}}
+      base = Azure::Armrest::BaseModel.new(json)
+      expect(base.tags).to eq({:foo => 1, :bar => 2})
     end
 
-    it "returns the expected hash for the tags method when defined" do 
-      @json = {:name => 'test', :tags => {:foo => 1, :bar => 2}}.to_json
-      base = Azure::Armrest::BaseModel.new(@json)
-      expect(base.tags).to eq({:foo => 1, :bar => 2})
+    it "returns the expected hash for the tags and other declared methods when defined" do
+      json = {:name => 'test', :tags => {:foo => 1, :bar => 2}, :users => {:foo => 3, :bar => 4} }
+      test = Class.new(Azure::Armrest::BaseModel) do
+        attr_hash :users
+      end.new(json)
+
+      expect(test.tags).to eq({:foo => 1, :bar => 2})
+      expect(test.users).to eq({:foo => 3, :bar => 4})
+    end
+
+    it "returns the expected hash for declared nested methods" do
+      json = {
+        :name => 'test',
+        :attr1 => {
+          :attr2 => [
+            :attr3 => {:foo => 1, :bar => 2},
+            :attr4 => {:foo => 3, :bar => 4}
+          ]
+        }
+      }
+
+      test = Class.new(Azure::Armrest::BaseModel) do
+        attr_hash 'attr1#attr2#attr3'
+      end.new(json)
+
+      expect(test.attr1.attr2[0].attr3).to eq({:foo => 1, :bar => 2})
+      expect(test.attr1.attr2[0].attr4).to be_kind_of(Azure::Armrest::BaseModel)
     end
   end
 
   context "inspection methods" do
     it "defines a to_s method that returns the original json" do
-      expect(base.to_s).to eq(@json)
+      expect(base.to_s).to eq(json)
     end
 
     it "defines a to_str method that returns the original json" do
-      expect(base.to_str).to eq(@json)
+      expect(base.to_str).to eq(json)
     end
 
     it "defines a to_json method that returns the original json" do
-      expect(base.to_json).to eq(@json)
+      expect(base.to_json).to eq(json)
     end
 
     it "defines a custom inspect method" do
-      @json = {:name => 'test', :age => 33}.to_json
-      base = Azure::Armrest::BaseModel.new(@json)
-      expected = "<Azure::Armrest::BaseModel name=test age=33>"
+      json = {:name => 'test', :age => 33}.to_json
+      base = Azure::Armrest::BaseModel.new(json)
+      expected = '<Azure::Armrest::BaseModel name="test", age=33>'
       expect(base.inspect).to eq(expected)
     end
   end
 
   context "dynamic method generation" do
-    it "defines a method for each json property" do
-      expect(base).to respond_to(:firstName)
-      expect(base).to respond_to(:lastName)
-      expect(base).to respond_to(:address)
-    end
-
-    it "defines snake_case aliases for each dynamic method" do
+    it "defines snake_case for each dynamic method" do
       expect(base).to respond_to(:first_name)
       expect(base).to respond_to(:last_name)
       expect(base).to respond_to(:address)
+    end
+
+    it "removes camel_case methods default from open_struct conversion" do
+      expect(base).not_to respond_to(:firstName)
+      expect(base).not_to respond_to(:lastName)
     end
 
     it "allows you to chain dynamic methods" do
@@ -93,18 +117,16 @@ describe "BaseModel" do
   end
 
   context "dynamic accessors" do
-    it "returns expected value for firstName method" do
-      expect(base.firstName).to eq('jeff')
+    it "returns expected value for first_name method" do
       expect(base.first_name).to eq('jeff')
     end
 
-    it "returns expected value for lastName method" do
-      expect(base.lastName).to eq('durand')
+    it "returns expected value for last_name method" do
       expect(base.last_name).to eq('durand')
     end
 
-    it "returns expected value for address method" do
-      expect(base.address).to be_kind_of(OpenStruct)
+    it "returns an object instantiated from a subclass of BaseModel for address method" do
+      expect(base.address).to be_kind_of(Azure::Armrest::BaseModel)
     end
 
     it "returns expected value for zipcode method" do


### PR DESCRIPTION
With this work all attributes are by default objects instantiated from a subclass of the `BaseModel` unless they are declared to be remain a `Hash`.

The declare is through `attr_hash` which accepts direct attributes in string or symbol or nested attributes in string only format.

All camel_case methods automatically converted by openstruct are removed.

From the user experience point of view, no openstruct object is exposed.