### PR TITLE
attach/detach data disk to vm

### DIFF
--- a/spec/virtual_machine_service_spec.rb
+++ b/spec/virtual_machine_service_spec.rb
@@ -73,6 +73,14 @@ describe "VirtualMachineService" do
       expect(vms).to respond_to(:stop)
     end
 
+    it "defines a attach_data_disk method" do
+      expect(vms).to respond_to(:attach_data_disk)
+    end
+
+    it "defines a detach_data_disk method" do
+      expect(vms).to respond_to(:detach_data_disk)
+    end
+
     it "defines a provider= method" do
       expect(vms).to respond_to(:provider=)
     end


### PR DESCRIPTION
Hello all !

I'm using azure-armrest to manage azure volumes and I want to add new functions to attach/detach Data Disk (Volume) to one VM base on update VM API.
Can you please take a look at my PR and tell me if there is anything wrong. I'll fix it asap.
If you have better ideas, please let me know.

Thank you very much!