### PR TITLE
Hide cache methods in Configuration class

### DIFF
--- a/lib/azure/armrest/armrest_service.rb
+++ b/lib/azure/armrest/armrest_service.rb
@@ -47,9 +47,7 @@ module Azure
       # Returns a list of the available resource providers. This is really
       # just a wrapper for Azure::Armrest::Configuration#providers.
       #
-      def list_providers
-        configuration.providers
-      end
+      delegate :list_providers, :to => :configuration
 
       alias providers list_providers
       deprecate :providers, :list_providers, 2018, 1
@@ -282,13 +280,9 @@ module Azure
       # cannot be determined
       def set_service_api_version(options, service)
         @api_version =
-          if options.has_key?('api_version')
-            options['api_version']
-          elsif Azure::Armrest::Configuration.provider_version_cache[provider.downcase]
-            Azure::Armrest::Configuration.provider_version_cache[provider.downcase][service.downcase]
-          else
-            configuration.api_version
-          end
+          options['api_version'] ||
+          configuration.provider_default_api_version(provider, service) ||
+          configuration.api_version
       end
 
       # Parse the skip token value out of the nextLink attribute from a response.

--- a/lib/azure/armrest/virtual_machine_service.rb
+++ b/lib/azure/armrest/virtual_machine_service.rb
@@ -21,13 +21,11 @@ module Azure
       #
       def series(location)
         namespace = 'microsoft.compute'
-        resource_hash = Azure::Armrest::Configuration.provider_version_cache[namespace]
+        version = configuration.provider_default_api_version(namespace, 'locations/vmsizes')
 
-        unless resource_hash
+        unless version
           raise ArgumentError, "Unable to find resources for #{namespace}"
         end
