### PR TITLE
Backport custom Exception class updates into 0.2.x

### DIFF
--- a/lib/azure/armrest/exception.rb
+++ b/lib/azure/armrest/exception.rb
@@ -4,15 +4,30 @@ module Azure
       attr_accessor :cause
       attr_writer :message
 
+      # Create a new Armrest::Exception object. The +message+ should be an
+      # error string, while +cause_exception+ is typically set to the
+      # raw RestClient exception.
+      #
+      # You will not typically use this object directly.
+      #
       def initialize(message = nil, cause_exception = nil)
         @message = message
         @cause = cause_exception
       end
 
+      # The stringified version (message) of the exception.
+      #
       def to_s
-        message
+        if cause
+          "#{message} (cause: #{cause})"
+        else
+          message
+        end
       end
 
+      # The error message or, if the message is not set, the name of the
+      # exception class.
+      #
       def message
         @message || self.class.name
       end
@@ -21,15 +36,23 @@ module Azure
     class ApiException < Exception
       attr_accessor :code
 
+      # Create a new ApiException class. The +code+ is the error code.
+      #
+      # This class serves as the parent
       def initialize(code, message, cause_exception)
         @code = code
         super(message, cause_exception)
       end
 
+      # A stringified version of the error. If self is a plain ApiException,
+      # then the cause is included to aid in debugging.
+      #
       def to_s
-        "[#{code}] #{message}"
+        "[#{code}] #{super}"
       end
     end
+
+    # A list of predefined exceptions that we wrap around RestClient exceptions.
 
     class ResourceNotFoundException < ApiException; end
 

--- a/spec/exception_spec.rb
+++ b/spec/exception_spec.rb
@@ -1,0 +1,80 @@
+########################################################################
+# exception_spec.rb
+#
+# Test suite for the Azure::Armrest::Exception class and
+# Azure::Armrest::ApiException subclass.
+########################################################################
+require 'spec_helper'
+
+describe Azure::Armrest::Exception do
+  before { setup_params }
+
+  let(:message) { 'test message' }
+  let(:code)    { 'ResourceNotFound' }
+  let(:cause)   { '404 Not Found' }
+
+  context "constructor" do
+    it "may be instantiated with no arguments" do
+      expect(described_class.new).to be_kind_of(Azure::Armrest::Exception)
+    end
+
+    it "may include an optional message" do
+      error = described_class.new(message)
+      expect(error.message).to eql(message)
+    end
+
+    it "uses the class name for the message if not defined" do
+      error = described_class.new
+      expect(error.message).to eql(described_class.name)
+    end
+
+    it "may include an optional cause" do
+      error = described_class.new(message, cause)
+      expect(error.cause).to eql(cause)
+    end
+
+    it "defines to_s and returns the message" do
+      error = described_class.new(message, cause)
+      expect(error.to_s).to eql("#{message} (cause: #{error.cause})")
+    end
+  end
+
+  context "ApiException subclass" do
+    subject { Azure::Armrest::ApiException.new(code, message, cause) }
+
+    it "is a subclass of Armrest::Exception" do
+      expect(subject).to be_kind_of(Azure::Armrest::Exception)
+    end
+
+    it "defines a code accessor that returns the expected value" do
+      expect(subject).to respond_to(:code)
+      expect(subject.code).to eql(code)
+    end
+
+    it "defines a code message that returns the expected value" do
+      expect(subject).to respond_to(:message)
+      expect(subject.message).to eql(message)
+    end
+
+    it "defines a cause message that returns the expected value" do
+      expect(subject).to respond_to(:cause)
+      expect(subject.cause).to eql(cause)
+    end
+
+    it "defines a custom to_s method that returns the expected result" do
+      string = "[#{subject.code}] #{subject.message} (cause: #{subject.cause})"
+      expect(subject.to_s).to eql(string)
+    end
+  end
+
+  context "subclasses of ApiException" do
+    it "defines the expected subclasses" do
+      expect(Azure::Armrest::ResourceNotFoundException).to_not be_nil
+      expect(Azure::Armrest::BadRequestException).to_not be_nil
+      expect(Azure::Armrest::UnauthorizedException).to_not be_nil
+      expect(Azure::Armrest::BadGatewayException).to_not be_nil
+      expect(Azure::Armrest::GatewayTimeoutException).to_not be_nil
+      expect(Azure::Armrest::TooManyRequestsException).to_not be_nil
+    end
+  end
+end

--- a/spec/exception_spec.rb
+++ b/spec/exception_spec.rb
@@ -74,7 +74,7 @@ describe Azure::Armrest::Exception do
       expect(Azure::Armrest::UnauthorizedException).to_not be_nil
       expect(Azure::Armrest::BadGatewayException).to_not be_nil
       expect(Azure::Armrest::GatewayTimeoutException).to_not be_nil
-      expect(Azure::Armrest::TooManyRequestsException).to_not be_nil
+      #expect(Azure::Armrest::TooManyRequestsException).to_not be_nil
     end
   end
 end


### PR DESCRIPTION
This backports #210 into the 0.2.x branch. I commented out one test because that exception class doesn't exist here.