### PR TITLE
Delegate the hash method, and create an 'as_cache_key' alias

### DIFF
--- a/lib/azure/armrest/armrest_service.rb
+++ b/lib/azure/armrest/armrest_service.rb
@@ -52,6 +52,10 @@ module Azure
       alias providers list_providers
       deprecate :providers, :list_providers, 2018, 1
 
+      # Need an "as_cache_key" method for the cache_method library interface.
+      delegate :hash, :to => :configuration
+      alias as_cache_key hash
+
       # Returns information about the specific provider +namespace+.
       #
       def get_provider(provider)


### PR DESCRIPTION
The cache_method library requires an `as_cache_key` method to work as part of its interface. We forgot about that, and we also changed the method name to `hash`.

This delegates the `hash` method to the configuration object in the base class, and creates an `as_cache_key` alias so that `cache_method` will work.

Addresses: https://github.com/ManageIQ/azure-armrest/issues/177