### PR TITLE
Add support for a TooManyRequests exception.

### DIFF
--- a/lib/azure/armrest/armrest_service.rb
+++ b/lib/azure/armrest/armrest_service.rb
@@ -211,6 +211,8 @@ module Azure
                              BadGatewayException
                            when RestClient::Unauthorized, RestClient::Forbidden
                              UnauthorizedException
+                           when RestClient::TooManyRequests
+                             TooManyRequestsException
                            else
                              ApiException
                            end

--- a/lib/azure/armrest/exception.rb
+++ b/lib/azure/armrest/exception.rb
@@ -41,5 +41,7 @@ module Azure
 
     class GatewayTimeoutException < ApiException; end
 
+    class TooManyRequestsException < ApiException; end
+
   end
 end


### PR DESCRIPTION
This just adds a TooManyRequestsException class that wraps a RestClient::TooManyRequests error. We will need this to handle errors caused by issuing too many requests in too short a time.