### PR TITLE
Add a VirtualMachineSize model

### DIFF
--- a/lib/azure/armrest/model/base_model.rb
+++ b/lib/azure/armrest/model/base_model.rb
@@ -147,6 +147,7 @@ module Azure
     class VirtualMachineModel < VirtualMachine; end
     class VirtualMachineExtension < BaseModel; end
     class VirtualMachineImage < BaseModel; end
+    class VirtualMachineSize < BaseModel; end
 
     module Network
       class IpAddress < BaseModel; end

--- a/lib/azure/armrest/network/ip_address_service.rb
+++ b/lib/azure/armrest/network/ip_address_service.rb
@@ -17,7 +17,7 @@ module Azure
         # IP address name.
         #
         def get_ip(ip_name, resource_group = armrest_configuration.resource_group)
-          get(ip_name, resource_group).properties.ipAddress
+          get(ip_name, resource_group).properties.ip_address
         end
 
         alias get_ip_address get_ip

--- a/lib/azure/armrest/virtual_machine_service.rb
+++ b/lib/azure/armrest/virtual_machine_service.rb
@@ -47,7 +47,7 @@ module Azure
           'providers', provider, 'locations', location, 'vmSizes'
         )
 
-        JSON.parse(rest_get(url))['value']
+        JSON.parse(rest_get(url))['value'].map{ |hash| VirtualMachineSize.new(hash) }
       end
 
       alias sizes series
@@ -63,94 +63,6 @@ module Azure
       def capture(vmname, options, group = armrest_configuration.resource_group)
         vm_operate('capture', vmname, group, options)
       end
-
-      # Creates a new virtual machine (or updates an existing one). Pass a hash
-      # of options to configure the VM as you see fit. Some options are
-      # mandatory. The following are a list of possible options:
-      #
-      # - :name
-      #   Required. The name of the virtual machine. The name must be unique
-      #   within the availability set that it belongs to.
-      #
-      # - :location
-      #   Required. The location where the VM should be created, e.g. "West US".
-      #
-      # - :tags
-      #   Optional. Specifies an identifier for the availability set.
-      #
-      # - :hardwareprofile
-      #   Required. Contains a collection of hardware settings for the VM.
-      #
-      #   - :vmsize
-      #     Required. Specifies the size of the virtual machine. Possible
-      #     sizes are Standard_A0..Standard_A4.
-      #
-      # - :osprofile
-      #   Required. Contains a collection of settings for the OS configuration
-      #   which must contain all of the following:
-      #
-      #   - :computername
-      #   - :adminusername
-      #   - :adminpassword
-      #   - :username
-      #   - :password
-      #
-      # - :storageprofile
-      #   Required. Contains a collection of settings for storage and disk
-      #   settings for the VM. You must specify an :osdisk and :name. The
-      #   :datadisks setting is optional.
-      #
-      #   - :osdisk
-      #     Required. Contains a collection of settings for the operating
-      #     system disk.
-      #
-      #     - :name
-      #     - :ostype
-      #     - :caching
-      #     - :image
-      #     - :vhd
-      #
-      #   - :datadisks
-      #     Optional. Contains a collection of settings for data disks.
-      #
-      #     - :name
-      #     - :image
-      #     - :vhd
-      #     - :lun
-      #     - :caching
-      #
-      #   - :name
-      #     Required. Specifies the name of the disk.
-      #
-      # For clarity, we recommend using the update method for existing VM's.
-      #
-      # Example:
-      #
-      #   vmm = VirtualMachineService.new(x, y, z)
-      #
-      #   vm = vmm.create(
-      #     :name            => 'test1',
-      #     :location        => 'West US',
-      #     :hardwareprofile => {:vmsize => 'Standard_A0'},
-      #     :osprofile       => {
-      #       :computername  => 'some_name',
-      #       :adminusername => 'admin_user',
-      #       :adminpassword => 'adminxxxxxx',
-      #       :username      => 'some_user',
-      #       :password      => 'userpassxxxxxx',
-      #     },
-      #     :storageprofile  => {
-      #       :osdisk => {
-      #         :ostype  => 'Windows',
-      #         :caching => 'Read'
-      #       }
-      #     }
-      #   )
-      #--
-      # PUT operation
-      # TODO: Implement
-      #def create(options = {})
-      #end
 
       # Stop the VM +vmname+ in +group+ and deallocate the tenant in Fabric.
       #

--- a/spec/armrest_service_config_spec.rb
+++ b/spec/armrest_service_config_spec.rb
@@ -20,9 +20,9 @@ describe "ArmrestService" do
 
   context 'token generation' do
     it 'caches the token to be reused for the same client' do
+      token = "Bearer eyJ0eXAiOiJKV1Q"
       expect(RestClient).to receive(:post).exactly(1).times.and_return(token_response)
-      Azure::Armrest::ArmrestService.configure(options_with_subscription).token
-        .should == "Bearer eyJ0eXAiOiJKV1Q"
+      expect(Azure::Armrest::ArmrestService.configure(options_with_subscription).token).to eql(token)
       Azure::Armrest::ArmrestService.configure(options_with_subscription).token
     end
 
@@ -47,17 +47,17 @@ describe "ArmrestService" do
 
     it 'fills some attributes with default values' do
       conf = Azure::Armrest::ArmrestService.configure(options_with_subscription)
-      conf.api_version.should_not be_nil
-      conf.grant_type.should_not be_nil
-      conf.content_type.should_not be_nil
-      conf.accept.should_not be_nil
+      expect(conf.api_version).to_not be_nil
+      expect(conf.grant_type).to_not be_nil
+      expect(conf.content_type).to_not be_nil
+      expect(conf.accept).to_not be_nil
     end
 
     it 'finds a subscription id if not given' do
       expect(RestClient).to receive(:post).exactly(1).times.and_return(token_response)
       expect(RestClient).to receive(:get).exactly(1).times.and_return(subscription_response)
       conf = Azure::Armrest::ArmrestService.configure(options)
-      conf.subscription_id.should == '4f5a544b'
+      expect(conf.subscription_id).to eql('4f5a544b')
     end
   end
 end


### PR DESCRIPTION
This adds a VirtualMachineSize wrapper model, and updates the VirtualMachineService#series method to utilize it instead of returning a plain hash.

I also removed the old VirtualMachineService#create code and comments since it's now handled by the superclass.

It also updates the rspec syntax in a few places to eliminate warnings.