### PR TITLE
When fetching default subscriptions, only allow enabled subscriptions

### DIFF
--- a/spec/armrest_service_config_spec.rb
+++ b/spec/armrest_service_config_spec.rb
@@ -42,7 +42,7 @@ describe "ArmrestService" do
 
   context 'auto fill attributes' do
     let(:subscription_response) do
-      '{"value":[{"id":"/subscriptions/4f5a544b","subscriptionId":"4f5a544b"}]}'
+      '{"value":[{"id":"/subscriptions/4f5a544b","subscriptionId":"4f5a544b","state":"Enabled"}]}'
     end
 
     it 'fills some attributes with default values' do


### PR DESCRIPTION
This modifies the fetch_subscription_id singleton method so that it only allows **enabled** subscriptions. A minor update to the spec was also needed.