### PR TITLE
Added class method to clear caches.

### DIFF
--- a/lib/azure/armrest/armrest_service.rb
+++ b/lib/azure/armrest/armrest_service.rb
@@ -84,11 +84,14 @@ module Azure
       # The SSL version used for each request. The default is TLSv1.
       attr_accessor :ssl_version
 
-      @@providers_hash = {} # Set in constructor
+      # Clear class level caches.
+      def self.clear_caches
+        @@providers_hash = {} # Set in constructor
+        @@tokens         = {} # token caches
+        @@subscriptions  = {} # subscription caches
+      end
 
-      @@tokens = {} # token caches
-
-      @@subscriptions = {} # subscription caches
+      clear_caches
 
       # Create a configuration object based on input options.
       # This object can be used to create service objects.


### PR DESCRIPTION
Added a class method to clear class-level caches in ArmrestService.
This is needed when recording multiple VCR cassettes within a test -
as the tests need to clear the cache between exampes.