### PR TITLE
Add proxy support to Storage model

### DIFF
--- a/lib/azure/armrest/armrest_service.rb
+++ b/lib/azure/armrest/armrest_service.rb
@@ -337,6 +337,10 @@ module Azure
         rest_execute(options, :put)
       end
 
+      def self.rest_head(options)
+        rest_execute(options, :head)
+      end
+
       def self.raise_api_exception(e)
         begin
           response = JSON.parse(e.http_body)
@@ -404,6 +408,10 @@ module Azure
 
       def rest_delete(url)
         rest_execute(url, nil, :delete)
+      end
+
+      def rest_head(url)
+        rest_execute(url, nil, :head)
       end
 
       # Take an array of URI elements and join the together with the API version.

--- a/spec/models/storage_account_spec.rb
+++ b/spec/models/storage_account_spec.rb
@@ -40,6 +40,14 @@ describe "StorageAccount" do
       expect(storage).to respond_to(:storage_api_version)
       expect(storage.storage_api_version).to eq('2015-02-21')
     end
+
+    it "defines a proxy accessor that defaults to the http_proxy environment variable" do
+      proxy = "http://www.somewebsiteyyyyzzzz.com/bogusproxy"
+      allow(ENV).to receive(:[]).with('http_proxy').and_return(proxy)
+
+      expect(storage).to respond_to(:proxy)
+      expect(storage.proxy).to eq(proxy)
+    end
   end
 
   context "custom methods" do


### PR DESCRIPTION
* Added rest_head as instance and singleton methods.
* Added a proxy accessor to the Storage model class, and replaced RestClient calls with ArmrestService wrapper methods.
* Set Content-Type in the build_headers method once instead of individual methods.
* Added a proxy spec for the Storage class.