### PR TITLE
Modify the ResourceGroupBasedService to return ArmrestCollection objects.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /pkg/
 /spec/reports/
 /tmp/
+/futz/

--- a/lib/azure/armrest/armrest_collection.rb
+++ b/lib/azure/armrest/armrest_collection.rb
@@ -4,6 +4,38 @@ module Azure
   module Armrest
     class ArmrestCollection < Array
       attr_accessor :continuation_token
+      attr_accessor :response_headers
+
+      # Creates and returns a ArmrestCollection object based on JSON input,
+      # using +klass+ to generate the list elements. In addition, both the
+      # response headers and continuation token are set.
+      #
+      # You may optionally pass a plain array instead, in which case you
+      # get back an array re-wrapped as an ArmrestCollection object, but
+      # the response_headers and continuation_token properties are not set
+      # automatically.
+      #
+      def initialize(response, klass = nil)
+        if response.kind_of?(Array)
+          super(response)
+        else
+          json_response = JSON.parse(response)
+          @response_headers = response.headers
+          @continuation_token = parse_skip_token(json_response)
+          super(json_response['value'].map { |hash| klass.new(hash) })
+        end
+      end
+
+      alias skip_token continuation_token
+      alias skip_token= continuation_token=
+
+      private
+
+      # Parse the skip token value out of the nextLink attribute from a response.
+      def parse_skip_token(json)
+        return nil unless json['nextLink']
+        json['nextLink'][/.*?skipToken=(.*?)$/i, 1]
+      end
     end
   end
 end

--- a/lib/azure/armrest/armrest_collection.rb
+++ b/lib/azure/armrest/armrest_collection.rb
@@ -6,35 +6,31 @@ module Azure
       attr_accessor :continuation_token
       attr_accessor :response_headers
 
-      # Creates and returns a ArmrestCollection object based on JSON input,
-      # using +klass+ to generate the list elements. In addition, both the
-      # response headers and continuation token are set.
-      #
-      # You may optionally pass a plain array instead, in which case you
-      # get back an array re-wrapped as an ArmrestCollection object, but
-      # the response_headers and continuation_token properties are not set
-      # automatically.
-      #
-      def initialize(response, klass = nil)
-        if response.kind_of?(Array)
-          super(response)
-        else
-          json_response = JSON.parse(response)
-          @response_headers = response.headers
-          @continuation_token = parse_skip_token(json_response)
-          super(json_response['value'].map { |hash| klass.new(hash) })
-        end
-      end
-
       alias skip_token continuation_token
       alias skip_token= continuation_token=
 
-      private
+      class << self
+        # Creates and returns a ArmrestCollection object based on JSON input,
+        # using +klass+ to generate the list elements. In addition, both the
+        # response headers and continuation token are set.
+        #
+        def create_from_response(response, klass = nil)
+          json_response = JSON.parse(response)
+          array = new(json_response['value'].map { |hash| klass.new(hash) })
 
-      # Parse the skip token value out of the nextLink attribute from a response.
-      def parse_skip_token(json)
-        return nil unless json['nextLink']
-        json['nextLink'][/.*?skipToken=(.*?)$/i, 1]
+          array.response_headers = response.headers
+          array.continuation_token = parse_skip_token(json_response)
+
+          array
+        end
+
+        private
+
+        # Parse the skip token value out of the nextLink attribute from a response.
+        def parse_skip_token(json)
+          return nil unless json['nextLink']
+          json['nextLink'][/.*?skipToken=(.*?)$/i, 1]
+        end
       end
     end
   end

--- a/lib/azure/armrest/exception.rb
+++ b/lib/azure/armrest/exception.rb
@@ -42,6 +42,5 @@ module Azure
     class GatewayTimeoutException < ApiException; end
 
     class TooManyRequestsException < ApiException; end
-
   end
 end

--- a/lib/azure/armrest/insights/event_service.rb
+++ b/lib/azure/armrest/insights/event_service.rb
@@ -53,7 +53,7 @@ module Azure
           response = rest_get(url)
 
           klass  = Azure::Armrest::Insights::Event
