### PR TITLE
Add armrest_configuration alias

### DIFF
--- a/lib/azure/armrest/armrest_service.rb
+++ b/lib/azure/armrest/armrest_service.rb
@@ -59,6 +59,8 @@ module Azure
       # Configuration to access azure APIs
       attr_accessor :armrest_configuration
 
+      alias configuration armrest_configuration
+
       # Base url used for REST calls.
       attr_accessor :base_url
 
@@ -187,7 +189,7 @@ module Azure
       # Returns a list of the available resource providers.
       #
       def providers
-        url = url_with_api_version(armrest_configuration.api_version, @base_url, 'providers')
+        url = url_with_api_version(configuration.api_version, @base_url, 'providers')
         resp = rest_get(url)
         JSON.parse(resp.body)["value"].map{ |hash| Azure::Armrest::ResourceProvider.new(hash) }
       end
@@ -195,7 +197,7 @@ module Azure
       # Returns information about the specific provider +namespace+.
       #
       def provider_info(provider)
-        url = url_with_api_version(armrest_configuration.api_version, @base_url, 'providers', provider)
+        url = url_with_api_version(configuration.api_version, @base_url, 'providers', provider)
         response = rest_get(url)
         Azure::Armrest::ResourceProvider.new(response)
       end
@@ -221,7 +223,7 @@ module Azure
       # Returns a list of subscriptions for the tenant.
       #
       def subscriptions
-        url = url_with_api_version(armrest_configuration.api_version, @base_url, 'subscriptions')
+        url = url_with_api_version(configuration.api_version, @base_url, 'subscriptions')
         response = rest_get(url)
         JSON.parse(response.body)["value"].map{ |hash| Azure::Armrest::Subscription.new(hash) }
       end
@@ -230,12 +232,12 @@ module Azure
       # subscription ID that was provided in the constructor if none is
       # specified.
       #
-      def subscription_info(subscription_id = armrest_configuration.subscription_id)
+      def subscription_info(subscription_id = configuration.subscription_id)
         url = url_with_api_version(
-          armrest_configuration.api_version,
+          configuration.api_version,
           @base_url,
           'subscriptions',
-          armrest_configuration.subscription_id
+          subscription_id
         )
 
         response = rest_get(url)
@@ -247,11 +249,11 @@ module Azure
       # resource group.
       #
       def resources(resource_group = nil)
-        url_comps = [@base_url, 'subscriptions', armrest_configuration.subscription_id]
+        url_comps = [@base_url, 'subscriptions', configuration.subscription_id]
         url_comps += ['resourcegroups', resource_group] if resource_group
         url_comps << 'resources'
 
-        url = url_with_api_version(armrest_configuration.api_version, url_comps)
+        url = url_with_api_version(configuration.api_version, url_comps)
         response = rest_get(url)
 
         JSON.parse(response)["value"].map{ |hash| Azure::Armrest::Resource.new(hash) }
@@ -261,10 +263,10 @@ module Azure
       #
       def resource_groups
         url = url_with_api_version(
-          armrest_configuration.api_version,
+          configuration.api_version,
           @base_url,
           'subscriptions',
-          armrest_configuration.subscription_id,
+          configuration.subscription_id,
           'resourcegroups'
         )
         response = rest_get(url)
@@ -275,12 +277,12 @@ module Azure
       # subscription, or the resource group specified in the constructor if
       # none is provided.
       #
-      def resource_group_info(resource_group = armrest_configuration.resource_group)
+      def resource_group_info(resource_group = configuration.resource_group)
         url = url_with_api_version(
-          armrest_configuration.api_version,
+          configuration.api_version,
           @base_url,
           'subscriptions',
-          armrest_configuration.subscription_id,
+          configuration.subscription_id,
           'resourcegroups',
           resource_group
         )
