### PR TITLE
Add StorageAccountService#list_all_private_images method

### DIFF
--- a/spec/storage_account_service_spec.rb
+++ b/spec/storage_account_service_spec.rb
@@ -73,6 +73,10 @@ describe "StorageAccountService" do
       expect(sas).to respond_to(:list_private_images)
     end
 
+    it "defines a list_all_private_images method" do
+      expect(sas).to respond_to(:list_all_private_images)
+    end
+
     it "defines a parse_uri method" do
       expect(sas).to respond_to(:parse_uri)
     end


### PR DESCRIPTION
This PR adds the StorageAccount#list_all_private_images method. This supercedes #187 that got goofed up somehow.

This is similar to StorageAccount#list_private_images, except that it uses a single call to get all storage accounts, which the user can filter, prior to making additional REST calls needed to get private images.

This is much more efficient, and effectively solves a problem where users would hit the request rate limit because they were iterating over too many resource groups.

All of the shared code was moved to private methods.