### PR TITLE
EventService - Changed 'nextlink' property on REST response to 'nextLink'

### DIFF
--- a/lib/azure/armrest/insights/event_service.rb
+++ b/lib/azure/armrest/insights/event_service.rb
@@ -49,7 +49,7 @@ module Azure
           json_response = JSON.parse(response.body)
 
           events          = json_response['value'].map{ |e| Azure::Armrest::Insights::Event.new(e) }
-          next_link       = json_response['nextlink']
+          next_link       = json_response['nextLink']
           next_skip_token = next_link[/.*?skipToken=(.*?)$/, 1] if next_link
           Azure::Armrest::Insights::EventList.new(events, next_skip_token)
         end

--- a/spec/insights_event_service_spec.rb
+++ b/spec/insights_event_service_spec.rb
@@ -34,8 +34,8 @@ describe "Insights::EventService" do
   context "paging support" do
     let(:response_bodies) do
       [
-        '{"value":[{"channels":"one"}],"nextlink":"https://example.com?skipToken=123"}',
-        '{"value":[{"channels":"two"},{"channels":"two"}],"nextlink":"https://example.com?skipToken=456"}',
+        '{"value":[{"channels":"one"}],"nextLink":"https://example.com?skipToken=123"}',
+        '{"value":[{"channels":"two"},{"channels":"two"}],"nextLink":"https://example.com?skipToken=456"}',
         '{"value":[{"channels":"three"},{"channels":"three"},{"channels":"three"}]}'
       ]
     end


### PR DESCRIPTION
Turns out the 'nextLink' property on the REST response for events is case sensitive, this PR changes 'nextlink' to 'nextLink'.
Also updated specs.