### PR TITLE
Update travis.yml to only test Ruby 2.2.5 or later

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: ruby
 rvm:
-- "2.0"
-- "2.1"
-- "2.2"
+- "2.2.5"
+- "2.3.1"
 - ruby-head
 - jruby-head
 matrix:


### PR DESCRIPTION
This limits our testing to Ruby 2.2.5 or 2.3.1.

Not only are older versions of Ruby mostly irrelevant, these are necessary to work with activesupport 5.x, and that's one of our dependencies.