### PR TITLE
Allow URI objects for proxy settings.

### DIFF
--- a/lib/azure/armrest/armrest_service.rb
+++ b/lib/azure/armrest/armrest_service.rb
@@ -135,6 +135,9 @@ module Azure
         configuration.subscription_id ||= fetch_subscription_id(configuration)
         configuration.proxy           ||= ENV['http_proxy']
 
+        # Allows for URI objects or Strings
+        configuration.proxy = configuration.proxy.to_s if configuration.proxy
+
         configuration
       end
 

--- a/spec/armrest_service_config_spec.rb
+++ b/spec/armrest_service_config_spec.rb
@@ -10,6 +10,8 @@ describe "ArmrestService" do
     )
   end
 
+  let(:proxy) { "http://www.somewebsiteyyyyzzzz.com/bogusproxy" }
+
   let(:options_with_subscription) do
     options.merge(:subscription_id => 'sid')
   end
@@ -59,11 +61,18 @@ describe "ArmrestService" do
       conf = Azure::Armrest::ArmrestService.configure(options)
       expect(conf.subscription_id).to eql('4f5a544b')
     end
+  end
 
+  context 'http proxy' do
     it 'uses the http_proxy environment variable for the proxy value if set' do
-      proxy = "http://www.somewebsiteyyyyzzzz.com/bogusproxy"
       allow(ENV).to receive(:[]).with('http_proxy').and_return(proxy)
       conf = Azure::Armrest::ArmrestService.configure(options_with_subscription)
+      expect(conf.proxy).to eq(proxy)
+    end
+
+    it 'accepts a URI object for a proxy' do
+      uri = URI.parse(proxy)
+      conf = Azure::Armrest::ArmrestService.configure(options_with_subscription.merge(:proxy => uri))
       expect(conf.proxy).to eq(proxy)
     end
   end


### PR DESCRIPTION
Minor tweak that calls .to_s on the proxy configuration setting (assuming it's not nil). I also added a spec.

This allows for URI objects as well as strings (or anything that responds to .to_s) for the :proxy option.