### PR TITLE
Add support for proxies, and refactor code to use new generic method.

### DIFF
--- a/spec/armrest_service_spec.rb
+++ b/spec/armrest_service_spec.rb
@@ -108,28 +108,28 @@ describe "ArmrestService" do
 
   context "api exception handling" do
     it "converts exception from rest_get" do
-      expect(RestClient).to receive(:get).and_raise(RestClient::Exception.new)
-      expect{ Azure::Armrest::ArmrestService.rest_get('') }.to raise_error(Azure::Armrest::ApiException)
+      expect(RestClient::Request).to receive(:execute).and_raise(RestClient::Exception.new)
+      expect { Azure::Armrest::ArmrestService.rest_get(:url => '') }.to raise_error(Azure::Armrest::ApiException)
     end
 
     it "converts exception from rest_put" do
-      expect(RestClient).to receive(:put).and_raise(RestClient::Exception.new)
-      expect{ Azure::Armrest::ArmrestService.rest_put('', '') }.to raise_error(Azure::Armrest::ApiException)
+      expect(RestClient::Request).to receive(:execute).and_raise(RestClient::Exception.new)
+      expect { Azure::Armrest::ArmrestService.rest_put(:url => '', :body => '') }.to raise_error(Azure::Armrest::ApiException)
     end
 
     it "converts exception from rest_post" do
-      expect(RestClient).to receive(:post).and_raise(RestClient::Exception.new)
-      expect{ Azure::Armrest::ArmrestService.rest_post('', '') }.to raise_error(Azure::Armrest::ApiException)
+      expect(RestClient::Request).to receive(:execute).and_raise(RestClient::Exception.new)
+      expect { Azure::Armrest::ArmrestService.rest_post(:url => '', :body => '') }.to raise_error(Azure::Armrest::ApiException)
     end
 
     it "converts exception from rest_patch" do
-      expect(RestClient).to receive(:patch).and_raise(RestClient::Exception.new)
-      expect{ Azure::Armrest::ArmrestService.rest_patch('', '') }.to raise_error(Azure::Armrest::ApiException)
+      expect(RestClient::Request).to receive(:execute).and_raise(RestClient::Exception.new)
+      expect { Azure::Armrest::ArmrestService.rest_patch(:url => '', :body => '') }.to raise_error(Azure::Armrest::ApiException)
     end
 
     it "converts exception from rest_delete" do
-      expect(RestClient).to receive(:delete).and_raise(RestClient::Exception.new)
-      expect{ Azure::Armrest::ArmrestService.rest_delete('') }.to raise_error(Azure::Armrest::ApiException)
+      expect(RestClient::Request).to receive(:execute).and_raise(RestClient::Exception.new)
+      expect { Azure::Armrest::ArmrestService.rest_delete(:url => '') }.to raise_error(Azure::Armrest::ApiException)
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,4 +26,13 @@ def setup_params
     :token_expiration => Time.now + 3600
   )
 
+  @req = {
+    :method  => :get,
+    :proxy   => nil,
+    :headers => {
+      :accept        => "application/json",
+      :content_type  => "application/json",
+      :authorization => @tok
+    }
+  }
 end

--- a/spec/template_deployment_service_spec.rb
+++ b/spec/template_deployment_service_spec.rb
@@ -24,45 +24,52 @@ describe "TemplateDeploymentService" do
 
   context "instance methods" do
     it "defines a create method" do
-      expected_url = url_prefix + "/deployname?api-version=2014-04-01-preview"
-      expect(RestClient).to receive(:put).with(expected_url, anything, anything).and_return('{}')
+      expected = @req.merge(
+        :url     => url_prefix + "/deployname?api-version=2014-04-01-preview",
+        :method  => :put,
+        :payload => "{}"
+      )
+      expect(RestClient::Request).to receive(:execute).with(expected).and_return('{}')
       tds.create('deployname', 'groupname', {})
     end
 
     it "defines a delete method" do
-      expected_url = url_prefix + "/deployname?api-version=2014-04-01-preview"
-      expect(RestClient).to receive(:delete).with(expected_url, anything)
+      expected = @req.merge(
+        :url => url_prefix + "/deployname?api-version=2014-04-01-preview",
+        :method => :delete
+      )
+      expect(RestClient::Request).to receive(:execute).with(expected)
       tds.delete('deployname', 'groupname')
     end
 
     it "defines a list_names method" do
-      expected_url = url_prefix + "?api-version=2014-04-01-preview"
+      expected = @req.merge(:url => url_prefix + "?api-version=2014-04-01-preview")
       expected_return = '{"value":[{"name":"deployname"}]}'
-      expect(RestClient).to receive(:get).with(expected_url, anything).and_return(expected_return)
+      expect(RestClient::Request).to receive(:execute).with(expected).and_return(expected_return)
       tds.list_names('groupname')
     end
 
     it "defines a list method" do
-      expected_url = url_prefix + "?api-version=2014-04-01-preview"
-      expect(RestClient).to receive(:get).with(expected_url, anything).and_return('{"value":{}}')
+      expected = @req.merge(:url => url_prefix + "?api-version=2014-04-01-preview")
+      expect(RestClient::Request).to receive(:execute).with(expected).and_return('{"value":{}}')
       tds.list('groupname')
     end
 
     it "defines a get method" do
-      expected_url = url_prefix + "/deployname?api-version=2014-04-01-preview"
-      expect(RestClient).to receive(:get).with(expected_url, anything).and_return('{}')
+      expected = @req.merge(:url => url_prefix + "/deployname?api-version=2014-04-01-preview")
+      expect(RestClient::Request).to receive(:execute).with(expected).and_return('{}')
       tds.get('deployname', 'groupname')
     end
 
     it "defines a list_deployment_operations method" do
-      expected_url = url_prefix + "/deployname/operations?api-version=2014-04-01-preview"
-      expect(RestClient).to receive(:get).with(expected_url, anything).and_return('{"value":{}}')
+      expected = @req.merge(:url => url_prefix + "/deployname/operations?api-version=2014-04-01-preview")
+      expect(RestClient::Request).to receive(:execute).with(expected).and_return('{"value":{}}')
       tds.list_deployment_operations('deployname', 'groupname')
     end
 
     it "defines a get_deployment_operation method" do
-      expected_url = url_prefix + "/deployname/operations/opid?api-version=2014-04-01-preview"
-      expect(RestClient).to receive(:get).with(expected_url, anything).and_return('{}')
+      expected = @req.merge(:url => url_prefix + "/deployname/operations/opid?api-version=2014-04-01-preview")
+      expect(RestClient::Request).to receive(:execute).with(expected).and_return('{}')
       tds.get_deployment_operation('opid', 'deployname', 'groupname')
     end
   end


### PR DESCRIPTION
This adds proxy support to azure-armrest.

This required refactoring the rest_xxx methods internally to use a single generic function called rest_execute, which uses RestClient::Request.execute instead of the rest-client helper methods, which don't support parameters beyond the url and headers.

At the moment, the tests are failing however, and need to be refactored. I am not sure we really want the rest methods exposed as part of the API, either.