### PR TITLE
Remove storage account type validation and related specs.

### DIFF
--- a/lib/azure/armrest/storage_account_service.rb
+++ b/lib/azure/armrest/storage_account_service.rb
@@ -4,15 +4,6 @@ module Azure
   module Armrest
     # Class for managing storage accounts.
     class StorageAccountService < ResourceGroupBasedService
-
-      # Valid account types for the create or update method.
-      VALID_ACCOUNT_TYPES = %w[
-        Standard_LRS
-        Standard_ZRS
-        Standard_GRS
-        Standard_RAGRS
-      ]
-
       # Creates and returns a new StorageAccountService (SAS) instance.
       #
       def initialize(configuration, options = {})
@@ -89,7 +80,6 @@ module Azure
       #
       def create(account_name, rgroup = configuration.resource_group, options)
         validating = options.delete(:validating)
-        validate_account_type(options[:properties][:accountType])
         validate_account_name(account_name)
 
         acct = super(account_name, rgroup, options) do |url|
@@ -283,12 +273,6 @@ module Azure
         end
 
         hash
-      end
-
-      def validate_account_type(account_type)
-        unless VALID_ACCOUNT_TYPES.include?(account_type)
-          raise ArgumentError, "invalid account type '#{account_type}'"
-        end
       end
 
       def validate_account_name(name)

--- a/spec/storage_account_service_spec.rb
+++ b/spec/storage_account_service_spec.rb
@@ -21,14 +21,6 @@ describe "StorageAccountService" do
     end
   end
 
-  context "constants" do
-    it "defines VALID_ACCOUNT_TYPES" do
-      expect(Azure::Armrest::StorageAccountService::VALID_ACCOUNT_TYPES).not_to be_nil
-      expect(Azure::Armrest::StorageAccountService::VALID_ACCOUNT_TYPES).to be_a_kind_of(Array)
-      expect(Azure::Armrest::StorageAccountService::VALID_ACCOUNT_TYPES.size).to eql(4)
-    end
-  end
-
   context "accessors" do
     it "defines a base_url accessor" do
       expect(sas).to respond_to(:base_url)
@@ -95,11 +87,6 @@ describe "StorageAccountService" do
       options = {:location => "West US", :properties => {:accountType => "Standard_GRS"}}
       expect { sas.create("xx", @res, options) }.to raise_error(ArgumentError)
       expect { sas.create("^&123***", @res, options) }.to raise_error(ArgumentError)
-    end
-
-    it "requires a valid account type" do
-      options = {:location => "West US", :properties => {:accountType => "bogus"}}
-      expect { sas.create("test", @res, options) }.to raise_error(ArgumentError)
     end
   end
 


### PR DESCRIPTION
An API change on the MS side has broken the validation for accountType because the request body has changed as of 2016-01-01.

Upon further review, I think it was misguided anyway. It is up to the users to know which account type they want, and the request response will contain an appropriate error message if it's invalid.