-          events = Azure::Armrest::ArmrestCollection.new(response, klass)
+          events = Azure::Armrest::ArmrestCollection.create_from_response(response, klass)
 
           if options[:all] && events.continuation_token
             events.push(*list(options.merge(:skip_token => events.continuation_token)))

--- a/lib/azure/armrest/insights/event_service.rb
+++ b/lib/azure/armrest/insights/event_service.rb
@@ -44,22 +44,16 @@ module Azure
         #   filter = "eventTimestamp ge #{date} and eventChannels eq 'Admin, Operation'"
         #   select = "resourceGroupName, operationName"
         #
-        #   ies.list(:filter => filter, :select => select, :all => true).events.each{ |event|
+        #   ies.list(:filter => filter, :select => select, :all => true).each{ |event|
         #     p event
         #   }
         #
         def list(options = {})
           url = build_url(options)
           response = rest_get(url)
-          json_response = JSON.parse(response.body)
 
-          events = ArmrestCollection.new(
-            json_response['value'].map do |hash|
-              Azure::Armrest::Insights::Event.new(hash)
-            end
-          )
-
-          events.continuation_token = parse_skip_token(json_response)
+          klass  = Azure::Armrest::Insights::Event
+          events = Azure::Armrest::ArmrestCollection.new(response, klass)
 
           if options[:all] && events.continuation_token
             events.push(*list(options.merge(:skip_token => events.continuation_token)))

--- a/lib/azure/armrest/model/base_model.rb
+++ b/lib/azure/armrest/model/base_model.rb
@@ -22,6 +22,8 @@ module Azure
 
       attr_hash :tags
 
+      attr_accessor :response_headers
+
       # Constructs and returns a new JSON wrapper class. Pass in a plain
       # JSON string and it will automatically give you accessor methods
       # that make it behave like a typical Ruby object. You may also pass

--- a/lib/azure/armrest/model/storage_account.rb
+++ b/lib/azure/armrest/model/storage_account.rb
@@ -21,7 +21,7 @@ module Azure
       class TableData < BaseModel; end
 
       # The version string used in headers sent as part any internal http
-      # request. The default is 2015-02-21.
+      # request. The default is 2015-12-11.
       attr_accessor :storage_api_version
 
       # An http proxy to use per request. Defaults to ENV['http_proxy'] if set.
@@ -35,7 +35,7 @@ module Azure
 
       def initialize(json)
         super
-        @storage_api_version = '2015-02-21'
+        @storage_api_version = '2015-12-11'
         @proxy = ENV['http_proxy']
         @ssl_version = 'TLSv1'
         @ssl_verify = nil
@@ -99,11 +99,12 @@ module Azure
         key ||= properties.key1
 
         query = build_query(options)
-
         response = table_response(key, query, name)
-        json_response = JSON.parse(response.body)
 
-        data = ArmrestCollection.new(json_response['value'].map { |t| TableData.new(t) })
+        klass = Azure::Armrest::StorageAccount::TableData
+        data  = Azure::Armrest::ArmrestCollection.new(response, klass)
+
+        # Continuation tokens are parsed differently for storage
         data.continuation_token = parse_continuation_tokens(response)
 
         if options[:all] && data.continuation_token

--- a/lib/azure/armrest/model/storage_account.rb
+++ b/lib/azure/armrest/model/storage_account.rb
@@ -102,7 +102,7 @@ module Azure
         response = table_response(key, query, name)
 
         klass = Azure::Armrest::StorageAccount::TableData
-        data  = Azure::Armrest::ArmrestCollection.new(response, klass)
+        data  = Azure::Armrest::ArmrestCollection.create_from_response(response, klass)
 
         # Continuation tokens are parsed differently for storage
         data.continuation_token = parse_continuation_tokens(response)

--- a/lib/azure/armrest/resource_group_based_service.rb
+++ b/lib/azure/armrest/resource_group_based_service.rb
@@ -46,7 +46,7 @@ module Azure
         url = yield(url) || url if block_given?
         response = rest_get(url)
 
-        Azure::Armrest::ArmrestCollection.new(response, model_class)
+        Azure::Armrest::ArmrestCollection.create_from_response(response, model_class)
       end
 
       # Use a single call to get all resources for the service. You may
