### PR TITLE
Add support for ssl_version and ssl_verify config options

### DIFF
--- a/spec/armrest_service_spec.rb
+++ b/spec/armrest_service_spec.rb
@@ -104,6 +104,16 @@ describe "ArmrestService" do
       expect(arm.armrest_configuration).to respond_to(:grant_type)
       expect(arm.armrest_configuration.grant_type).to eq('client_credentials')
     end
+
+    it "defines an ssl_verify accessor" do
+      expect(arm.armrest_configuration).to respond_to(:ssl_verify)
+      expect(arm.armrest_configuration.ssl_verify).to be_nil
+    end
+
+    it "defines an ssl_version accessor" do
+      expect(arm.armrest_configuration).to respond_to(:ssl_version)
+      expect(arm.armrest_configuration.ssl_version).to eq('TLSv1')
+    end
   end
 
   context "api exception handling" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -27,8 +27,10 @@ def setup_params
   )
 
   @req = {
-    :method  => :get,
-    :proxy   => nil,
+    :method      => :get,
+    :proxy       => nil,
+    :ssl_verify  => nil,
+    :ssl_version => 'TLSv1',
     :headers => {
       :accept        => "application/json",
       :content_type  => "application/json",


### PR DESCRIPTION
This adds support for two more configuration options - ssl_verify and ssl_version, and passes these values to each http request.

By default the ssl_verify is set to nil, and the ssl_version is set to "TLSv1". As far as I can tell, rest-client is using SSLv3 by default, which is not great. Users can still configure the ssl_version if our default does not suit their needs.

Lastly, this fixes a potential bug in the configure + fetch_subscription_id logic where it wouldn't use the default proxy because it was being called before the default was set. That method should always be called last in the configure method.