### PR TITLE
Added copy_blob method

### DIFF
--- a/spec/models/storage_account_spec.rb
+++ b/spec/models/storage_account_spec.rb
@@ -71,5 +71,9 @@ describe "StorageAccount" do
     it "defines a blob_service_stats method" do
       expect(storage).to respond_to(:blob_service_stats)
     end
+
+    it "defines a copy_blob method" do
+      expect(storage).to respond_to(:copy_blob)
+    end
   end
 end


### PR DESCRIPTION
This PR adds the copy blob method. We'll need this for ManageIQ to copy stuff out of "system" (or other deeply nested hierarchies) for provisioning.