### PR TITLE
Capture skip_token when listing events

### DIFF
--- a/lib/azure/armrest/insights/event_service.rb
+++ b/lib/azure/armrest/insights/event_service.rb
@@ -13,6 +13,47 @@ module Azure
           super(armrest_configuration, 'eventTypes', 'Microsoft.Insights', options)
         end
 
+        # Returns an +EventList+ containing a list of management evnets for the
+        # current subscription as well as a +next_link+ attribute that can be
+        # used to obtain the next batch of events for this result.
+        #
+        # The +filter+ option can be used to filter the result set. Additionally,
+        # you may restrict the results to only return certain fields using
+        # the +select+ option. The possible fields for both filtering and selection
+        # are:
+        #
+        # authorization, channels, claims, correlationId, description, eventDataId,
+        # eventName, eventSource, eventTimestamp, httpRequest, level, operationId,
+        # operationName, properties, resourceGroupName, resourceProviderName,
+        # resourceUri, status, submissionTimestamp, subStatus and subscriptionId.
+        #
+        # The +skip_token+ option can be used to grab the next batch of events
+        # when the first call reaches the maximum number of events that the API
+        # can return in one batch (API default 200).
+        #
+        # Example:
+        #
+        #   ies = Azure::Armrest::Insights::EventService.new(conf)
+        #
+        #   date   = (Time.now - 86400).httpdate
+        #   filter = "eventTimestamp ge #{date} and eventChannels eq 'Admin, Operation'"
+        #   select = "resourceGroupName, operationName"
+        #
+        #   ies.list(filter, select, skip_token).events.each{ |event|
+        #     p event
+        #   }
+        #
+        def list(filter = nil, select = nil, skip_token = nil)
+          url = build_url(filter, select, skip_token)
+          response = rest_get(url)
+          json_response = JSON.parse(response.body)
+
+          events          = json_response['value'].map{ |e| Azure::Armrest::Insights::Event.new(e) }
+          next_link       = json_response['nextlink']
+          next_skip_token = next_link[/.*?skipToken=(.*?)$/, 1] if next_link
+          Azure::Armrest::Insights::EventList.new(events, next_skip_token)
+        end
+
         # Returns a list of management events for the current subscription.
         # The +filter+ option can be used to filter the result set. Additionally,
         # you may restrict the results to only return certain fields using
@@ -24,6 +65,11 @@ module Azure
         # operationName, properties, resourceGroupName, resourceProviderName,
         # resourceUri, status, submissionTimestamp, subStatus and subscriptionId.
         #
+        # +list_all+ differs from the +list+ method in that it will list all of
+        # the events that would be returned for the given +filter+ and +select+
+        # instead of returning only the first page of events as defined by the
+        # Azure API event threshold (200 per page, by default).
+        #
         # Example:
         #
         #   ies = Azure::Armrest::Insights::EventService.new(conf)
@@ -32,19 +78,24 @@ module Azure
         #   filter = "eventTimestamp ge #{date} and eventChannels eq 'Admin, Operation'"
         #   select = "resourceGroupName, operationName"
         #
-        #   ies.list(filter, select).each{ |event|
+        #   ies.list_all(filter, select).each{ |event|
         #     p event
         #   }
         #
-        def list(filter = nil, select = nil)
-          url = build_url(filter, select)
-          response = rest_get(url)
-          JSON.parse(response.body)['value'].map{ |e| Azure::Armrest::Insights::Event.new(e) }
+        def list_all(filter = nil, select = nil)
+          event_list = list(filter, select)
+          events = event_list.events
+
+          while skip_token = event_list.skip_token do
+            event_list = list(filter, select, skip_token)
+            events += event_list.events
+          end
+          events
         end
 
         private
 
-        def build_url(filter = nil, select = nil)
+        def build_url(filter = nil, select = nil, skip_token = nil)
           sub_id = armrest_configuration.subscription_id
 
           url =
@@ -61,6 +112,7 @@ module Azure
           url << "?api-version=#{@api_version}"
           url << "&$filter=#{filter}" if filter
           url << "&$select=#{select}" if select
+          url << "&$skipToken=#{skip_token}" if skip_token
 
           url
         end

--- a/lib/azure/armrest/model/base_model.rb
+++ b/lib/azure/armrest/model/base_model.rb
@@ -192,6 +192,15 @@ module Azure
     module Insights
       class Alert < BaseModel; end
       class Event < BaseModel; end
+      class EventList
+        attr_accessor :skip_token
+        attr_accessor :events
+
+        def initialize(events, skip_token = nil)
+          @events = events
+          @skip_token = skip_token
+        end
+      end
     end
 
     module Network

--- a/spec/insights_event_service_spec.rb
+++ b/spec/insights_event_service_spec.rb
@@ -25,5 +25,46 @@ describe "Insights::EventService" do
     it "defines a list method" do
       expect(ies).to respond_to(:list)
     end
+
+    it "defines a list_all method" do
+      expect(ies).to respond_to(:list_all)
+    end
+  end
+
+  context "paging support" do
+    let(:response_bodies) do
+      [
+        '{"value":[{"channels":"one"}],"nextlink":"https://example.com?skipToken=123"}',
+        '{"value":[{"channels":"two"},{"channels":"two"}],"nextlink":"https://example.com?skipToken=456"}',
+        '{"value":[{"channels":"three"},{"channels":"three"},{"channels":"three"}]}'
+      ]
+    end
+
+    it "returns a single page of results" do
+      response = double()
+      expect(response).to receive(:body) { response_bodies.first }
+
+      expect(ies).to receive(:rest_get).and_return(response)
+
+      event_list = ies.list
+
+      expect(event_list.events.first.channels).to eq("one")
+      expect(event_list.events.size).to eq(1)
+      expect(event_list.skip_token).to eq("123")
+    end
+
+    it "returns all the pages of results" do
+      responses = [double(), double(), double()]
+      responses.each_with_index do |response, index|
+        expect(response).to receive(:body) { response_bodies[index] }
+      end
+
+      expect(ies).to receive(:rest_get).and_return(*responses)
+
+      events = ies.list_all
+
+      expect(events.first.channels).to eq("one")
+      expect(events.last.channels).to eq("three")
+    end
   end
 end


### PR DESCRIPTION
* add new `event_list` model that captures the list of the `events` and the `skip_token` if the list of events exceeds the API threshold (which is currently 200 events)
* return `event_list` model from `EventService#list` method
* add new `EventService#list_all` method to return all `events` matching the given `filter` and `select`ion by gathering all the pages of results and concatenating them together
* specs

@djberg96, @bzwei please review
/cc @Fryguy 