### PR TITLE
Fix delegation bug

### DIFF
--- a/lib/azure/armrest/armrest_service.rb
+++ b/lib/azure/armrest/armrest_service.rb
@@ -47,7 +47,7 @@ module Azure
       # Returns a list of the available resource providers. This is really
       # just a wrapper for Azure::Armrest::Configuration#providers.
       #
-      delegate :list_providers, :to => :configuration
+      delegate :providers, :to => :configuration, :prefix => :list
 
       alias providers list_providers
       deprecate :providers, :list_providers, 2018, 1

--- a/spec/armrest_service_spec.rb
+++ b/spec/armrest_service_spec.rb
@@ -58,6 +58,14 @@ describe Azure::Armrest::ArmrestService do
     end
   end
 
+  context "delegated methods" do
+    it "delegates the providers method to Azure::Armrest::Configuration" do
+      expect(subject).to respond_to(:providers)
+      expect(subject.providers).to be_kind_of(Array)
+      expect(subject.providers.first).to be_kind_of(Azure::Armrest::ResourceProvider)
+    end
+  end
+
   context "accessors" do
     it "defines a base_url accessor" do
       expect(subject).to respond_to(:base_url)


### PR DESCRIPTION
This addresses https://github.com/ManageIQ/azure-armrest/issues/172

Basically, we can't delegate "list_providers" because that method doesn't exist in the Configuration class, and it wouldn't make sense to rename it, since it's just an instance variable.

I know we wanted to be consistent with the naming, but I think we should let this one slide. Also, it's how the current API works, so there's no breakage.