### PR TITLE
Modify the Insight::Event list method and approach to skip tokens.

### DIFF
--- a/lib/azure/armrest.rb
+++ b/lib/azure/armrest.rb
@@ -22,6 +22,7 @@ end
 
 require 'azure/armrest/version'
 require 'azure/armrest/exception'
+require 'azure/armrest/armrest_collection'
 require 'azure/armrest/armrest_service'
 require 'azure/armrest/resource_group_based_service'
 require 'azure/armrest/resource_group_based_subservice'

--- a/lib/azure/armrest/armrest_collection.rb
+++ b/lib/azure/armrest/armrest_collection.rb
@@ -1,0 +1,9 @@
+# Custom array class we use in order to track extra attributes
+# on a collection of results.
+module Azure
+  module Armrest
+    class ArmrestCollection < Array
+      attr_accessor :skip_token
+    end
+  end
+end

--- a/lib/azure/armrest/armrest_service.rb
+++ b/lib/azure/armrest/armrest_service.rb
@@ -501,6 +501,12 @@ module Azure
             configuration.api_version
           end
       end
+
+      # Parse the skip token value out of the nextLink attribute from a response.
+      def parse_skip_token(json)
+        return nil unless json['nextLink']
+        json['nextLink'][/.*?skipToken=(.*?)$/i, 1]
+      end
     end # ArmrestService
   end # Armrest
 end # Azure

--- a/lib/azure/armrest/model/base_model.rb
+++ b/lib/azure/armrest/model/base_model.rb
@@ -192,15 +192,6 @@ module Azure
     module Insights
       class Alert < BaseModel; end
       class Event < BaseModel; end
-      class EventList
-        attr_accessor :skip_token
-        attr_accessor :events
-
-        def initialize(events, skip_token = nil)
-          @events = events
-          @skip_token = skip_token
-        end
-      end
       class Metric < BaseModel; end
     end
 

--- a/spec/insights_event_service_spec.rb
+++ b/spec/insights_event_service_spec.rb
@@ -25,10 +25,6 @@ describe "Insights::EventService" do
     it "defines a list method" do
       expect(ies).to respond_to(:list)
     end
-
-    it "defines a list_all method" do
-      expect(ies).to respond_to(:list_all)
-    end
   end
 
   context "paging support" do
@@ -48,8 +44,8 @@ describe "Insights::EventService" do
 
       event_list = ies.list
 
-      expect(event_list.events.first.channels).to eq("one")
-      expect(event_list.events.size).to eq(1)
+      expect(event_list.first.channels).to eq("one")
+      expect(event_list.size).to eq(1)
       expect(event_list.skip_token).to eq("123")
     end
 
@@ -61,7 +57,7 @@ describe "Insights::EventService" do
 
       expect(ies).to receive(:rest_get).and_return(*responses)
 
-      events = ies.list_all
+      events = ies.list(:all => true)
 
       expect(events.first.channels).to eq("one")
       expect(events.last.channels).to eq("three")


### PR DESCRIPTION
Upon further discussion, we decided that we did not like the concept of an EventList class, as it would mean revamping the entire gem to handle skip tokens and lists to match that approach if we wanted to be consistent. Since that would cause serious breakage, this PR takes a different approach.

Within the list method, the last object (only) has the skip_token attribute set. The list_all method then looks for that token on the last object. This required adding the :skip_token attribute to the BaseModel, and modifying the list and list_all methods.

In addition, I added comments to warn users that you can only retrieve events for the last 90 days. Any more than that and you will get an error.

**Update**: we decided to revamp our approach, using a custom collection class (a subclass of Array with a custom attribute) to store the skip token, which the list method returns. We replaced the method prototype for the list method so that it accepts a single hash of options, including an :all option. This obviated the need for a list_all method.