### PR TITLE
Add a list_all_private_images method

### DIFF
--- a/spec/storage_account_service_spec.rb
+++ b/spec/storage_account_service_spec.rb
@@ -68,6 +68,10 @@ describe "StorageAccountService" do
     it "defines a regenerate_storage_account_keys method" do
       expect(sas).to respond_to(:regenerate_storage_account_keys)
     end
+
+    it "defines a list_private_images method" do
+      expect(sas).to respond_to(:list_private_images)
+    end
   end
 
   context "create" do


### PR DESCRIPTION
This PR adds the list_all_private images that lets users easily retrieve a list of .vhd uri's that are available for provisioning.