### PR TITLE
Added Configuration#validate_subscription!

### DIFF
--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -15,6 +15,7 @@ describe Azure::Armrest::Configuration do
       :subscription_id => 'sid'
     }
   end
+
   subject { described_class.new(options) }
 
   let(:log)            { 'azure-armrest.log' }
@@ -168,6 +169,13 @@ describe Azure::Armrest::Configuration do
           subject.token
           Timecop.freeze(Time.now.utc + 3600) { subject.token }
         end
+      end
+    end
+
+    context 'subscription validation' do
+      it 'raises an error if the subscription is invalid' do
+        allow_any_instance_of(Azure::Armrest::Configuration).to receive(:validate_subscription).and_raise(ArgumentError)
+        expect { Azure::Armrest::Configuration.new(options) }.to raise_error(ArgumentError)
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -69,6 +69,7 @@ def setup_params
   ]
 
   allow_any_instance_of(Azure::Armrest::Configuration).to receive(:fetch_providers).and_return(@providers_response)
+  allow_any_instance_of(Azure::Armrest::Configuration).to receive(:validate_subscription).and_return(true)
 
   @conf = Azure::Armrest::Configuration.new(
     :subscription_id  => @sub,


### PR DESCRIPTION
This adds a Configuration#validate_subscription! method, and addresses https://github.com/ManageIQ/azure-armrest/issues/189.

The main issue is that the constructor effectively does a validation check for tenant ID, client ID and client key via the `fetch_providers` method, but it does not validate the subscription. This method allows users to explicitly validate the subscription and/or check to ensure that it's enabled.