### PR TITLE
Replace uri with addressable

### DIFF
--- a/azure-armrest.gemspec
+++ b/azure-armrest.gemspec
@@ -25,6 +25,7 @@ behind the scenes.
   spec.add_dependency 'azure-signature', '~> 0.2.0'
   spec.add_dependency 'activesupport', '>= 1.2.0'
   spec.add_dependency 'nokogiri', '~> 1.6.0'
+  spec.add_dependency 'addressable', '~> 2.4.0'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'

--- a/lib/azure/armrest.rb
+++ b/lib/azure/armrest.rb
@@ -1,7 +1,7 @@
 require 'rest-client'
 require 'json'
 require 'thread'
-require 'uri'
+require 'addressable'
 
 # The Azure module serves as a namespace.
 module Azure

--- a/lib/azure/armrest/configuration.rb
+++ b/lib/azure/armrest/configuration.rb
@@ -211,7 +211,7 @@ module Azure
       end
 
       def fetch_providers
-        uri = URI.join(Azure::Armrest::RESOURCE, 'providers')
+        uri = Addressable::URI.join(Azure::Armrest::RESOURCE, 'providers')
         uri.query = "api-version=#{api_version}"
 
         response = ArmrestService.send(

--- a/lib/azure/armrest/resource_group_service.rb
+++ b/lib/azure/armrest/resource_group_service.rb
@@ -18,16 +18,16 @@ module Azure
       #
       #   rgs = ResourceGroupService.new
       #   rgs.list(:top => 2)
-      #   rgs.list(:filter => "sometag=value")
+      #   rgs.list(:filter => "sometag eq 'value'")
       #
       def list(options = {})
         url = build_url
         url << "&$top=#{options[:top]}" if options[:top]
         url << "&$filter=#{options[:filter]}" if options[:filter]
 
-        response = rest_get(URI.escape(url))
+        response = rest_get(url)
 
-        JSON.parse(response)["value"].map{ |hash| Azure::Armrest::ResourceGroup.new(hash) }
+        JSON.parse(response)['value'].map { |hash| Azure::Armrest::ResourceGroup.new(hash) }
       end
 
       # Creates a new +group+ in +location+ for the current subscription.

--- a/lib/azure/armrest/resource_service.rb
+++ b/lib/azure/armrest/resource_service.rb
@@ -22,8 +22,8 @@ module Azure
       #
       def list(resource_group, options = {})
         url = build_url(resource_group, options)
-        response = rest_get(URI.escape(url))
-        JSON.parse(response)["value"].map { |hash| Azure::Armrest::Resource.new(hash) }
+        response = rest_get(url)
+        JSON.parse(response)['value'].map { |hash| Azure::Armrest::Resource.new(hash) }
       end
 
       # Same as Azure::Armrest::ResourceService#list but returns all resources
@@ -31,8 +31,8 @@ module Azure
       #
       def list_all(options = {})
         url = build_url(nil, options)
-        response = rest_get(URI.escape(url))
-        JSON.parse(response)["value"].map{ |hash| Azure::Armrest::Resource.new(hash) }
+        response = rest_get(url)
+        JSON.parse(response)['value'].map { |hash| Azure::Armrest::Resource.new(hash) }
       end
 
       # Move the resources from +source_group+ under +source_subscription+,

--- a/lib/azure/armrest/storage_account_service.rb
+++ b/lib/azure/armrest/storage_account_service.rb
@@ -228,7 +228,7 @@ module Azure
       end
 
       def parse_uri(uri)
-        uri = URI.parse(uri)
+        uri = Addressable::URI.parse(uri)
         host_components = uri.host.split('.')
 
         rh = {


### PR DESCRIPTION
This PR replaces the uri standard library with addressable, which I've found is simply more robust and a better library in general. This was inspired by a recent issue that the azure-signature gem hit, which I want to avoid with this gem.

I also removed all calls to URI.escape since rest-client already auto-escapes, and made one minor doc update.