### PR TITLE
Remove hard coded api-version string for TemplateDeploymentService

### DIFF
--- a/lib/azure/armrest/template_deployment_service.rb
+++ b/lib/azure/armrest/template_deployment_service.rb
@@ -4,8 +4,6 @@ module Azure
     class TemplateDeploymentService < ResourceGroupBasedService
 
       def initialize(configuration, options = {})
-        # Has to be hard coded for now
-        options = {'api_version' => '2014-04-01-preview'}.merge(options)
         super(configuration, 'deployments', 'Microsoft.Resources', options)
       end
 

--- a/spec/template_deployment_service_spec.rb
+++ b/spec/template_deployment_service_spec.rb
@@ -8,6 +8,7 @@ require 'spec_helper'
 describe "TemplateDeploymentService" do
   before { setup_params }
   let(:tds) { Azure::Armrest::TemplateDeploymentService.new(@conf) }
+  let(:api_version) { tds.api_version }
   let(:url_prefix) { "https://management.azure.com/subscriptions/abc-123-def-456/resourceGroups/groupname/providers/Microsoft.Resources/deployments" }
 
   context "inheritance" do
@@ -25,7 +26,7 @@ describe "TemplateDeploymentService" do
   context "instance methods" do
     it "defines a create method" do
       expected = @req.merge(
-        :url     => url_prefix + "/deployname?api-version=2014-04-01-preview",
+        :url     => url_prefix + "/deployname?api-version=#{api_version}",
         :method  => :put,
         :payload => "{}"
       )
@@ -35,7 +36,7 @@ describe "TemplateDeploymentService" do
 
     it "defines a delete method" do
       expected = @req.merge(
-        :url => url_prefix + "/deployname?api-version=2014-04-01-preview",
+        :url    => url_prefix + "/deployname?api-version=#{api_version}",
         :method => :delete
       )
       expect(RestClient::Request).to receive(:execute).with(expected)
@@ -43,32 +44,32 @@ describe "TemplateDeploymentService" do
     end
 
     it "defines a list_names method" do
-      expected = @req.merge(:url => url_prefix + "?api-version=2014-04-01-preview")
+      expected = @req.merge(:url => url_prefix + "?api-version=#{api_version}")
       expected_return = '{"value":[{"name":"deployname"}]}'
       expect(RestClient::Request).to receive(:execute).with(expected).and_return(expected_return)
       tds.list_names('groupname')
     end
 
     it "defines a list method" do
-      expected = @req.merge(:url => url_prefix + "?api-version=2014-04-01-preview")
+      expected = @req.merge(:url => url_prefix + "?api-version=#{api_version}")
       expect(RestClient::Request).to receive(:execute).with(expected).and_return('{"value":{}}')
       tds.list('groupname')
     end
 
     it "defines a get method" do
-      expected = @req.merge(:url => url_prefix + "/deployname?api-version=2014-04-01-preview")
+      expected = @req.merge(:url => url_prefix + "/deployname?api-version=#{api_version}")
       expect(RestClient::Request).to receive(:execute).with(expected).and_return('{}')
       tds.get('deployname', 'groupname')
     end
 
     it "defines a list_deployment_operations method" do
-      expected = @req.merge(:url => url_prefix + "/deployname/operations?api-version=2014-04-01-preview")
+      expected = @req.merge(:url => url_prefix + "/deployname/operations?api-version=#{api_version}")
       expect(RestClient::Request).to receive(:execute).with(expected).and_return('{"value":{}}')
       tds.list_deployment_operations('deployname', 'groupname')
     end
 
     it "defines a get_deployment_operation method" do
-      expected = @req.merge(:url => url_prefix + "/deployname/operations/opid?api-version=2014-04-01-preview")
+      expected = @req.merge(:url => url_prefix + "/deployname/operations/opid?api-version=#{api_version}")
       expect(RestClient::Request).to receive(:execute).with(expected).and_return('{}')
       tds.get_deployment_operation('opid', 'deployname', 'groupname')
     end


### PR DESCRIPTION
This removes the hard-coded api-version string for TemplateDeploymentService. Our changes in our api-version handler make this unnecessary. The current version is 2016-02-01.

I also updated the specs to use the current api-version string.

As far as I can tell, there have been no changes to the output. I tested all the get and list methods with some basic scripting and they seemed to work fine.