### PR TITLE
Rename clear_caches to clear_token_cache, and update specs.

### DIFF
--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -174,7 +174,7 @@ describe Azure::Armrest::Configuration do
 
   context 'singletons' do
     before do
-      Azure::Armrest::Configuration.clear_caches
+      Azure::Armrest::Configuration.clear_token_cache
     end
 
     context 'cache_token' do
@@ -193,7 +193,7 @@ describe Azure::Armrest::Configuration do
       end
 
       it 'allows to clear caches' do
-        described_class.clear_caches
+        described_class.clear_token_cache
 
         retrieved_token, retrieved_expiration = described_class.retrieve_token(config_copy)
 


### PR DESCRIPTION
Since we only have one class level cache now, the `clear_caches` method is a bit of a misnomer. This just renames it to `clear_token_cache`. It also creates an alias for backwards compatibility, as well as a deprecation notice.

I used the `class << self` syntax, since it's easier to alias singleton methods that way, and gets rid of `self` everywhere, but can undo that if that style is not preferred.