### PR TITLE
No longer need custom list_all method for AvailabilitySetService

### DIFF
--- a/lib/azure/armrest/availability_set_service.rb
+++ b/lib/azure/armrest/availability_set_service.rb
@@ -9,10 +9,6 @@ module Azure
       def initialize(configuration, options = {})
         super(configuration, 'availabilitySets', 'Microsoft.Compute', options)
       end
-
-      def list_all
-        list_in_all_groups
-      end
     end # AvailabilitySetService
   end # Armrest
 end # Azure


### PR DESCRIPTION
It seems we can get all availability sets with the inherited list_all method now.