### PR TITLE
Add the custom attribute "subscription_id" to the base model

### DIFF
--- a/lib/azure/armrest/model/base_model.rb
+++ b/lib/azure/armrest/model/base_model.rb
@@ -69,6 +69,12 @@ module Azure
 
       attr_writer :resource_group
 
+      def subscription_id
+        @subscription_id ||= id[/subscriptions\/(.+?)\//i, 1] rescue nil
+      end
+
+      attr_writer :subscription_id
+
       def to_h
         @hash
       end

--- a/lib/azure/armrest/model/base_model.rb
+++ b/lib/azure/armrest/model/base_model.rb
@@ -69,8 +69,16 @@ module Azure
 
       attr_writer :resource_group
 
+      # The subscription ID for the given resource.
+      # --
+      # Defer to _subscription_id if object already contains subscription_id method.
+      #
       def subscription_id
-        @subscription_id ||= id[/subscriptions\/(.+?)\//i, 1] rescue nil
+        if respond_to?(:_subscription_id)
+          @subscription_id ||= _subscription_id
+        else
+          @subscription_id ||= id[/subscriptions\/([\w+-]+)\/?/i, 1] rescue nil
+        end
       end
 
       attr_writer :subscription_id

--- a/spec/models/base_model_spec.rb
+++ b/spec/models/base_model_spec.rb
@@ -52,6 +52,17 @@ describe "BaseModel" do
       base = Azure::Armrest::BaseModel.new(json)
       expect(base.resource_group).to eq('foo')
     end
+
+    it "defines a subscription_id method that returns nil by default" do
+      expect(base).to respond_to(:subscription_id)
+      expect(base.subscription_id).to eq(nil)
+    end
+
+    it "returns the expected value for the subscription_id method" do
+      json = {:id => '/foo/bar/subscriptions/123-456/resourceGroups/foo/x/y/z'}
+      base = Azure::Armrest::BaseModel.new(json)
+      expect(base.subscription_id).to eq('123-456')
+    end
   end
 
   context "reserved hashes" do

--- a/spec/models/base_model_spec.rb
+++ b/spec/models/base_model_spec.rb
@@ -58,8 +58,14 @@ describe "BaseModel" do
       expect(base.subscription_id).to eq(nil)
     end
 
-    it "returns the expected value for the subscription_id method" do
+    it "returns the expected value for the subscription_id method for normal path" do
       json = {:id => '/foo/bar/subscriptions/123-456/resourceGroups/foo/x/y/z'}
+      base = Azure::Armrest::BaseModel.new(json)
+      expect(base.subscription_id).to eq('123-456')
+    end
+
+    it "returns the expected value for the subscription_id method for abbreviated path" do
+      json = {:id => '/foo/bar/subscriptions/123-456'}
       base = Azure::Armrest::BaseModel.new(json)
       expect(base.subscription_id).to eq('123-456')
     end


### PR DESCRIPTION
This PR adds the BaseModel#subscription_id method.

This will be useful if you're iterating over resources collected for multiple subscriptions and need to distinguish between subscriptions.