### PR TITLE
Use latest api-version string for StorageAccountService

### DIFF
--- a/lib/azure/armrest/model/base_model.rb
+++ b/lib/azure/armrest/model/base_model.rb
@@ -173,7 +173,14 @@ module Azure
     class ResourceGroup < BaseModel; end
     class ResourceProvider < BaseModel; end
     class Sku < BaseModel; end
+
     class StorageAccount < BaseModel; end
+    class StorageAccountKey < StorageAccount
+      def key1; key_name == 'key1' ? value : nil; end
+      def key2; key_name == 'key2' ? value : nil; end
+      def key; key1 || key2; end
+    end
+
     class Subscription < BaseModel; end
     class Tag < BaseModel; end
     class TemplateDeployment < BaseModel

--- a/spec/models/storage_key_spec.rb
+++ b/spec/models/storage_key_spec.rb
@@ -1,0 +1,41 @@
+########################################################################
+# storage_key_spec.rb
+#
+# Test suite for the Azure::Armrest::StorageAccountKey model class.
+########################################################################
+require 'spec_helper'
+
+describe "StorageAccountKey" do
+  before do
+    @json = '{
+      "keyName":     "key1",
+      "value":       "key1Value",
+      "permissions": "FULL"
+    }'
+  end
+
+  let(:acct_key) { Azure::Armrest::StorageAccountKey.new(@json) }
+
+  context "constructor" do
+    it "returns a StorageAccount class as expected" do
+      expect(acct_key).to be_kind_of(Azure::Armrest::StorageAccountKey)
+    end
+  end
+
+  context "custom methods" do
+    it "defines a key method that returns the expected value" do
+      expect(acct_key).to respond_to(:key)
+      expect(acct_key.key).to eql('key1Value')
+    end
+
+    it "defines a key1 method that returns the expected value" do
+      expect(acct_key).to respond_to(:key1)
+      expect(acct_key.key1).to eql('key1Value')
+    end
+
+    it "defines a key2 method that returns the expected value" do
+      expect(acct_key).to respond_to(:key2)
+      expect(acct_key.key2).to be_nil
+    end
+  end
+end

--- a/spec/storage_account_service_spec.rb
+++ b/spec/storage_account_service_spec.rb
@@ -61,12 +61,20 @@ describe "StorageAccountService" do
       expect(sas).to respond_to(:list_account_keys)
     end
 
+    it "defines a list_account_key_objects method" do
+      expect(sas).to respond_to(:list_account_key_objects)
+    end
+
     it "defines a list_all method" do
       expect(sas).to respond_to(:list_all)
     end
 
-    it "defines a regenerate_storage_account_keys method" do
+    it "defines a regenerate_account_keys method" do
       expect(sas).to respond_to(:regenerate_storage_account_keys)
+    end
+
+    it "defines a regenerate_account_key_objects method" do
+      expect(sas).to respond_to(:regenerate_account_key_objects)
     end
 
     it "defines a list_private_images method" do


### PR DESCRIPTION
In the past we hard coded the api-version string for the StorageAccountService class because certain versions did not work. However, the latest version (2016-01-01) works fine and even provides additional information, so I've removed the '2015-05-01-preview' version setting.

However, this did cause some changes. First and foremost the ```list_account_keys``` and ```regenerate_storage_account_keys``` methods had to be updated since they no longer return a simple hash. Instead, they now return a list of StorageAccountKey objects.

To facilitate backwards compatibility, I've added 3 simple methods to the StorageAccountKey model - the key, key1 and key2 methods. Now, instead of calling ```hash#fetch('key1')```, it's just ```obj.key1``` or even just ```obj.key```, with the latter returning key1 if present, or key2 if key1 is not present.

Luckily I think these are rarely used methods in practice and so this should have little impact out in the world.

Internally, the only other method I found that needed modification was the ```list_private_images``` method, which was a minor one-line modification.

For get/list/create/update, there were some changes in the returned json output. Mostly the fields are the same. However, with the new api-version the additional fields "encryption", "sku", and "kind" are available, while the "properties.accountType" was removed. Instead it is now under "sku.name". So, any instances of ```acct.properties.account_type``` would need to be changed to ```acct.sku.name```. I did not see any instances of that in our cloud provider code, but others might be using it. Worst case, they could always explicitly set the api_version value.

I've also included some basic specs for the StorageAccountKey class.

See https://msdn.microsoft.com/en-us/library/azure/mt163553.aspx for more details.
