### PR TITLE
Add poll and wait methods.

### DIFF
--- a/spec/armrest_service_spec.rb
+++ b/spec/armrest_service_spec.rb
@@ -67,28 +67,33 @@ describe Azure::Armrest::ArmrestService do
   end
 
   context "poll and wait" do
+    let(:url) { "http://www.foo.bar" }
+
     it "polls a resource as expected with a plain string" do
       expect(subject).to receive(:poll).and_return("Succeeded")
-      expect(subject.poll("http://www.foo.bar")).to eql("Succeeded")
+      expect(subject.poll(url)).to eql("Succeeded")
     end
 
     it "polls a resource as expected with a ResponseHeader" do
       expect(subject).to receive(:poll).and_return("Succeeded")
-      url = "http://www.foo.bar"
-      header = Azure::Armrest::ResponseHeaders.new(:location => url)
+      header = Azure::Armrest::ResponseHeaders.new(:azure_asyncoperation => url)
       expect(subject.poll(header)).to eql("Succeeded")
     end
 
     it "waits on a resource as expected with a plain string" do
       expect(subject).to receive(:wait).and_return("Succeeded")
-      expect(subject.wait("http://www.foo.bar", 1)).to eql("Succeeded")
+      expect(subject.wait(url, 1)).to eql("Succeeded")
     end
 
     it "waits on a resource as expected with a ResponseHeader" do
       expect(subject).to receive(:wait).and_return("Succeeded")
-      url = "http://www.foo.bar"
-      header = Azure::Armrest::ResponseHeaders.new(:location => url)
+      header = Azure::Armrest::ResponseHeaders.new(:azure_asyncoperation => url)
       expect(subject.wait(header, 1)).to eql("Succeeded")
+    end
+
+    it "waits on a resource with a timeout value as expected" do
+      expect(subject).to receive(:wait).with(url, 5).and_return("Succeeded")
+      expect(subject.wait(url, 5)).to eql("Succeeded")
     end
   end
 

--- a/spec/armrest_service_spec.rb
+++ b/spec/armrest_service_spec.rb
@@ -56,6 +56,40 @@ describe Azure::Armrest::ArmrestService do
     it "defines a tenants method" do
       expect(subject).to respond_to(:tenants)
     end
+
+    it "defines a poll method" do
+      expect(subject).to respond_to(:poll)
+    end
+
+    it "defines a wait method" do
+      expect(subject).to respond_to(:wait)
+    end
+  end
+
+  context "poll and wait" do
+    it "polls a resource as expected with a plain string" do
+      expect(subject).to receive(:poll).and_return("Succeeded")
+      expect(subject.poll("http://www.foo.bar")).to eql("Succeeded")
+    end
+
+    it "polls a resource as expected with a ResponseHeader" do
+      expect(subject).to receive(:poll).and_return("Succeeded")
+      url = "http://www.foo.bar"
+      header = Azure::Armrest::ResponseHeaders.new(:location => url)
+      expect(subject.poll(header)).to eql("Succeeded")
+    end
+
+    it "waits on a resource as expected with a plain string" do
+      expect(subject).to receive(:wait).and_return("Succeeded")
+      expect(subject.wait("http://www.foo.bar", 1)).to eql("Succeeded")
+    end
+
+    it "waits on a resource as expected with a ResponseHeader" do
+      expect(subject).to receive(:wait).and_return("Succeeded")
+      url = "http://www.foo.bar"
+      header = Azure::Armrest::ResponseHeaders.new(:location => url)
+      expect(subject.wait(header, 1)).to eql("Succeeded")
+    end
   end
 
   context "delegated methods" do


### PR DESCRIPTION
This adds poll and wait methods to the base ArmrestService class. This lets us take the result of an asynchronous option (e.g. delete), and poll the resulting url header for its operations status. 

The wait method is just a sleepy loop around the poll method that would let users essentially "block until complete" for async operations.

This is part of the continuing effort towards a "delete_associated" method.