@@ -63,7 +63,7 @@ module Azure
         url = yield(url) || url if block_given?
 
         response = rest_get(url)
-        results  = Azure::Armrest::ArmrestCollection.new(response, model_class)
+        results  = Azure::Armrest::ArmrestCollection.create_from_response(response, model_class)
 
         filter.empty? ? results : results.select { |obj| filter.all? { |k, v| obj.public_send(k) == v } }
       end

--- a/lib/azure/armrest/resource_group_based_service.rb
+++ b/lib/azure/armrest/resource_group_based_service.rb
@@ -2,6 +2,17 @@ module Azure
   module Armrest
     # Base class for services that need to run in a resource group
     class ResourceGroupBasedService < ArmrestService
+      # Create a resource +name+ within the resource group +rgroup+, or the
+      # resource group that was specified in the configuration, along with
+      # a hash of appropriate +options+.
+      #
+      # Returns an instance of the object that was created if possible,
+      # otherwise nil is returned.
+      #
+      # Note that this is an asynchronous operation. You can check the current
+      # status of the resource by inspecting the :response_headers instance and
+      # polling either the :azure_asyncoperation or :location URL.
+      #
       def create(name, rgroup = configuration.resource_group, options = {})
         validate_resource_group(rgroup)
         validate_resource(name)
@@ -9,18 +20,33 @@ module Azure
         url = build_url(rgroup, name)
         url = yield(url) || url if block_given?
         response = rest_put(url, options.to_json)
-        model_class.new(response) unless response.empty?
+
+        obj = nil
+
+        unless response.empty?
+          obj = model_class.new(response.body)
+          obj.response_headers = Azure::Armrest::ResponseHeaders.new(response.headers)
+        end
+
+        obj
       end
 
       alias update create
 
+      # List all resources within the resource group +rgroup+, or the
+      # resource group that was specified in the configuration.
+      #
+      # Returns an ArmrestCollection, with the response headers set
+      # for the operation as a whole.
+      #
       def list(rgroup = configuration.resource_group)
         validate_resource_group(rgroup)
 
         url = build_url(rgroup)
         url = yield(url) || url if block_given?
         response = rest_get(url)
-        JSON.parse(response)['value'].map { |hash| model_class.new(hash) }
+
+        Azure::Armrest::ArmrestCollection.new(response, model_class)
       end
 
       # Use a single call to get all resources for the service. You may
@@ -35,11 +61,16 @@ module Azure
       def list_all(filter = {})
         url = build_url
         url = yield(url) || url if block_given?
+
         response = rest_get(url)
-        results = JSON.parse(response)['value'].map { |hash| model_class.new(hash) }
+        results  = Azure::Armrest::ArmrestCollection.new(response, model_class)
+
         filter.empty? ? results : results.select { |obj| filter.all? { |k, v| obj.public_send(k) == v } }
       end
 
+      # Get information about a single resource +name+ within resource group
+      # +rgroup+, or the resource group that was set in the configuration.
+      #
       def get(name, rgroup = configuration.resource_group)
         validate_resource_group(rgroup)
         validate_resource(name)
@@ -47,7 +78,11 @@ module Azure
         url = build_url(rgroup, name)
         url = yield(url) || url if block_given?
         response = rest_get(url)
-        model_class.new(response)
+
+        obj = model_class.new(response.body)
+        obj.response_headers = Azure::Armrest::ResponseHeaders.new(response.headers)
+
+        obj
       end
 
       # Delete the resource with the given +name+ for the provided +resource_group+,
@@ -101,19 +136,27 @@ module Azure
 
       # Aggregate resources from all resource groups.
       #
-      # To be used in the cases where the API does not support list_all with one call.
+      # To be used in the cases where the API does not support list_all with
+      # one call. Note that this does not set the skip token because we're
+      # actually collating the results of multiple calls internally.
       #
       def list_in_all_groups
-        array = []
-        mutex = Mutex.new
+        array   = []
+        mutex   = Mutex.new
+        headers = nil
 
         Parallel.each(list_resource_groups, :in_threads => configuration.max_threads) do |rg|
           response = rest_get(build_url(rg.name))
