### PR TITLE
Add a NetworkSecurityRuleService class

### DIFF
--- a/lib/azure/armrest.rb
+++ b/lib/azure/armrest.rb
@@ -36,6 +36,7 @@ require 'azure/armrest/resource_provider_service'
 require 'azure/armrest/network/ip_address_service'
 require 'azure/armrest/network/network_interface_service'
 require 'azure/armrest/network/network_security_group_service'
+require 'azure/armrest/network/network_security_rule_service'
 require 'azure/armrest/network/virtual_network_service'
 require 'azure/armrest/network/subnet_service'
 

--- a/lib/azure/armrest/model/base_model.rb
+++ b/lib/azure/armrest/model/base_model.rb
@@ -186,6 +186,7 @@ module Azure
       class IpAddress < BaseModel; end
       class NetworkInterface < BaseModel; end
       class NetworkSecurityGroup < BaseModel; end
+      class NetworkSecurityRule < NetworkSecurityGroup; end
       class VirtualNetwork < BaseModel; end
       class Subnet < VirtualNetwork; end
     end

--- a/lib/azure/armrest/network/network_security_rule_service.rb
+++ b/lib/azure/armrest/network/network_security_rule_service.rb
@@ -1,0 +1,47 @@
+module Azure
+  module Armrest
+    module Network
+      # Base class for managing securityRules
+      class NetworkSecurityRuleService < NetworkSecurityGroupService
+        # Creates a new +rule_name+ on +security_group+ using the given +options+.
+        def create(rule_name, security_group, resource_group = armrest_configuration.resource_group, options = {})
+          super(combine(security_group, rule_name), resource_group, options)
+        end
+
+        alias update create
+
+        # Deletes the given +rule_name+ in +security_group+.
+        #
+        def delete(rule_name, security_group, resource_group = armrest_configuration.resource_group)
+          super(combine(security_group, rule_name), resource_group)
+        end
+
+        # Retrieves information for the provided +rule_name+ in +security_group+ for
+        # the current subscription.
+        #
+        def get(rule_name, security_group, resource_group = armrest_configuration.resource_group)
+          super(combine(security_group, rule_name), resource_group)
+        end
+
+        # List available security rules on +security_group+ for the given +resource_group+.
+        #
+        def list(security_group, resource_group = armrest_configuration.resource_group)
+          raise ArgumentError, "must specify resource group" unless resource_group
+          raise ArgumentError, "must specify name of the resource" unless security_group
+
+          url = build_url(resource_group, security_group, 'securityRules')
+          response = rest_get(url)
+          JSON.parse(response)['value'].map{ |hash| model_class.new(hash) }
+        end
+
+        alias list_all list
+
+        private
+
+        def combine(virtual_network, subnet)
+          File.join(virtual_network, 'securityRules', subnet)
+        end
+      end
+    end # Network
+  end # Armrest
+end # Azure

--- a/spec/network_security_rule_spec.rb
+++ b/spec/network_security_rule_spec.rb
@@ -1,0 +1,38 @@
+#################################################################################
+# network_security_group_service_spec.rb
+#
+# Test suite for the Azure::Armrest::Network::NetworkSecurityRuleService class.
+#################################################################################
+require 'spec_helper'
+
+describe "Network::NetworkSecurityRuleService" do
+  before { setup_params }
+  let(:nsg) { Azure::Armrest::Network::NetworkSecurityRuleService.new(@conf) }
+
+  context "inheritance" do
+    it "is a subclass of NetworkSecurityGroupService" do
+      ancestor = Azure::Armrest::Network::NetworkSecurityGroupService
+      expect(Azure::Armrest::Network::NetworkSecurityRuleService.ancestors).to include(ancestor)
+    end
+  end
+
+  context "constructor" do
+    it "returns a nsg instance as expected" do
+      expect(nsg).to be_kind_of(Azure::Armrest::Network::NetworkSecurityRuleService)
+    end
+  end
+
+  context "instance methods" do
+    it "defines a get method" do
+      expect(nsg).to respond_to(:get)
+    end
+
+    it "defines a list method" do
+      expect(nsg).to respond_to(:list)
+    end
+
+    it "defines a list_all method" do
+      expect(nsg).to respond_to(:list_all)
+    end
+  end
+end


### PR DESCRIPTION
This adds a NetworkSecurityRuleService class. This class will likely be part of the MIQ effort to gather security group information.

Some basic specs are included, too.