### PR TITLE
Update delete method to handle 204 response.

### DIFF
--- a/lib/azure/armrest/model/base_model.rb
+++ b/lib/azure/armrest/model/base_model.rb
@@ -194,6 +194,8 @@ module Azure
     class Sku < BaseModel; end
     class Usage < BaseModel; end
 
+    class ResponseHeaders < BaseModel; end
+
     class StorageAccount < BaseModel; end
     class StorageAccountKey < StorageAccount
       def key1; key_name == 'key1' ? value : nil; end

--- a/spec/template_deployment_service_spec.rb
+++ b/spec/template_deployment_service_spec.rb
@@ -39,7 +39,12 @@ describe "TemplateDeploymentService" do
         :url    => url_prefix + "/deployname?api-version=#{api_version}",
         :method => :delete
       )
-      expect(RestClient::Request).to receive(:execute).with(expected)
+
+      response = double
+      expect(response).to receive(:code) { 200 }
+      expect(response).to receive(:headers) { {} }
+
+      expect(RestClient::Request).to receive(:execute).with(expected).and_return(response)
       tds.delete('deployname', 'groupname')
     end
 


### PR DESCRIPTION
It turns out that the Azure REST API typically returns a 204 (empty body) on a DELETE operation for most resources if the resource does not exist instead of a 404 as you might expect. The net result is that you could call .delete on a resource multiple times and not realize that it didn't actually do anything. This PR specifically checks for a 204 and raises a ResourceNotFoundException if that's the response code.

More importantly, when calling delete we (eventually) want valid header information from the request that we can use to poll the resource because it's an asynchronous operation. If the resource does exist when we made the call to delete it, the header information will include a :location url attribute that we can use to poll the operation to see when it actually completes.

~~I'm also open to the approach of just returning true/false for the sake of backwards compatibility, in case anyone was relying on the old behavior.~~

Actually, we really, really need response header information, so I've updated the PR to return an actual ResponseHeader object that will contain the information we need.