-          results = JSON.parse(response)['value'].map { |hash| model_class.new(hash) }
+          json_response = JSON.parse(response.body)['value']
+          headers = Azure::Armrest::ResponseHeaders.new(response.headers)
+          results = json_response.map { |hash| model_class.new(hash) }
           mutex.synchronize { array << results } unless results.blank?
         end
 
-        array.flatten
+        array = ArmrestCollection.new(array.flatten)
+        array.response_headers = headers # Use the last set of headers for the overall result
+
+        array
       end
     end
   end

--- a/lib/azure/armrest/resource_group_service.rb
+++ b/lib/azure/armrest/resource_group_service.rb
@@ -26,7 +26,7 @@ module Azure
         url << "&$filter=#{options[:filter]}" if options[:filter]
 
         response = rest_get(url)
-        Azure::Armrest::ArmrestCollection.new(response, Azure::Armrest::ResourceGroup)
+        Azure::Armrest::ArmrestCollection.create_from_response(response, Azure::Armrest::ResourceGroup)
       end
 
       # Creates a new +group+ in +location+ for the current subscription.

--- a/lib/azure/armrest/resource_group_service.rb
+++ b/lib/azure/armrest/resource_group_service.rb
@@ -26,8 +26,7 @@ module Azure
         url << "&$filter=#{options[:filter]}" if options[:filter]
 
         response = rest_get(url)
-
-        JSON.parse(response)['value'].map { |hash| Azure::Armrest::ResourceGroup.new(hash) }
+        Azure::Armrest::ArmrestCollection.new(response, Azure::Armrest::ResourceGroup)
       end
 
       # Creates a new +group+ in +location+ for the current subscription.

--- a/lib/azure/armrest/resource_service.rb
+++ b/lib/azure/armrest/resource_service.rb
@@ -23,7 +23,7 @@ module Azure
       def list(resource_group, options = {})
         url = build_url(resource_group, options)
         response = rest_get(url)
-        JSON.parse(response)['value'].map { |hash| Azure::Armrest::Resource.new(hash) }
+        Azure::Armrest::ArmrestCollection.new(response, Azure::Armrest::Resource)
       end
 
       # Same as Azure::Armrest::ResourceService#list but returns all resources
@@ -32,7 +32,7 @@ module Azure
       def list_all(options = {})
         url = build_url(nil, options)
         response = rest_get(url)
-        JSON.parse(response)['value'].map { |hash| Azure::Armrest::Resource.new(hash) }
+        Azure::Armrest::ArmrestCollection.new(response, Azure::Armrest::Resource)
       end
 
       # Move the resources from +source_group+ under +source_subscription+,

--- a/lib/azure/armrest/resource_service.rb
+++ b/lib/azure/armrest/resource_service.rb
@@ -23,7 +23,7 @@ module Azure
       def list(resource_group, options = {})
         url = build_url(resource_group, options)
         response = rest_get(url)
-        Azure::Armrest::ArmrestCollection.new(response, Azure::Armrest::Resource)
+        Azure::Armrest::ArmrestCollection.create_from_response(response, Azure::Armrest::Resource)
       end
 
       # Same as Azure::Armrest::ResourceService#list but returns all resources
@@ -32,7 +32,7 @@ module Azure
       def list_all(options = {})
         url = build_url(nil, options)
         response = rest_get(url)
-        Azure::Armrest::ArmrestCollection.new(response, Azure::Armrest::Resource)
+        Azure::Armrest::ArmrestCollection.create_from_response(response, Azure::Armrest::Resource)
       end
 
       # Move the resources from +source_group+ under +source_subscription+,

