### PR TITLE
Modify the list_private_images method to return a PrivateImage object

### DIFF
--- a/lib/azure/armrest/model/base_model.rb
+++ b/lib/azure/armrest/model/base_model.rb
@@ -54,14 +54,14 @@ module Azure
         end
 
         if json.is_a?(Hash)
-          hash = json
+          @hash = json
           @json = json.to_json
         else
-          hash = JSON.parse(json)
+          @hash = JSON.parse(json)
           @json = json
         end
 
-        __setobj__(hash)
+        __setobj__(@hash.dup)
       end
 
       def resource_group
@@ -70,6 +70,14 @@ module Azure
 
       def resource_group=(rg)
         @resource_group = rg
+      end
+
+      def to_h
+        @hash
+      end
+
+      def to_hash
+        @hash
       end
 
       def to_json

--- a/lib/azure/armrest/model/storage_account.rb
+++ b/lib/azure/armrest/model/storage_account.rb
@@ -10,6 +10,7 @@ module Azure
       class ContainerProperty < BaseModel; end
       class Blob < BaseModel; end
       class BlobProperty < BaseModel; end
+      class PrivateImage < BlobProperty; end
       class BlobServiceProperty < BaseModel; end
       class BlobServiceStat < BaseModel; end
       class BlobMetadata < BaseModel; end

--- a/lib/azure/armrest/storage_account_service.rb
+++ b/lib/azure/armrest/storage_account_service.rb
@@ -118,11 +118,8 @@ module Azure
               next unless blob_properties.x_ms_meta_microsoftazurecompute_osstate.downcase == 'generalized'
 
               mutex.synchronize do
-                results << File.join(
-                  storage_account.properties.primary_endpoints.blob,
-                  blob.container,
-                  blob.name
-                )
+                hash = blob_properties.to_h.merge(:storage_account => storage_account.to_h)
+                results << StorageAccount::PrivateImage.new(hash)
               end
             end
           end

--- a/spec/models/base_model_spec.rb
+++ b/spec/models/base_model_spec.rb
@@ -14,6 +14,14 @@ describe "BaseModel" do
     }'
   end
 
+  let(:hash) do
+    {
+      'firstName' => 'jeff',
+      'lastName' => 'durand',
+      'address' => {'street' => '22 charlotte rd', 'zipcode' => '01013'}
+    }
+  end
+
   let(:base) { Azure::Armrest::BaseModel.new(json) }
 
   context "constructor" do
@@ -88,6 +96,10 @@ describe "BaseModel" do
 
     it "defines a to_json method that returns the original json" do
       expect(base.to_json).to eq(json)
+    end
+
+    it "defines a to_h method that returns the original hash" do
+      expect(base.to_h).to eql(hash)
     end
 
     it "defines a custom inspect method" do


### PR DESCRIPTION
This modifies the list_private_images method to return an PrivateImage object, which is an amalgam of the BlobProperty and StorageAccount objects. With this change you can do something like this:
```
sas.list_private_images('miqazure-dan1').each do |image|
  puts image.storage_account.name # storage account name, e.g. "miqazuredan12006"
  puts image.storage_account.properties.primary_endpoints.blob # "https://miqazuredan12006.blob.core.windows.net/"
  puts image.x_ms_meta_microsoftazurecompute_ostype
end
```

I've also added a .to_h method to the BaseModel class that returns the original hash passed to the constructor, and use it for the list_private_images method.