### PR TITLE
Fix all_blobs method

### DIFF
--- a/lib/azure/armrest/model/storage_account.rb
+++ b/lib/azure/armrest/model/storage_account.rb
@@ -49,7 +49,9 @@ module Azure
         doc = Nokogiri::XML(response.body)
 
         doc.xpath('//Blobs/Blob').map do |node|
-          Blob.new(Hash.from_xml(node.to_s)['Blob'])
+          blob = Blob.new(Hash.from_xml(node.to_s)['Blob'])
+          blob[:container] = container
+          blob
         end
       end
 
@@ -60,8 +62,8 @@ module Azure
         array = []
         threads = []
 
-        containers.each do |container|
-          threads << Thread.new(container, key){ |c,k| array << blobs(c.name, k) }
+        containers(key).each do |container|
+          threads << Thread.new(container, key) { |c, k| array << blobs(c.name, k) }
         end
 
         threads.each(&:join)

--- a/lib/azure/armrest/resource_group_service.rb
+++ b/lib/azure/armrest/resource_group_service.rb
@@ -13,16 +13,14 @@ module Azure
       end
 
       # List all the resources for the current subscription. You can optionally
-      # pass :top or :filter options as well to restrict returned results.
-      #
-      # If you pass a :resource_group option, then only resources for that
-      # resource group are returned.
+      # pass :top or :filter options as well to restrict returned results. The
+      # :filter option only applies to tags.
       #
       # Examples:
       #
       #   rgs = ResourceGroupService.new
       #   rgs.list(:top => 2)
-      #   rgs.list(:filter => "location eq 'centralus'")
+      #   rgs.list(:filter => "sometag=value")
       #
       def list(options = {})
         url = build_url


### PR DESCRIPTION
The all_blobs method needs to explicitly pass the key to the containers method.

I also added the :container attribute to the Blob object. This will help comparing blob image names with VM images.