### PR TITLE
Modify the fetch_subscription_id method so that it skips over unauthorized subscriptions

### DIFF
--- a/spec/armrest_service_config_spec.rb
+++ b/spec/armrest_service_config_spec.rb
@@ -61,7 +61,7 @@ describe "ArmrestService" do
 
     it 'finds a subscription id if not given' do
       expect(RestClient::Request).to receive(:execute).exactly(1).times.and_return(token_response)
-      expect(RestClient::Request).to receive(:execute).exactly(1).times.and_return(subscription_response)
+      expect(RestClient::Request).to receive(:execute).exactly(2).times.and_return(subscription_response)
       conf = Azure::Armrest::ArmrestService.configure(options)
       expect(conf.subscription_id).to eql('4f5a544b')
     end


### PR DESCRIPTION
Users will sometimes see "The access token is from the wrong issuer". This can happen if there are multiple AD's (tenants) on the same subscription, but then try to access data from a subscription that belongs to a separate tenant.

In our case the tenant used in the fetch_token method would be mismatched with a subscription picked up in the fetch_subscription_id method.

So, this modifies the fetch_subscription_id method to make a test request (looking for something with a relatively small response - tags) for each subscription. If it's invalid, it skips it and looks for the next one. It breaks out of the loop the first time it finds a valid one that is also enabled.

This will, of course, be a moot point in 0.3.0, but we should fix this for the 0.2.x branch.