@@ -293,10 +295,10 @@ module Azure
       #
       def tags
         url = url_with_api_version(
-          armrest_configuration.api_version,
+          configuration.api_version,
           @base_url,
           'subscriptions',
-          armrest_configuration.subscription_id,
+          configuration.subscription_id,
           'tagNames'
         )
         resp = rest_get(url)
@@ -306,7 +308,7 @@ module Azure
       # Returns a list of tenants that can be accessed.
       #
       def tenants
-        url = url_with_api_version(armrest_configuration.api_version, @base_url, 'tenants')
+        url = url_with_api_version(configuration.api_version, @base_url, 'tenants')
         resp = rest_get(url)
         JSON.parse(resp.body)['value'].map{ |hash| Azure::Armrest::Tenant.new(hash) }
       end
@@ -377,11 +379,11 @@ module Azure
       def rest_execute(url, body = nil, http_method = :get)
         options = {
           :url     => url,
-          :proxy   => armrest_configuration.proxy,
+          :proxy   => configuration.proxy,
           :headers => {
-            :accept        => armrest_configuration.accept,
-            :content_type  => armrest_configuration.content_type,
-            :authorization => armrest_configuration.token
+            :accept        => configuration.accept,
+            :content_type  => configuration.content_type,
+            :authorization => configuration.token
           }
         }
 
@@ -466,7 +468,7 @@ module Azure
           elsif @@providers_hash.has_key?(provider.downcase)
             @@providers_hash[provider.downcase][service.downcase]['api_version']
           else
-            armrest_configuration.api_version
+            configuration.api_version
           end
       end
     end # ArmrestService

--- a/lib/azure/armrest/availability_set_service.rb
+++ b/lib/azure/armrest/availability_set_service.rb
@@ -6,8 +6,8 @@ module Azure
     class AvailabilitySetService < ResourceGroupBasedService
       # Create and return a new AvailabilitySetService instance.
       #
-      def initialize(armrest_configuration, options = {})
-        super(armrest_configuration, 'availabilitySets', 'Microsoft.Compute', options)
+      def initialize(configuration, options = {})
+        super(configuration, 'availabilitySets', 'Microsoft.Compute', options)
       end
 
       def list_all

--- a/lib/azure/armrest/resource_group_based_service.rb
+++ b/lib/azure/armrest/resource_group_based_service.rb
@@ -2,7 +2,7 @@ module Azure
   module Armrest
     # Base class for services that need to run in a resource group
     class ResourceGroupBasedService < ArmrestService
-      def create(name, rgroup = armrest_configuration.resource_group, options = {})
+      def create(name, rgroup = configuration.resource_group, options = {})
         validate_resource_group(rgroup)
         validate_resource(name)
 
@@ -14,7 +14,7 @@ module Azure
 
       alias update create
 
-      def list(rgroup = armrest_configuration.resource_group)
+      def list(rgroup = configuration.resource_group)
         validate_resource_group(rgroup)
 
         url = build_url(rgroup)
@@ -30,7 +30,7 @@ module Azure
         JSON.parse(response)['value'].map { |hash| model_class.new(hash) }
       end
 
-      def get(name, rgroup = armrest_configuration.resource_group)
+      def get(name, rgroup = configuration.resource_group)
         validate_resource_group(rgroup)
         validate_resource(name)
 
@@ -40,7 +40,7 @@ module Azure
         model_class.new(response)
       end
 
-      def delete(name, rgroup = armrest_configuration.resource_group)
+      def delete(name, rgroup = configuration.resource_group)
         validate_resource_group(rgroup)
         validate_resource(name)
 
@@ -64,7 +64,7 @@ module Azure
       # arguments provided, and appends it with the api_version.
       #
       def build_url(resource_group = nil, *args)
-        url = File.join(Azure::Armrest::COMMON_URI, armrest_configuration.subscription_id)
+        url = File.join(Azure::Armrest::COMMON_URI, configuration.subscription_id)
         url = File.join(url, 'resourceGroups', resource_group) if resource_group
         url = File.join(url, 'providers', @provider, @service_name)
         url = File.join(url, *args) unless args.empty?

