### PR TITLE
Switch from Nokogiri to Oga

### DIFF
--- a/azure-armrest.gemspec
+++ b/azure-armrest.gemspec
@@ -22,9 +22,9 @@ behind the scenes.
   spec.add_dependency 'json', '~> 2.0.1'
   spec.add_dependency 'rest-client', '~> 2.0.0'
   spec.add_dependency 'cache_method', '~> 0.2.7'
-  spec.add_dependency 'azure-signature', '~> 0.2.3'
+  spec.add_dependency 'azure-signature', '~> 0.2.0'
   spec.add_dependency 'activesupport', '>= 4.2.2'
-  spec.add_dependency 'nokogiri', '~> 1.6.8'
+  spec.add_dependency 'oga', '~> 2.3.0'
   spec.add_dependency 'addressable', '~> 2.4.0'
   spec.add_dependency 'parallel', '~> 1.9.0'
 


### PR DESCRIPTION
This PR switches us from Nokogiri to Oga.

http://yorickpeterse.com/articles/oga-a-new-xml-and-html-parser-for-ruby/

While not as fast as Nokogiri, it is faster than REXML, and is "good enough" for the limited usage of this library, which only uses it in four methods total, with two of those methods rarely used in practice. The amount of XML being parsed is relatively small, too.

Mostly this is to avoid the Hakiri warnings, and to avoid the dependencies of nokogiri (libxml, etc), which should ease installation as well. The maintainer is active, too.

On a side note, I modified the `blobs` method to accept either a Container object or a plain string.