### PR TITLE
Use custom OpenStruct to override method collisions

### DIFF
--- a/lib/azure/armrest/model/base_model.rb
+++ b/lib/azure/armrest/model/base_model.rb
@@ -7,16 +7,18 @@ module Azure
     # a corresponding class that wraps the JSON it collects, and each of
     # them should subclass this base class.
     class BaseModel < Delegator
+      # Initially inherit the exclusion list from parent class or create an empty Set.
       def self.excl_list
-        # initially inherit the exclusion list from parent class or create an empty Set
         @excl_list ||= superclass.respond_to?(:excl_list, true) ? superclass.send(:excl_list) : Set.new
       end
+
       private_class_method :excl_list
 
+      # Merge the declared exclusive attributes to the existing list.
       def self.attr_hash(*attrs)
-        # merge the declared exclusive attributes to the existing list
         @excl_list = excl_list | Set.new(attrs.map(&:to_s))
       end
+
       private_class_method :attr_hash
 
       attr_hash :tags
@@ -62,7 +64,18 @@ module Azure
           @json = json
         end
 
-        @ostruct = OpenStruct.new(hash)
+        ostruct = OpenStruct.new(hash)
+        keys = ostruct.to_h.keys
+
+        # If the method already exists then create an "_alias" method for it.
+        methods.each do |m|
+          if keys.include?(m)
+            ostruct.class.instance_eval{ alias_method "_#{m}", m }
+            instance_eval{ define_singleton_method("_#{m}"){ ostruct[m] } }
+          end
+        end
+
+        @ostruct = ostruct
         super(@ostruct)
       end
 

--- a/lib/azure/armrest/model/base_model.rb
+++ b/lib/azure/armrest/model/base_model.rb
@@ -70,7 +70,6 @@ module Azure
         # If the method already exists then create an "_alias" method for it.
         methods.each do |m|
           if keys.include?(m)
-            ostruct.class.instance_eval{ alias_method "_#{m}", m }
             instance_eval{ define_singleton_method("_#{m}"){ ostruct[m] } }
           end
         end

--- a/spec/models/base_model_spec.rb
+++ b/spec/models/base_model_spec.rb
@@ -114,6 +114,16 @@ describe "BaseModel" do
       expect(base.address).to respond_to(:street)
       expect(base.address).to respond_to(:zipcode)
     end
+
+    it "defines an underscore alias for any existing methods" do
+      Object.class_eval{ def temp_stuff; 'hi'; end }
+      json = {:name => 'test', :temp_stuff => 33}.to_json
+      base = Azure::Armrest::BaseModel.new(json)
+
+      expect(base).to respond_to(:_temp_stuff)
+      expect(base._temp_stuff).to eq(33)
+      expect(base.temp_stuff).to eq('hi')
+    end
   end
 
   context "dynamic accessors" do

--- a/spec/models/base_model_spec.rb
+++ b/spec/models/base_model_spec.rb
@@ -117,12 +117,17 @@ describe "BaseModel" do
 
     it "defines an underscore alias for any existing methods" do
       Object.class_eval{ def temp_stuff; 'hi'; end }
-      json = {:name => 'test', :temp_stuff => 33}.to_json
+      Object.class_eval{ def tempStuff; 'hello'; end }
+
+      json = {:name => 'test', :temp_stuff => 33, :tempStuff => 44}.to_json
       base = Azure::Armrest::BaseModel.new(json)
 
       expect(base).to respond_to(:_temp_stuff)
+      expect(base).to respond_to(:_tempStuff)
       expect(base._temp_stuff).to eq(33)
+      expect(base._tempStuff).to eq(44)
       expect(base.temp_stuff).to eq('hi')
+      expect(base.tempStuff).to eq('hello')
     end
   end
 


### PR DESCRIPTION
In order to override any Object methods in our wrapper classes, we need to do a couple things. First, we must use a custom subclass of OpenStruct that redefines new_ostruct_member so that it doesn't skip methods that are already defined. Second, we need to undefine existing methods within the constructor to override the default Delegator behavior.