--- a/lib/azure/armrest/resource_group_based_subservice.rb
+++ b/lib/azure/armrest/resource_group_based_subservice.rb
@@ -6,12 +6,12 @@ module Azure
       # all other service classes should subclass, and call super within their
       # own constructors.
       #
-      def initialize(armrest_configuration, service_name, subservice_name, default_provider, options)
+      def initialize(configuration, service_name, subservice_name, default_provider, options)
         @subservice_name = subservice_name
-        super(armrest_configuration, service_name, default_provider, options)
+        super(configuration, service_name, default_provider, options)
       end
 
-      def create(resource, subresource, rgroup = armrest_configuration.resource_group, options = {})
+      def create(resource, subresource, rgroup = configuration.resource_group, options = {})
         validate_resource_group(rgroup)
         validate_resource(resource)
         validate_subresource(subresource)
@@ -20,7 +20,7 @@ module Azure
 
       alias update create
 
-      def list(resource, rgroup = armrest_configuration.resource_group)
+      def list(resource, rgroup = configuration.resource_group)
         validate_resource_group(rgroup)
         validate_resource(resource)
 
@@ -32,14 +32,14 @@ module Azure
 
       alias list_all list
 
-      def get(resource, subresource, rgroup = armrest_configuration.resource_group)
+      def get(resource, subresource, rgroup = configuration.resource_group)
         validate_resource_group(rgroup)
         validate_resource(resource)
         validate_subresource(subresource)
         super(combine(resource, subresource), rgroup)
       end
 
-      def delete(resource, subresource, rgroup = armrest_configuration.resource_group)
+      def delete(resource, subresource, rgroup = configuration.resource_group)
         validate_resource_group(rgroup)
         validate_resource(resource)
         validate_subresource(subresource)

--- a/lib/azure/armrest/resource_group_service.rb
+++ b/lib/azure/armrest/resource_group_service.rb
@@ -6,8 +6,8 @@ module Azure
 
       # Creates and returns a new ResourceGroupService object.
       #
-      def initialize(armrest_configuration, options = {})
-        super(armrest_configuration, 'resourceGroups', 'Microsoft.Resources', options)
+      def initialize(configuration, options = {})
+        super(configuration, 'resourceGroups', 'Microsoft.Resources', options)
       end
 
       # List all the resources for the current subscription. You can optionally
@@ -70,7 +70,7 @@ module Azure
       private
 
       def build_url(group = nil, *args)
-        id = armrest_configuration.subscription_id
+        id = configuration.subscription_id
         url = File.join(Azure::Armrest::COMMON_URI, id, 'resourcegroups')
         url = File.join(url, group) if group
         url = File.join(url, *args) unless args.empty?

--- a/lib/azure/armrest/resource_provider_service.rb
+++ b/lib/azure/armrest/resource_provider_service.rb
@@ -23,8 +23,8 @@ module Azure
       #
       # You can also set the provider. The default is 'Microsoft.Resources'.
       #
-      def initialize(armrest_configuration, options = {})
-        super(armrest_configuration, 'resourceGroups', 'Microsoft.Resources', options)
+      def initialize(configuration, options = {})
+        super(configuration, 'resourceGroups', 'Microsoft.Resources', options)
 
         if options[:cache_time]
           @cache_time = options[:cache_time]
@@ -126,7 +126,7 @@ module Azure
       private
 
       def build_url(namespace = nil, *args)
-        id = armrest_configuration.subscription_id
+        id = configuration.subscription_id
         url = File.join(Azure::Armrest::COMMON_URI, id, 'providers')
         url = File.join(url, namespace) if namespace
         url = File.join(url, *args) unless args.empty?

