### PR TITLE
Modify configure method so that api_version overrides local settings

### DIFF
--- a/lib/azure/armrest/armrest_service.rb
+++ b/lib/azure/armrest/armrest_service.rb
@@ -184,7 +184,11 @@ module Azure
         # Base URL used for REST calls. Modify within method calls as needed.
         @base_url = Azure::Armrest::RESOURCE
 
-        set_service_api_version(options, service_name)
+        if armrest_configuration.api_version && !options['api_version']
+          @api_version = armrest_configuration.api_version
+        else
+          set_service_api_version(options, service_name)
+        end
       end
 
       # Returns a list of the available resource providers.

--- a/spec/armrest_service_spec.rb
+++ b/spec/armrest_service_spec.rb
@@ -15,6 +15,13 @@ describe "ArmrestService" do
     it "returns an armrest service instance as expected" do
       expect(arm).to be_kind_of(Azure::Armrest::ArmrestService)
     end
+
+    it "uses the api_version specified in the configuration, if present" do
+      date = '2015-01-01'
+      @conf[:api_version] = date
+      arm = Azure::Armrest::ArmrestService.new(@conf, 'servicename', 'provider', {})
+      expect(arm.api_version).to eq(date)
+    end
   end
 
   context "methods" do

--- a/spec/storage_account_service_spec.rb
+++ b/spec/storage_account_service_spec.rb
@@ -19,6 +19,13 @@ describe "StorageAccountService" do
     it "returns a SAS instance as expected" do
       expect(sas).to be_kind_of(Azure::Armrest::StorageAccountService)
     end
+
+    it "overrides the api_version with its own version" do
+      expected_date = '2015-05-01-preview' # Hard coded in StorageAccountService
+      @conf[:api_version] = '2010-01-01'
+      sas = Azure::Armrest::StorageAccountService.new(@conf)
+      expect(sas.api_version).to eq(expected_date)
+    end
   end
 
   context "constants" do

--- a/spec/template_deployment_service_spec.rb
+++ b/spec/template_deployment_service_spec.rb
@@ -20,6 +20,13 @@ describe "TemplateDeploymentService" do
     it "returns a TDS instance as expected" do
       expect(tds).to be_kind_of(Azure::Armrest::TemplateDeploymentService)
     end
+
+    it "overrides the api_version with its own version" do
+      expected_date = '2014-04-01-preview' # Hard coded in TemplateDeploymentService
+      @conf[:api_version] = '2010-01-01'
+      tds = Azure::Armrest::TemplateDeploymentService.new(@conf)
+      expect(tds.api_version).to eq(expected_date)
+    end
   end
 
   context "instance methods" do


### PR DESCRIPTION
See https://github.com/ManageIQ/azure-armrest/issues/132

With this patch, the api_version specified in ArmrestService.configure will now apply to all subclasses globally EXCEPT those service classes that explicitly specify an api_version string in their constructors. For now that means storage accounts and template deployments.

```
conf = Azure::Armrest::ArmrestService.configure(
  :tenant_id   => "xxx",
  :client_id   => "yyy",
  :client_key  => "zzz",
  :api_version => '2015-01-01'
)

vms = Azure::Armrest::VirtualMachineService.new(conf)
sas = Azure::Armrest::StorageAccountService.new(conf)
nis = Azure::Armrest::Network::NetworkInterfaceService.new(conf)
tds = Azure::Armrest::TemplateDeploymentService.new(conf)

p vms.api_version
p sas.api_version
p nis.api_version
p tds.api_version

# Results
"2015-01-01"
"2015-05-01-preview" # => Hard coded for StorageAccountService
"2015-01-01"
"2014-04-01-preview" # => Hard coded for TemplateDeploymentService
```
You can still set the api_version on a per service instance basis if desired:

    vms.api_version = '2015-06-15'

This will probably be necessary for certain service classes, since not all dates are globally valid for all service classes.

