### PR TITLE
Don't depend on key order for pretty_print spec.

### DIFF
--- a/spec/models/base_model_spec.rb
+++ b/spec/models/base_model_spec.rb
@@ -120,8 +120,11 @@ describe "BaseModel" do
       require 'pp'
       json = {:name => 'test', :age => 33, :array => ["stuff"]}.to_json
       base = Azure::Armrest::BaseModel.new(json)
-      expected = /^#<Azure::Armrest::BaseModel:0x\h+\n name="test",\n age=33,\n array=\["stuff"\]>$/
+      expected = /^#<Azure::Armrest::BaseModel:0x\h+\n.*?$/
       expect(base.pretty_inspect).to match(expected)
+      expect(base.pretty_inspect).to include('name="test"')
+      expect(base.pretty_inspect).to include('age=33')
+      expect(base.pretty_inspect).to include('array=["stuff"]')
     end
   end
 


### PR DESCRIPTION
This fixes a failing spec for 2.3.x where the key ordering is not reliable. It limits the regex check and then just looks for specific strings.

Addresses https://github.com/ManageIQ/azure-armrest/issues/175