### PR TITLE
Add a list_all method to ResourceProviderService

### DIFF
--- a/lib/azure/armrest/resource_provider_service.rb
+++ b/lib/azure/armrest/resource_provider_service.rb
@@ -47,12 +47,31 @@ module Azure
         response = rest_get(build_url)
         JSON.parse(response)["value"]
       end
+
       private :_list
 
-      # Cannot directly cache list method, because Marshal used by chche_method
-      # cannot dump anonymous class, including the ones derived from Azure::Armrest::BaseModel
-      # Same applies to other cached methods in this class
+      # Cannot directly cache list method, because Marshal used by cache_method
+      # cannot dump anonymous classes, including the ones derived from
+      # Azure::Armrest::BaseModel.
+      #
+      # The same applies to other cached methods in this class.
       cache_method(:_list, cache_time)
+
+      # List all the providers for Azure. This may include results that are
+      # not available for the current subscription.
+      #
+      def list_all
+        _list_all.map{ |hash| Azure::Armrest::ResourceProvider.new(hash) }
+      end
+
+      def _list_all
+        url = File.join(Azure::Armrest::RESOURCE, 'providers')
+        url << "?api-version=#{@api_version}"
+        response = rest_get(url)
+        JSON.parse(response)['value']
+      end
+
+      cache_method(:_list_all, cache_time)
 
       # Return information about a specific +namespace+ provider. The results
       # of this method are cached.
@@ -65,6 +84,7 @@ module Azure
         url = build_url(namespace)
         rest_get(url).body
       end
+
       private :_get
 
       cache_method(:_get, cache_time)

--- a/spec/resource_provider_spec.rb
+++ b/spec/resource_provider_spec.rb
@@ -36,6 +36,10 @@ describe "ResourceProviderService" do
       expect(rpsrv).to respond_to(:list)
     end
 
+    it "defines a list_all method" do
+      expect(rpsrv).to respond_to(:list_all)
+    end
+
     it "defines a get method" do
       expect(rpsrv).to respond_to(:get)
     end


### PR DESCRIPTION
This is the first part of an overall refactoring where I try to eliminate the providers_hash class variable and use our ResourceProviderService instead.

This PR adds a list_all method. Unlike the list method, this includes providers that may not be available to the current subscription.