### PR TITLE
Add support for PP

### DIFF
--- a/lib/azure/armrest/model/base_model.rb
+++ b/lib/azure/armrest/model/base_model.rb
@@ -89,11 +89,30 @@ module Azure
         @json
       end
 
+      def inspect_method_list
+        methods(false).reject { |m| m.to_s.end_with?('=') }
+      end
+      private :inspect_method_list
+
       def inspect
-        string = "<#{self.class} "
-        method_list = methods(false).select { |m| !m.to_s.include?('=') }
-        string << method_list.map { |m| "#{m}=#{send(m).inspect}" }.join(', ')
-        string << '>'
+        Kernel.instance_method(:to_s).bind(self).call.chomp!('>') <<
+          ' ' <<
+          inspect_method_list.map { |m| "#{m}=#{send(m).inspect}" }.join(', ') <<
+          '>'
+      end
+
+      def pretty_print(q)
+        q.object_address_group(self) {
+          q.seplist(inspect_method_list, lambda { q.text ',' }) {|v|
+            q.breakable
+            q.text v.to_s
+            q.text '='
+            q.group(1) {
+              q.breakable ''
+              q.pp(send(v))
+            }
+          }
+        }
       end
 
       def ==(other)

--- a/spec/models/base_model_spec.rb
+++ b/spec/models/base_model_spec.rb
@@ -112,8 +112,16 @@ describe "BaseModel" do
     it "defines a custom inspect method" do
       json = {:name => 'test', :age => 33}.to_json
       base = Azure::Armrest::BaseModel.new(json)
-      expected = '<Azure::Armrest::BaseModel name="test", age=33>'
-      expect(base.inspect).to eq(expected)
+      expected = /^#<Azure::Armrest::BaseModel:0x\h+ name="test", age=33>$/
+      expect(base.inspect).to match(expected)
+    end
+
+    it "defines a pretty_print method when pp is available" do
+      require 'pp'
+      json = {:name => 'test', :age => 33, :array => ["stuff"]}.to_json
+      base = Azure::Armrest::BaseModel.new(json)
+      expected = /^#<Azure::Armrest::BaseModel:0x\h+\n name="test",\n age=33,\n array=\["stuff"\]>$/
+      expect(base.pretty_inspect).to match(expected)
     end
   end
 


### PR DESCRIPTION
Because the `inspect` method was overridden, Ruby's PP module (and by extension `pry`'s pretty printer) would not pretty print any objects properly, instead leaving them on a single line which is hard to use.  This PR allows PP to work properly.

Before:

```ruby
$ bundle exec irb -Ilib -r"azure-armrest" -rpp
irb(main):001:0> o = Azure::Armrest::BaseModel.new({:name => 'test', :age => 33, :array => ["stuff"]}.to_json)
=> <Azure::Armrest::BaseModel name="test", age=33, array=["stuff"]>
irb(main):002:0> pp o
<Azure::Armrest::BaseModel name="test", age=33, array=["stuff"]>
=> <Azure::Armrest::BaseModel name="test", age=33, array=["stuff"]>
```

After

```ruby
$ bundle exec irb -Ilib -r"azure-armrest" -rpp
irb(main):001:0> o = Azure::Armrest::BaseModel.new({:name => 'test', :age => 33, :array => ["stuff"]}.to_json)
=> #<Azure::Armrest::BaseModel:0x007fe3b5282d28 name="test", age=33, array=["stuff"]>
irb(main):002:0> pp o
#<Azure::Armrest::BaseModel:0x007fe3b5282d28
 name="test",
 age=33,
 array=["stuff"]>
=> #<Azure::Armrest::BaseModel:0x007fe3b5282d28 name="test", age=33, array=["stuff"]>
```