--- a/spec/armrest_collection_spec.rb
+++ b/spec/armrest_collection_spec.rb
@@ -1,0 +1,64 @@
+########################################################################
+# armest_collection_spec.rb
+#
+# Test suite for the base Azure::Armrest::ArmrestCollection type.
+########################################################################
+require 'spec_helper'
+
+describe "ArmrestCollection" do
+  before do
+    hash = {:x_ms_ratelimit_remaining_subscription_reads => '14999'}
+    allow_any_instance_of(String).to receive(:headers).and_return(hash)
+  end
+
+  let(:json_response) do
+    '{"value": [{"id": "xxx"}, {"id": "yyy"}], "nextLink":"https://example.com?skipToken=123"}'
+  end
+
+  let(:klass) { Azure::Armrest::VirtualMachine }
+  let(:collection) { Azure::Armrest::ArmrestCollection.new(json_response, klass) }
+
+  context "class" do
+    it "is a kind of Array" do
+      expect(collection).to be_a_kind_of(Array)
+    end
+  end
+
+  context "accessors" do
+    it "defines a response_headers accessor" do
+      expect(collection).to respond_to(:response_headers)
+    end
+
+    it "defines a continuation_token accessor" do
+      expect(collection).to respond_to(:continuation_token)
+    end
+
+    it "defines a skip_token alias" do
+      expect(collection).to respond_to(:skip_token)
+    end
+  end
+
+  context "response_headers" do
+    it "returns the expected result for the response_headers method" do
+      hash = {:x_ms_ratelimit_remaining_subscription_reads => '14999'}
+      expect(collection.response_headers).to eql(hash)
+    end
+  end
+
+  context "continuation_token" do
+    it "returns the expected result for the continuation_token method" do
+      expect(collection.continuation_token).to eql('123')
+    end
+  end
+
+  context "collection object" do
+    it "returns an array of the expected class type" do
+      expect(collection.first).to be_kind_of(Azure::Armrest::VirtualMachine)
+    end
+
+    it "returns elements with expected values" do
+      expect(collection.first.id).to eql('xxx')
+      expect(collection.last.id).to eql('yyy')
+    end
+  end
+end

--- a/spec/armrest_collection_spec.rb
+++ b/spec/armrest_collection_spec.rb
@@ -16,7 +16,7 @@ describe "ArmrestCollection" do
   end
 
   let(:klass) { Azure::Armrest::VirtualMachine }
-  let(:collection) { Azure::Armrest::ArmrestCollection.new(json_response, klass) }
+  let(:collection) { Azure::Armrest::ArmrestCollection.create_from_response(json_response, klass) }
 
   context "class" do
     it "is a kind of Array" do

--- a/spec/models/storage_account_spec.rb
+++ b/spec/models/storage_account_spec.rb
@@ -38,7 +38,7 @@ describe "StorageAccount" do
   context "accessors" do
     it "defines a storage_api_version accessor that defaults to 2015-02-01" do
       expect(storage).to respond_to(:storage_api_version)
-      expect(storage.storage_api_version).to eq('2015-02-21')
+      expect(storage.storage_api_version).to eq('2015-12-11')
     end
 
     it "defines a proxy accessor that defaults to the http_proxy environment variable" do

--- a/spec/template_deployment_service_spec.rb
+++ b/spec/template_deployment_service_spec.rb
@@ -6,7 +6,15 @@
 require 'spec_helper'
 
 describe "TemplateDeploymentService" do
-  before { setup_params }
+  before do
+    setup_params
+
+    class String
+      def body; self; end
+      def headers; {}; end
+    end
+  end
+
   let(:tds) { Azure::Armrest::TemplateDeploymentService.new(@conf) }
   let(:api_version) { tds.api_version }
   let(:url_prefix) { "https://management.azure.com/subscriptions/abc-123-def-456/resourceGroups/groupname/providers/Microsoft.Resources/deployments" }


### PR DESCRIPTION
This is a solution to https://github.com/ManageIQ/azure-armrest/issues/178.

This modifies the ResourceGroupBasedService so that the `list` and `list_all` methods return an `ArmrestCollection` object instead of a plain array. In turn, the `ArmrestCollection` object has been modified to include a `response_headers` accessor, and a `ResponseHeaders` model has been added as well, which is then set within the `list` and `list_all` methods.

*Update: the ResponseHeaders class was already added within a separate PR, so we use that now. Also, the method was changed from :headers to :response_headers.*

The short version is that now you can do something like this:

```
results = vms.list_all
results.response_headers.x_ms_ratelimit_remaining_subscription_reads
```

This lets us store the returned header information per collection set, rather than per object, since such information would be redundant.

*Update: I should amend that to say that we want the header information set once per request. So, a :list or :list_all call would set it once for the collection, while a :get would set it once on the returned object.*

~~A couple specs are currently failing because of missing attributes, but they're minor.~~