### PR TITLE
Provider namespace

### DIFF
--- a/lib/azure/armrest/armrest_service.rb
+++ b/lib/azure/armrest/armrest_service.rb
@@ -415,7 +415,10 @@ module Azure
               'locations'   => resource.locations - [''] # Ignore empty elements
             }
           end
-          @@providers_hash[info.namespace.downcase] = provider_info
+          # TODO: how does base model handle method naming collision?
+          # rename or access through hash?
+          # namespace is a method introduced by more_core_extensions
+          @@providers_hash[info['namespace'].downcase] = provider_info
         end
       end
 

--- a/lib/azure/armrest/model/base_model.rb
+++ b/lib/azure/armrest/model/base_model.rb
@@ -138,7 +138,7 @@ module Azure
     class Subscription < BaseModel; end
     class Tag < BaseModel; end
     class TemplateDeployment < BaseModel
-      attr_hash 'properties#parameters'
+      attr_hash 'properties#parameters', 'properties#outputs'
     end
     class TemplateDeploymentOperation < TemplateDeployment; end
     class Tenant < BaseModel; end


### PR DESCRIPTION
1. Avoid the method naming conflict for `namespace` introduced by gem `more_core_extension` if it is required in the application
2. Treat `properties/outputs` as a hash in `TemplateDeployment`