### PR TITLE
Add a :max_threads configuration option

### DIFF
--- a/lib/azure/armrest/configuration.rb
+++ b/lib/azure/armrest/configuration.rb
@@ -60,6 +60,9 @@ module Azure
       # Namespace providers, their resource types, locations and supported api-version strings.
       attr_reader :providers
 
+      # Maximum number of threads to use within methods that use Parallel for thread pooling.
+      attr_accessor :max_threads
+
       # Yields a new Azure::Armrest::Configuration objects. Note that you must
       # specify a client_id, client_key, tenant_id and subscription_id. All other
       # parameters are optional.
@@ -93,7 +96,11 @@ module Azure
           :grant_type   => 'client_credentials',
           :proxy        => ENV['http_proxy'],
           :ssl_version  => 'TLSv1',
+          :max_threads  => 10
         }.merge(args.symbolize_keys)
+
+        # Avoid thread safety issues for VCR testing.
+        options[:max_threads] = 1 if defined?(VCR)
 
         user_token = options.delete(:token)
         user_token_expiration = options.delete(:token_expiration)

--- a/lib/azure/armrest/model/storage_account.rb
+++ b/lib/azure/armrest/model/storage_account.rb
@@ -212,12 +212,12 @@ module Azure
 
       # Returns an array of all blobs for all containers.
       #
-      def all_blobs(key = nil)
+      def all_blobs(key = nil, max_threads = 10)
         key ||= properties.key1
         array = []
         mutex = Mutex.new
 
-        Parallel.each(containers(key), :in_threads => 10) do |container|
+        Parallel.each(containers(key), :in_threads => max_threads) do |container|
           mutex.synchronize { array << blobs(container.name, key) }
         end
 

--- a/lib/azure/armrest/resource_group_based_service.rb
+++ b/lib/azure/armrest/resource_group_based_service.rb
@@ -93,7 +93,7 @@ module Azure
         array = []
         mutex = Mutex.new
 
-        Parallel.each(list_resource_groups, :in_threads => 10) do |rg|
+        Parallel.each(list_resource_groups, :in_threads => configuration.max_threads) do |rg|
           response = rest_get(build_url(rg.name))
           results = JSON.parse(response)['value'].map { |hash| model_class.new(hash) }
           mutex.synchronize { array << results } unless results.blank?

--- a/lib/azure/armrest/storage_account_service.rb
+++ b/lib/azure/armrest/storage_account_service.rb
@@ -248,10 +248,10 @@ module Azure
         results = []
         mutex = Mutex.new
 
-        Parallel.each(storage_accounts, :in_threads => 10) do |storage_account|
+        Parallel.each(storage_accounts, :in_threads => configuration.max_threads) do |storage_account|
           key = get_account_key(storage_account)
 
-          storage_account.all_blobs(key).each do |blob|
+          storage_account.all_blobs(key, configuration.max_threads).each do |blob|
             next unless File.extname(blob.name).casecmp('.vhd') == 0
             next unless blob.properties.lease_state.casecmp('available') == 0
 

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -110,6 +110,19 @@ describe Azure::Armrest::Configuration do
         subject.subscription_id = 'new_id'
         expect(subject.subscription_id).to eql('new_id')
       end
+
+      it 'defines a max_threads accessor' do
+        expect(subject.max_threads).to eql(10)
+        subject.max_threads = 8
+        expect(subject.max_threads).to eql(8)
+      end
+    end
+
+    context 'max_threads' do
+      it 'defaults to 1 thread if the VCR singleton is defined' do
+        class VCR; end
+        expect(subject.max_threads).to eql(1)
+      end
     end
 
     context 'http proxy' do


### PR DESCRIPTION
This adds a :max_threads option with a default of 10. This value is used internally as the value for any calls to Parallel.

Because of thread safety issues caused by the interaction of the Parallel and VCR gems, the default is reduced to 1 in a VCR environment.

There was also a minor change made to the StorageAccount#all_blobs method so that we can control the maximum number of threads there as well.