### PR TITLE
Add RBAC service classes

### DIFF
--- a/lib/azure/armrest.rb
+++ b/lib/azure/armrest.rb
@@ -41,6 +41,8 @@ require 'azure/armrest/network/network_security_group_service'
 require 'azure/armrest/network/network_security_rule_service'
 require 'azure/armrest/network/virtual_network_service'
 require 'azure/armrest/network/subnet_service'
+require 'azure/armrest/role/assignment_service'
+require 'azure/armrest/role/definition_service'
 
 # JSON wrapper classes. The service classes should require their own
 # wrappers from this point on.

--- a/lib/azure/armrest/model/base_model.rb
+++ b/lib/azure/armrest/model/base_model.rb
@@ -195,6 +195,11 @@ module Azure
       class VirtualNetwork < BaseModel; end
       class Subnet < VirtualNetwork; end
     end
+
+    module Role
+      class Assignment < BaseModel; end
+      class Definition < BaseModel; end
+    end
   end
 end
 

--- a/lib/azure/armrest/role/assignment_service.rb
+++ b/lib/azure/armrest/role/assignment_service.rb
@@ -1,0 +1,23 @@
+# Azure namespace
+module Azure
+  # Armrest namespace
+  module Armrest
+    # Role namespace
+    module Role
+      # Base class for managing Role Assignments
+      class AssignmentService < ResourceGroupBasedService
+        # The provider used in requests when gathering Role information.
+        attr_reader :provider
+
+        # Create and return a new AssignmentService instance.
+        #
+        def initialize(_armrest_configuration, options = {})
+          super
+          @provider = options[:provider] || 'Microsoft.Authorization'
+          @service_name = 'roleAssignments'
+          set_service_api_version(options, @service_name)
+        end
+      end # AssignmentService
+    end # Role
+  end # Armrest
+end # Azure

--- a/lib/azure/armrest/role/definition_service.rb
+++ b/lib/azure/armrest/role/definition_service.rb
@@ -1,0 +1,23 @@
+# Azure namespace
+module Azure
+  # Armrest namespace
+  module Armrest
+    # Role namespace
+    module Role
+      # Base class for managing Role Definitions
+      class DefinitionService < ResourceGroupBasedService
+        # The provider used in requests when gathering Role information.
+        attr_reader :provider
+
+        # Create and return a new DefinitionService instance.
+        #
+        def initialize(_armrest_configuration, options = {})
+          super
+          @provider = options[:provider] || 'Microsoft.Authorization'
+          @service_name = 'roleDefinitions'
+          set_service_api_version(options, @service_name)
+        end
+      end # DefinitionService
+    end # Role
+  end # Armrest
+end # Azure

--- a/spec/role_assignment_service_spec.rb
+++ b/spec/role_assignment_service_spec.rb
@@ -1,0 +1,37 @@
+#################################################################################
+# role_assignment_service_spec.rb
+#
+# Test suite for the Azure::Armrest::Role::AssignmentService class.
+#################################################################################
+require 'spec_helper'
+
+describe "Role::AssignmentService" do
+  before { setup_params }
+  let(:ras) { Azure::Armrest::Role::AssignmentService.new(@conf) }
+
+  context "inheritance" do
+    it "is a subclass of ArmrestService" do
+      expect(Azure::Armrest::Role::AssignmentService.ancestors).to include(Azure::Armrest::ArmrestService)
+    end
+  end
+
+  context "constructor" do
+    it "returns a ras instance as expected" do
+      expect(ras).to be_kind_of(Azure::Armrest::Role::AssignmentService)
+    end
+  end
+
+  context "instance methods" do
+    it "defines a get method" do
+      expect(ras).to respond_to(:get)
+    end
+
+    it "defines a list method" do
+      expect(ras).to respond_to(:list)
+    end
+
+    it "defines a list_all method" do
+      expect(ras).to respond_to(:list_all)
+    end
+  end
+end

--- a/spec/role_definition_service_spec.rb
+++ b/spec/role_definition_service_spec.rb
@@ -1,0 +1,37 @@
+#################################################################################
+# role_definition_service_spec.rb
+#
+# Test suite for the Azure::Armrest::Role::DefinitionService class.
+#################################################################################
+require 'spec_helper'
+
+describe "Role::DefinitionService" do
+  before { setup_params }
+  let(:rds) { Azure::Armrest::Role::DefinitionService.new(@conf) }
+
+  context "inheritance" do
+    it "is a subclass of ArmrestService" do
+      expect(Azure::Armrest::Role::DefinitionService.ancestors).to include(Azure::Armrest::ArmrestService)
+    end
+  end
+
+  context "constructor" do
+    it "returns a rds instance as expected" do
+      expect(rds).to be_kind_of(Azure::Armrest::Role::DefinitionService)
+    end
+  end
+
+  context "instance methods" do
+    it "defines a get method" do
+      expect(rds).to respond_to(:get)
+    end
+
+    it "defines a list method" do
+      expect(rds).to respond_to(:list)
+    end
+
+    it "defines a list_all method" do
+      expect(rds).to respond_to(:list_all)
+    end
+  end
+end


### PR DESCRIPTION
This adds the Role::Assignment and Role::Definition service classes, along with corresponding model definitions. Some basic specs are included as well.