### PR TITLE
Fix and refactor the StorageAccount#table_data method

### DIFF
--- a/lib/azure/armrest/armrest_collection.rb
+++ b/lib/azure/armrest/armrest_collection.rb
@@ -3,7 +3,7 @@
 module Azure
   module Armrest
     class ArmrestCollection < Array
-      attr_accessor :skip_token
+      attr_accessor :continuation_token
     end
   end
 end

--- a/lib/azure/armrest/insights/event_service.rb
+++ b/lib/azure/armrest/insights/event_service.rb
@@ -59,11 +59,11 @@ module Azure
             end
           )
 
-          events.skip_token = parse_skip_token(json_response)
+          events.continuation_token = parse_skip_token(json_response)
 
-          if options[:all] && events.skip_token
-            events.push(*list(options.merge(:skip_token => events.skip_token)))
-            events.skip_token = nil # Clear when finished
+          if options[:all] && events.continuation_token
+            events.push(*list(options.merge(:skip_token => events.continuation_token)))
+            events.continuation_token = nil # Clear when finished
           end
 
           events

--- a/spec/insights_event_service_spec.rb
+++ b/spec/insights_event_service_spec.rb
@@ -46,7 +46,7 @@ describe "Insights::EventService" do
 
       expect(event_list.first.channels).to eq("one")
       expect(event_list.size).to eq(1)
-      expect(event_list.skip_token).to eq("123")
+      expect(event_list.continuation_token).to eq("123")
     end
 
     it "returns all the pages of results" do


### PR DESCRIPTION
This updates the StorageAccount#table_data method, which is currently broken. In addition, it was refactored so that continuation tokens are now supported, and query parsing and string generation is in its own method. I've also updated the documentation.

On a side note, the ArmrestCollection was modified to change the accessor "skip_token" to "continuation_token", because the former implies "$skip" in the query and a String object, which is not necessarily the case. I've updated the EventService class appropriately.