### PR TITLE
Modify the StorageAccountService class so that it sets the proxy on all StorageAccount models

### DIFF
--- a/lib/azure/armrest/model/storage_account.rb
+++ b/lib/azure/armrest/model/storage_account.rb
@@ -246,7 +246,8 @@ module Azure
         response = ArmrestService.rest_put(
           :url     => dst_url,
           :payload => '',
-          :headers => headers
+          :headers => headers,
+          :proxy   => proxy
         )
 
         Blob.new(response.headers)

--- a/lib/azure/armrest/storage_account_service.rb
+++ b/lib/azure/armrest/storage_account_service.rb
@@ -20,6 +20,24 @@ module Azure
         super(configuration, 'storageAccounts', 'Microsoft.Storage', options)
       end
 
+      # Same as other resource based get methods, but also sets the proxy on the model object.
+      #
+      def get(name, resource_group = configuration.resource_group)
+        super.tap { |m| m.proxy = configuration.proxy }
+      end
+
+      # Same as other resource based list methods, but also sets the proxy on each model object.
+      #
+      def list(resource_group = configuration.resource_group)
+        super.each { |m| m.proxy = configuration.proxy }
+      end
+
+      # Same as other resource based list_all methods, but also sets the proxy on each model object.
+      #
+      def list_all
+        super.each { |m| m.proxy = configuration.proxy }
+      end
+
       # Creates a new storage account, or updates an existing account with the
       # specified parameters.
       #
@@ -65,7 +83,7 @@ module Azure
 
         super(account_name, rgroup, options) do |url|
           url << "&validating=" << validating if validating
-        end
+        end.tap { |m| m.proxy = configuration.proxy }
       end
 
       # Returns the primary and secondary access keys for the given

--- a/spec/armrest_service_spec.rb
+++ b/spec/armrest_service_spec.rb
@@ -17,7 +17,7 @@ describe "ArmrestService" do
     end
   end
 
-  context "methods" do
+  context "instance methods" do
     it "defines a locations method" do
       expect(arm).to respond_to(:locations)
     end


### PR DESCRIPTION
This PR adds the ArmrestService.configuration method. It returns whatever was sent to the ArmrestService.configure method. It also modifies the StorageAccount model's constructor to use the proxy information set in the configure method.

The primary motivation was to carry over the :proxy setting, which is not carried over automatically for the StorageAccount model because it makes its own http requests. However, setting this separately for every StorageAccount model object is cumbersome.

Note that I use a class instance variable, so subclasses will not have this information. It is easy enough to change if we would rather have it as a class variable and allow access for subclasses.