--- a/lib/azure/armrest/resource_service.rb
+++ b/lib/azure/armrest/resource_service.rb
@@ -6,8 +6,8 @@ module Azure
 
       # Creates and returns a new ResourceService object.
       #
-      def initialize(armrest_configuration, options = {})
-        super(armrest_configuration, 'subscriptions', 'Microsoft.Resources', options)
+      def initialize(configuration, options = {})
+        super(configuration, 'subscriptions', 'Microsoft.Resources', options)
       end
 
       # List all the resources for the current subscription. You can optionally
@@ -23,7 +23,7 @@ module Azure
       #   rs.list(:filter => "location eq 'centralus'")
       #
       def list(options = {})
-        subscription_id = armrest_configuration.subscription_id
+        subscription_id = configuration.subscription_id
 
         if options[:resource_group]
           url = File.join(
@@ -46,7 +46,7 @@ module Azure
       # Move the resources from +source_group+ under +source_subscription+,
       # which may be a different subscription.
       #
-      def move(source_group, source_subscription = armrest_configuration.subscription_id)
+      def move(source_group, source_subscription = configuration.subscription_id)
         url = File.join(
           Azure::Armrest::COMMON_URI, source_subscription,
           'resourcegroups', source_group, 'moveresources'

--- a/lib/azure/armrest/storage_account_service.rb
+++ b/lib/azure/armrest/storage_account_service.rb
@@ -15,9 +15,9 @@ module Azure
 
       # Creates and returns a new StorageAccountService (SAS) instance.
       #
-      def initialize(armrest_configuration, options = {})
+      def initialize(configuration, options = {})
         options = {'api_version' => '2015-05-01-preview'}.merge(options) # Must hard code for now
-        super(armrest_configuration, 'storageAccounts', 'Microsoft.Storage', options)
+        super(configuration, 'storageAccounts', 'Microsoft.Storage', options)
       end
 
       # Creates a new storage account, or updates an existing account with the
@@ -48,16 +48,17 @@ module Azure
       #
       #   sas = Azure::Armrest::StorageAccountService(config)
       #
-      #   sas.create("yourstorageaccount1",
+      #   sas.create(
+      #     "yourstorageaccount1",
+      #     "yourresourcegroup",
       #     {
       #       :location   => "West US",
       #       :properties => {:accountType => "Standard_ZRS"},
       #       :tags       => {:YourCompany => true}
-      #     },
-      #     "yourresourcegroup"
+      #     }
       #   )
       #
-      def create(account_name, rgroup = armrest_configuration.resource_group, options)
+      def create(account_name, rgroup = configuration.resource_group, options = {})
         validating = options.delete(:validating)
         validate_account_type(options[:properties][:accountType])
         validate_account_name(account_name)
@@ -70,7 +71,7 @@ module Azure
       # Returns the primary and secondary access keys for the given
       # storage account as a hash.
       #
-      def list_account_keys(account_name, group = armrest_configuration.resource_group)
+      def list_account_keys(account_name, group = configuration.resource_group)
         validate_resource_group(group)
 
         url = build_url(group, account_name, 'listKeys')
@@ -86,7 +87,7 @@ module Azure
       #     "keyName": "key1|key2"
       #   }
       #
-      def regenerate_storage_account_keys(account_name, group = armrest_configuration.resource_group, options)
+      def regenerate_storage_account_keys(account_name, group = configuration.resource_group, options = {})
         validate_resource_group(group)
 
         url = build_url(group, account_name, 'regenerateKey')
@@ -98,7 +99,7 @@ module Azure
       # storage accounts in the provided resource group. The custom keys
       # :uri and :operating_system have been added for convenience.
       #
-      def list_private_images(group = armrest_configuration.resource_group)
+      def list_private_images(group = configuration.resource_group)
         results = []
         threads = []
         mutex = Mutex.new

--- a/lib/azure/armrest/template_deployment_service.rb
+++ b/lib/azure/armrest/template_deployment_service.rb
@@ -3,14 +3,14 @@ module Azure
     # Base class for managing templates and deployments
     class TemplateDeploymentService < ResourceGroupBasedService
 
-      def initialize(armrest_configuration, options = {})
+      def initialize(configuration, options = {})
         # Has to be hard coded for now
         options = {'api_version' => '2014-04-01-preview'}.merge(options)
-        super(armrest_configuration, 'deployments', 'Microsoft.Resources', options)
+        super(configuration, 'deployments', 'Microsoft.Resources', options)
       end
 
       # Get names of all deployments in a resource group
-      def list_names(resource_group = armrest_configuration.resource_group)
+      def list_names(resource_group = configuration.resource_group)
         list(resource_group).map(&:name)
       end
 
@@ -20,7 +20,7 @@ module Azure
       end
 
       # Get all operations of a deployment in a resource group
-      def list_deployment_operations(deploy_name, resource_group = armrest_configuration.resource_group)
+      def list_deployment_operations(deploy_name, resource_group = configuration.resource_group)
         validate_resource_group(resource_group)
         validate_resource(deploy_name)
 
@@ -30,7 +30,7 @@ module Azure
       end
 
       # Get the operation of a deployment in a resource group
-      def get_deployment_operation(op_id, deploy_name, resource_group = armrest_configuration.resource_group)
+      def get_deployment_operation(op_id, deploy_name, resource_group = configuration.resource_group)
         validate_resource_group(resource_group)
         validate_resource(deploy_name)
         raise ArgumentError, "must specify operation id" unless op_id

--- a/lib/azure/armrest/virtual_machine_extension_service.rb
+++ b/lib/azure/armrest/virtual_machine_extension_service.rb
@@ -7,7 +7,7 @@ module Azure
 
       # Creates and returns a new VirtualMachineExtensionService object.
       #
-      def initialize(_armrest_configuration, options = {})
+      def initialize(_configuration, options = {})
         super
         set_service_api_version(options, 'virtualMachines/extensions')
       end
@@ -29,7 +29,7 @@ module Azure
       # For convenience, you may also specify a :resource_group as an option.
       #
       def create(vm_name, ext_name, options = {}, rgroup = nil)
-        rgroup ||= options.delete(:resource_group) || armrest_configuration.resource_group
+        rgroup ||= options.delete(:resource_group) || configuration.resource_group
 
         raise ArgumentError, "no resource group provided" unless rgroup
 
@@ -50,7 +50,7 @@ module Azure
 
       # Delete the given extension for the provided VM and resource group.
       #
-      def delete(vm_name, ext_name, rgroup = armrest_configuration.resource_group)
+      def delete(vm_name, ext_name, rgroup = configuration.resource_group)
         raise ArgumentError, "no resource group provided" unless rgroup
         url = build_url(rgroup, vm_name, ext_name)
         response = rest_delete(url)
@@ -61,7 +61,7 @@ module Azure
       # If the +instance_view+ option is true, it will retrieve instance
       # view information instead.
       #
-      def get(vm_name, ext_name, rgroup = armrest_configuration.resource_group, instance_view = false)
+      def get(vm_name, ext_name, rgroup = configuration.resource_group, instance_view = false)
         raise ArgumentError, "no resource group provided" unless rgroup
         url = build_url(rgroup, vm_name, ext_name)
         url << "&expand=instanceView" if instance_view
@@ -70,13 +70,13 @@ module Azure
       end
 
       # Shortcut to get an extension in model view.
-      def get_model_view(vm_name, ext_name, rgroup = armrest_configuration.resource_group)
+      def get_model_view(vm_name, ext_name, rgroup = configuration.resource_group)
         raise ArgumentError, "no resource group provided" unless rgroup
         get(vm_name, ext_name, rgroup, false)
       end
 
       # Shortcut to get an extension in instance view.
-      def get_instance_view(vm_name, ext_name, rgroup = armrest_configuration.resource_group)
+      def get_instance_view(vm_name, ext_name, rgroup = configuration.resource_group)
         raise ArgumentError, "no resource group provided" unless rgroup
         get(vm_name, ext_name, rgroup, true)
       end
@@ -90,7 +90,7 @@ module Azure
       #--
       # BUG: https://github.com/Azure/azure-xplat-cli/issues/1826
       #
-      def list(vm_name, rgroup = armrest_configuration.resource_group, instance_view = false)
+      def list(vm_name, rgroup = configuration.resource_group, instance_view = false)
         raise ArgumentError, "no resource group provided" unless rgroup
         url = build_url(rgroup, vm_name)
         url << "&expand=instanceView" if instance_view
@@ -99,13 +99,13 @@ module Azure
       end
 
       # Shortcut to get a list in model view.
-      def list_model_view(vmname, rgroup = armrest_configuration.resource_group)
+      def list_model_view(vmname, rgroup = configuration.resource_group)
         raise ArgumentError, "no resource group provided" unless rgroup
         list(vmname, false, rgroup)
       end
 
       # Shortcut to get a list in instance view.
-      def list_instance_view(vmname, rgroup = armrest_configuration.resource_group)
+      def list_instance_view(vmname, rgroup = configuration.resource_group)
         raise ArgumentError, "no resource group provided" unless rgroup
         list(vmname, true, rgroup)
       end
@@ -118,7 +118,7 @@ module Azure
       def build_url(resource_group, vm, *args)
         url = File.join(
           Azure::Armrest::COMMON_URI,
-          armrest_configuration.subscription_id,
+          configuration.subscription_id,
           'resourceGroups',
           resource_group,
           'providers',

--- a/lib/azure/armrest/virtual_machine_image_service.rb
+++ b/lib/azure/armrest/virtual_machine_image_service.rb
@@ -16,8 +16,8 @@ module Azure
       # :publisher options as well. The default provider is set to
       # 'Microsoft.Compute'.
       #
-      def initialize(armrest_configuration, options = {})
-        super(armrest_configuration, nil, 'Microsoft.Compute', options)
+      def initialize(configuration, options = {})
+        super(configuration, nil, 'Microsoft.Compute', options)
 
         @location  = options[:location]
         @publisher = options[:publisher]
@@ -103,7 +103,7 @@ module Azure
       def build_url(location, *args)
         url = File.join(
           Azure::Armrest::COMMON_URI,
-          armrest_configuration.subscription_id,
+          configuration.subscription_id,
           'providers',
           provider,
           'locations',

--- a/lib/azure/armrest/virtual_machine_service.rb
+++ b/lib/azure/armrest/virtual_machine_service.rb
@@ -12,8 +12,8 @@ module Azure
       # default is 'Microsoft.ClassicCompute'. You may need to set this to
       # 'Microsoft.Compute' for your purposes.
       #
-      def initialize(armrest_configuration, options = {})
-        super(armrest_configuration, 'virtualMachines', 'Microsoft.Compute', options)
+      def initialize(configuration, options = {})
+        super(configuration, 'virtualMachines', 'Microsoft.Compute', options)
       end
 
       # Return a list of available VM series (aka sizes, flavors, etc), such
@@ -27,7 +27,7 @@ module Azure
         version = @@providers_hash[provider.downcase]['locations/vmsizes']['api_version']
 
         url = url_with_api_version(
-          version, @base_url, 'subscriptions', armrest_configuration.subscription_id,
+          version, @base_url, 'subscriptions', configuration.subscription_id,
           'providers', provider, 'locations', location, 'vmSizes'
         )
 
@@ -44,19 +44,19 @@ module Azure
       # * overwriteVhds            - Boolean that indicates whether or not to overwrite any VHD's
       #                              with the same prefix. The default is false.
       #
-      def capture(vmname, options, group = armrest_configuration.resource_group)
+      def capture(vmname, options, group = configuration.resource_group)
         vm_operate('capture', vmname, group, options)
       end
 
       # Stop the VM +vmname+ in +group+ and deallocate the tenant in Fabric.
       #
-      def deallocate(vmname, group = armrest_configuration.resource_group)
+      def deallocate(vmname, group = configuration.resource_group)
         vm_operate('deallocate', vmname, group)
       end
 
       # Sets the OSState for the +vmname+ in +group+ to 'Generalized'.
       #
-      def generalize(vmname, group = armrest_configuration.resource_group)
+      def generalize(vmname, group = configuration.resource_group)
         vm_operate('generalize', vmname, group)
       end
 
@@ -67,21 +67,21 @@ module Azure
       # parameter is false, it will retrieve an instance view. The difference is
       # in the details of the information retrieved.
       #
-      def get(vmname, group = armrest_configuration.resource_group, model_view = true)
+      def get(vmname, group = configuration.resource_group, model_view = true)
         model_view ? super(vmname, group) : get_instance_view(vmname, group)
       end
 
       # Convenient wrapper around the get method that retrieves the model view
       # for +vmname+ in resource_group +group+.
       #
-      def get_model_view(vmname, group = armrest_configuration.resource_group)
+      def get_model_view(vmname, group = configuration.resource_group)
         get(vmname, group, true)
       end
 
       # Convenient wrapper around the get method that retrieves the instance view
       # for +vmname+ in resource_group +group+.
       #
-      def get_instance_view(vmname, group = armrest_configuration.resource_group)
+      def get_instance_view(vmname, group = configuration.resource_group)
         raise ArgumentError, "must specify resource group" unless group
         raise ArgumentError, "must specify name of the resource" unless vmname
 
@@ -96,7 +96,7 @@ module Azure
       # This is an asynchronous operation that returns a response object
       # which you can inspect, such as response.code or response.headers.
       #
-      def restart(vmname, group = armrest_configuration.resource_group)
+      def restart(vmname, group = configuration.resource_group)
         vm_operate('restart', vmname, group)
       end
 
@@ -106,7 +106,7 @@ module Azure
       # This is an asynchronous operation that returns a response object
       # which you can inspect, such as response.code or response.headers.
       #
-      def start(vmname, group = armrest_configuration.resource_group)
+      def start(vmname, group = configuration.resource_group)
         vm_operate('start', vmname, group)
       end
 
@@ -116,7 +116,7 @@ module Azure
       # This is an asynchronous operation that returns a response object
       # which you can inspect, such as response.code or response.headers.
       #
-      def stop(vmname, group = armrest_configuration.resource_group)
+      def stop(vmname, group = configuration.resource_group)
         vm_operate('powerOff', vmname, group)
       end
 

--- a/spec/storage_account_service_spec.rb
+++ b/spec/storage_account_service_spec.rb
@@ -77,13 +77,13 @@ describe "StorageAccountService" do
   context "create" do
     it "requires a valid account name" do
       options = {:location => "West US", :properties => {:accountType => "Standard_GRS"}}
-      expect{ sas.create("xx", options) }.to raise_error(ArgumentError)
-      expect{ sas.create("^&123***", options) }.to raise_error(ArgumentError)
+      expect { sas.create("xx", @res, options) }.to raise_error(ArgumentError)
+      expect { sas.create("^&123***", @res, options) }.to raise_error(ArgumentError)
     end
 
     it "requires a valid account type" do
       options = {:location => "West US", :properties => {:accountType => "bogus"}}
-      expect{sas.create("test", options)}.to raise_error(ArgumentError)
+      expect { sas.create("test", @res, options) }.to raise_error(ArgumentError)
     end
   end
 end


### PR DESCRIPTION
This is largely a cosmetic update. I was just tired of typing out "armest_configuration", so I added a shorter alias and use it internally.

This will not only help save my fingers, it will potentially help avoid Rubocop warnings for lines being too long.