### PR TITLE
Modify the list_private_images method to include more information

### DIFF
--- a/lib/azure/armrest/model/storage_account.rb
+++ b/lib/azure/armrest/model/storage_account.rb
@@ -96,9 +96,8 @@ module Azure
         doc = Nokogiri::XML(response.body)
 
         doc.xpath('//Blobs/Blob').map do |node|
-          blob = Blob.new(Hash.from_xml(node.to_s)['Blob'])
-          blob[:container] = container
-          blob
+          hash = Hash.from_xml(node.to_s)['Blob'].merge(:container => container)
+          Blob.new(hash)
         end
       end
 


### PR DESCRIPTION
This modifies the list_private_images method so that the "main" object is a Blob, and .blob_properties method gives you blob property information if you need to get at that directly. The .storage_account method is still there as well, if needed.

I also added two methods for convenience - :uri and :operating_system.

There was one minor fix required for the StorageAccount class as well.