### PR TITLE
Deal with all-caps response keys.

### DIFF
--- a/lib/azure/armrest/model/base_model.rb
+++ b/lib/azure/armrest/model/base_model.rb
@@ -1,3 +1,5 @@
+require 'active_support/core_ext/string/inflections'
+
 module Azure
   module Armrest
     # Base class for JSON wrapper classes. Each Service class should have
@@ -114,7 +116,7 @@ module Azure
         __getobj__[key] = val
 
         return if key_exists
-        add_accessor_methods(snake_case(key), key)
+        add_accessor_methods(key.to_s.underscore, key)
       end
 
       protected
@@ -130,7 +132,8 @@ module Azure
         @hashobj = obj
         excl_list = self.class.send(:excl_list)
         obj.each do |key, value|
-          snake = snake_case(key)
+          snake = key.to_s.underscore
+
           unless excl_list.include?(snake) # Must deal with nested models
             if value.kind_of?(Array)
               newval = value.map { |elem| elem.kind_of?(Hash) ? nested_object(snake.camelize.singularize, elem) : elem }
@@ -153,13 +156,9 @@ module Azure
       end
 
       def add_accessor_methods(method, key)
-        method.prepend('_') if methods.include?(method.to_sym)
+        method = "_#{method}" if methods.include?(method.to_sym)
         instance_eval { define_singleton_method(method) { __getobj__[key] } }
         instance_eval { define_singleton_method("#{method}=") { |val| __getobj__[key] = val } }
-      end
-
-      def snake_case(name)
-        name.to_s.gsub(/(.)([A-Z])/, '\1_\2').downcase
       end
     end
 

--- a/spec/models/base_model_spec.rb
+++ b/spec/models/base_model_spec.rb
@@ -147,6 +147,21 @@ describe "BaseModel" do
       expect(base.temp_stuff).to eq('hi')
       expect(base.tempStuff).to eq('hello')
     end
+
+    it "handles all-caps keys as expected" do
+      json = {'TIMESTAMP' => 123}
+      base = Azure::Armrest::BaseModel.new(json)
+      expect(base).to respond_to(:timestamp)
+    end
+
+    it "handles a mix of lowercase and all-caps keys as expected" do
+      json = {'TIMESTAMP' => 123, 'timestamp' => 456}
+      base = Azure::Armrest::BaseModel.new(json)
+      expect(base).to respond_to(:timestamp)
+      expect(base.timestamp).to eq(123)
+      expect(base).to respond_to(:_timestamp)
+      expect(base._timestamp).to eq(456)
+    end
   end
 
   context "dynamic accessors" do


### PR DESCRIPTION
It turns out that when getting table data, the response contains duplicate keys, and this causes our auto-method generation to behave strangely. Apparently, the MS solution to get around duplicate keys was to change the case. For example, you will see this in a parsed json response:

```
{"Timestamp@odata.type"=>"Edm.DateTime", "Timestamp"=>"2016-03-24T17:00:07.671801Z", "Average"=>512583270.4, "Count"=>240, "CounterName"=>"\\Memory\\AvailableMemory","Last"=>512753664.0, "Maximum"=>512753664.0,"Minimum"=>511705088.0, "TIMESTAMP@odata.type"=>"Edm.DateTime", "TIMESTAMP"=>"2016-03-24T16:00:00Z","Total"=>123019984896.0}
```
Notice that "timestamp" and "timestamp@odata.type" appears multiple times, differing only in case. The result for an all caps key like this is that it generates "t_im_es_ta_mp" instead of what we expect.

The proposed solution simply checks to see if the key string is all caps and/or contains a non-alpha character. If true, it downcases and capitalizes before proceeding. The result is that we will get "timestamp" and "_timestamp" as expected.

UPDATE: Dispensed with the original plan and switched to using the String#underscore method, and dispensing with our own snake_case method, since we already require active_support.