-
-        version = resource_hash['locations/vmsizes']
 
         url = url_with_api_version(
           version, @base_url, 'subscriptions', configuration.subscription_id,

--- a/spec/armrest_service_spec.rb
+++ b/spec/armrest_service_spec.rb
@@ -5,135 +5,91 @@
 ########################################################################
 require 'spec_helper'
 
-describe "ArmrestService" do
-  before(:each) { setup_params }
+describe Azure::Armrest::ArmrestService do
+  before { setup_params }
 
-  let(:arm) { Azure::Armrest::ArmrestService.new(@conf, 'servicename', 'provider', {}) }
+  subject { described_class.new(@conf, 'servicename', 'provider', {}) }
 
   context "constructor" do
     it "returns an armrest service instance as expected" do
-      expect(arm).to be_kind_of(Azure::Armrest::ArmrestService)
+      expect(subject).to be_kind_of(Azure::Armrest::ArmrestService)
     end
   end
 
   context "instance methods" do
     it "defines a locations method" do
-      expect(arm).to respond_to(:locations)
+      expect(subject).to respond_to(:locations)
     end
 
     it "defines a providers method" do
-      expect(arm).to respond_to(:providers)
+      expect(subject).to respond_to(:providers)
     end
 
     it "defines a provider_info method" do
-      expect(arm).to respond_to(:provider_info)
+      expect(subject).to respond_to(:provider_info)
     end
 
     it "defines a provider_info alias for get_provider" do
-      expect(arm).to respond_to(:provider_info)
+      expect(subject).to respond_to(:provider_info)
     end
 
     it "defines a resources method" do
-      expect(arm).to respond_to(:resources)
+      expect(subject).to respond_to(:resources)
     end
 
     it "defines a resource_groups method" do
-      expect(arm).to respond_to(:resource_groups)
+      expect(subject).to respond_to(:resource_groups)
     end
 
     it "defines a subscriptions method" do
-      expect(arm).to respond_to(:subscriptions)
+      expect(subject).to respond_to(:subscriptions)
     end
 
     it "defines a subscription_info method" do
-      expect(arm).to respond_to(:subscription_info)
+      expect(subject).to respond_to(:subscription_info)
     end
 
     it "defines a tags method" do
-      expect(arm).to respond_to(:tags)
+      expect(subject).to respond_to(:tags)
     end
 
     it "defines a tenants method" do
-      expect(arm).to respond_to(:tenants)
+      expect(subject).to respond_to(:tenants)
     end
   end
 
   context "accessors" do
-    it "defines a subscription_id accessor" do
-      expect(arm.armrest_configuration).to respond_to(:subscription_id)
-      expect(arm.armrest_configuration).to respond_to(:subscription_id=)
-      expect(arm.armrest_configuration.subscription_id).to eq(@sub)
-    end
-
-    it "defines a resource_group accessor" do
-      expect(arm.armrest_configuration).to respond_to(:resource_group)
-      expect(arm.armrest_configuration).to respond_to(:resource_group=)
-      expect(arm.armrest_configuration.resource_group).to eq(@res)
-    end
-
-    it "defines a api_version accessor" do
-      expect(arm.armrest_configuration).to respond_to(:api_version)
-      expect(arm.armrest_configuration).to respond_to(:api_version=)
-      expect(arm.armrest_configuration.api_version).to eq(@ver)
-    end
-
     it "defines a base_url accessor" do
-      expect(arm).to respond_to(:base_url)
-      expect(arm).to respond_to(:base_url=)
-      expect(arm.base_url).to eq(Azure::Armrest::RESOURCE)
-    end
-
-    it "defines a token accessor" do
-      expect(arm.armrest_configuration).to respond_to(:token)
-      expect(arm.armrest_configuration).to respond_to(:token=)
-      expect(arm.armrest_configuration.token).to eq(@tok)
-    end
-
-    it "defines a content_type reader" do
-      expect(arm.armrest_configuration).to respond_to(:content_type)
-      expect(arm.armrest_configuration.content_type).to eq('application/json')
-    end
-
-    it "defines a grant_type reader" do
-      expect(arm.armrest_configuration).to respond_to(:grant_type)
-      expect(arm.armrest_configuration.grant_type).to eq('client_credentials')
-    end
-
-    it "defines an ssl_verify accessor" do
-      expect(arm.armrest_configuration).to respond_to(:ssl_verify)
-      expect(arm.armrest_configuration.ssl_verify).to be_nil
-    end
-
-    it "defines an ssl_version accessor" do
-      expect(arm.armrest_configuration).to respond_to(:ssl_version)
-      expect(arm.armrest_configuration.ssl_version).to eq('TLSv1')
+      expect(subject).to respond_to(:base_url)
+      expect(subject).to respond_to(:base_url=)
+      expect(subject.base_url).to eq(Azure::Armrest::RESOURCE)
     end
   end
 
   context "api exception handling" do
     it "converts exception from rest_get" do
       expect(RestClient::Request).to receive(:execute).and_raise(RestClient::Exception.new)
-      expect { Azure::Armrest::ArmrestService.send(:rest_get, :url => '') }.to raise_error(Azure::Armrest::ApiException)
+      expect { described_class.send(:rest_get, :url => '') }.to raise_error(Azure::Armrest::ApiException)
     end
 
     it "converts exception from rest_put" do
       expect(RestClient::Request).to receive(:execute).and_raise(RestClient::Exception.new)
-      expect { Azure::Armrest::ArmrestService.send(:rest_put, :url => '', :body => '') }.to raise_error(Azure::Armrest::ApiException)
+      expect { described_class.send(:rest_put, :url => '', :body => '') }.to raise_error(Azure::Armrest::ApiException)
     end
 
     it "converts exception from rest_post" do
       expect(RestClient::Request).to receive(:execute).and_raise(RestClient::Exception.new)
-      expect { Azure::Armrest::ArmrestService.send(:rest_post, :url => '', :body => '') }.to raise_error(Azure::Armrest::ApiException)
+      expect { described_class.send(:rest_post, :url => '', :body => '') }.to raise_error(Azure::Armrest::ApiException)
     end
 
     it "converts exception from rest_patch" do
       expect(RestClient::Request).to receive(:execute).and_raise(RestClient::Exception.new)
-      expect { Azure::Armrest::ArmrestService.send(:rest_patch, :url => '', :body => '') }.to raise_error(Azure::Armrest::ApiException)
+      expect { described_class.send(:rest_patch, :url => '', :body => '') }.to raise_error(Azure::Armrest::ApiException)
     end
 
     it "converts exception from rest_delete" do
       expect(RestClient::Request).to receive(:execute).and_raise(RestClient::Exception.new)
-      expect { Azure::Armrest::ArmrestService.send(:rest_delete, :url => '') }.to raise_error(Azure::Armrest::ApiException)
+      expect { described_class.send(:rest_delete, :url => '') }.to raise_error(Azure::Armrest::ApiException)
     end
   end
 end


### PR DESCRIPTION
Previously the whole caches are exposed. Now only provide query methods
to access cached data (for api-version and token)