### PR TITLE
Add a filter option to the list_all method.

### DIFF
--- a/lib/azure/armrest/resource_group_based_service.rb
+++ b/lib/azure/armrest/resource_group_based_service.rb
@@ -23,11 +23,21 @@ module Azure
         JSON.parse(response)['value'].map { |hash| model_class.new(hash) }
       end
 
-      def list_all
+      # Use a single call to get all resources for the service. You may
+      # optionally provide a filter on various properties to limit the
+      # result set.
+      #
+      # Example:
+      #
+      #   vms = Azure::Armrest::VirtualMachineService.new(conf)
+      #   vms.list_all(:location => "eastus", :resource_group => "rg1")
+      #
+      def list_all(filter = {})
         url = build_url
         url = yield(url) || url if block_given?
         response = rest_get(url)
-        JSON.parse(response)['value'].map { |hash| model_class.new(hash) }
+        results = JSON.parse(response)['value'].map { |hash| model_class.new(hash) }
+        filter.empty? ? results : results.select { |obj| filter.all? { |k, v| obj.public_send(k) == v } }
       end
 
       def get(name, rgroup = configuration.resource_group)


### PR DESCRIPTION
I thought the filtering option for the `StorageAccountService#list_all_private_images` was quite handy, and would be generally useful for the `list_all` method.

This lets users do things like `vms.list_all(:location => 'westus')`, which I think is quite handy.