### PR TITLE
Ignore storage accounts with keys that cannot be read.

### DIFF
--- a/lib/azure/armrest/storage_account_service.rb
+++ b/lib/azure/armrest/storage_account_service.rb
@@ -261,7 +261,13 @@ module Azure
 
         storage_accounts.each do |lstorage_account|
           threads << Thread.new(lstorage_account) do |storage_account|
-            key = get_account_key(storage_account)
+            begin
+              key = get_account_key(storage_account)
+            rescue Azure::Armrest::ApiException => err
+              # Most likely because the storage account isn't completely provisioned
+              # yet or provisioning of the account was not successful
+              next
+            end
 
             storage_account.all_blobs(key).each do |blob|
               next unless File.extname(blob.name).casecmp('.vhd') == 0


### PR DESCRIPTION
Ignore any storage account that causes an exception to be thrown when its storage key is read. 
The list of errors that can be returned is documented here:https://msdn.microsoft.com/en-us/library/azure/mt163558.aspx

The BZ this will address is:
https://bugzilla.redhat.com/show_bug.cgi?id=1376468

Below is some sample back trace that applies to this BZ:

```[----] E, [2016-09-13T05:40:02.086088 #35846:c51994] ERROR -- : [Azure::Armrest::ApiException]: The storage account provisioning state must be 'Succeeded' before executing the operation.  Method:[rescue in block in refresh]
[----] E, [2016-09-13T05:40:02.086163 #35846:c51994] ERROR -- : /opt/rh/cfme-gemset/gems/azure-armrest-0.2.8/lib/azure/armrest/armrest_service.rb:442:in `raise_api_exception'
/opt/rh/cfme-gemset/gems/azure-armrest-0.2.8/lib/azure/armrest/armrest_service.rb:390:in `rescue in rest_execute'
/opt/rh/cfme-gemset/gems/azure-armrest-0.2.8/lib/azure/armrest/armrest_service.rb:383:in `rest_execute'
/opt/rh/cfme-gemset/gems/azure-armrest-0.2.8/lib/azure/armrest/armrest_service.rb:466:in `rest_execute'
/opt/rh/cfme-gemset/gems/azure-armrest-0.2.8/lib/azure/armrest/armrest_service.rb:478:in `rest_post'
/opt/rh/cfme-gemset/gems/azure-armrest-0.2.8/lib/azure/armrest/storage_account_service.rb:143:in `list_account_key_objects'
/opt/rh/cfme-gemset/gems/azure-armrest-0.2.8/lib/azure/armrest/storage_account_service.rb:309:in `get_account_key'
/opt/rh/cfme-gemset/gems/azure-armrest-0.2.8/lib/azure/armrest/storage_account_service.rb:264:in `block (2 levels) in get_private_images'
/opt/rh/cfme-gemset/gems/logging-2.1.0/lib/logging/diagnostic_context.rb:450:in `call'
/opt/rh/cfme-gemset/gems/logging-2.1.0/lib/logging/diagnostic_context.rb:450:in `block in create_with_logging_context'
```

