### PR TITLE
Call URI.encode on all url's before sending to rest-client.

### DIFF
--- a/lib/azure/armrest/armrest_service.rb
+++ b/lib/azure/armrest/armrest_service.rb
@@ -380,7 +380,12 @@ module Azure
       end
 
       def self.rest_execute(options, http_method = :get)
-        RestClient::Request.execute(options.merge(:method => http_method))
+        options = options.merge(
+          :method => http_method,
+          :url    => URI.escape(options[:url])
+        )
+
+        RestClient::Request.execute(options)
       rescue RestClient::Exception => e
         raise_api_exception(e)
       end

--- a/lib/azure/armrest/version.rb
+++ b/lib/azure/armrest/version.rb
@@ -1,5 +1,5 @@
 module Azure
   module Armrest
-    VERSION = '0.2.6'
+    VERSION = '0.2.7'.freeze
   end
 end


### PR DESCRIPTION
This explicitly encodes all url's before passing them on to rest-client.

This is a "sort of" back-port for 0.2.x. In 0.3.x, we use Addressable::URI instead.