### PR TITLE
Use the parallel gem to cap our thread usage 

### DIFF
--- a/azure-armrest.gemspec
+++ b/azure-armrest.gemspec
@@ -26,6 +26,7 @@ behind the scenes.
   spec.add_dependency 'activesupport', '>= 1.2.0'
   spec.add_dependency 'nokogiri', '~> 1.6.0'
   spec.add_dependency 'addressable', '~> 2.4.0'
+  spec.add_dependency 'parallel', '~> 1.9.0'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'

--- a/lib/azure/armrest.rb
+++ b/lib/azure/armrest.rb
@@ -2,6 +2,7 @@ require 'rest-client'
 require 'json'
 require 'thread'
 require 'addressable'
+require 'parallel'
 
 # The Azure module serves as a namespace.
 module Azure


### PR DESCRIPTION
Addresses: https://github.com/ManageIQ/azure-armrest/issues/169

This replaces explicit `Thread.new` calls with `Parallel.each` calls, capping our thread pool at 10 threads per operation. It also adds a mutex for the `all_blobs` method (should have had one before) and updates the gemspec.

This is primarily for the benefit of the `list_in_all_groups` internal method, but is potentially useful elsewhere.