### PR TITLE
Skip over storage accounts that have no key in list_all_private_images

### DIFF
--- a/lib/azure/armrest/storage_account_service.rb
+++ b/lib/azure/armrest/storage_account_service.rb
@@ -249,7 +249,11 @@ module Azure
         mutex = Mutex.new
 
         Parallel.each(storage_accounts, :in_threads => configuration.max_threads) do |storage_account|
-          key = get_account_key(storage_account)
+          begin
+            key = get_account_key(storage_account)
+          rescue Azure::Armrest::ApiException
+            next # Most likely due to incomplete or failed provisioning.
+          end
 
           storage_account.all_blobs(key, configuration.max_threads).each do |blob|
             next unless File.extname(blob.name).casecmp('.vhd') == 0


### PR DESCRIPTION
This mimics #212 for the 0.3.x branch. In short, it skips over storage accounts where we cannot acquire a key, most likely because the provisioning is incomplete or failed for some reason.