### PR TITLE
Add response_code accessor and use it internally.

### DIFF
--- a/lib/azure/armrest/armrest_collection.rb
+++ b/lib/azure/armrest/armrest_collection.rb
@@ -5,6 +5,7 @@ module Azure
     class ArmrestCollection < Array
       attr_accessor :continuation_token
       attr_accessor :response_headers
+      attr_accessor :response_code
 
       alias skip_token continuation_token
       alias skip_token= continuation_token=
@@ -18,6 +19,7 @@ module Azure
           json_response = JSON.parse(response)
           array = new(json_response['value'].map { |hash| klass.new(hash) })
 
+          array.response_code = response.code
           array.response_headers = response.headers
           array.continuation_token = parse_skip_token(json_response)
 

--- a/lib/azure/armrest/armrest_service.rb
+++ b/lib/azure/armrest/armrest_service.rb
@@ -166,7 +166,7 @@ module Azure
       # such as create or delete.
       #
       def poll(response)
-        return 'Succeeded' if [200,201].include?(response.response_code)
+        return 'Succeeded' if [200, 201].include?(response.response_code)
         url = response.try(:azure_asyncoperation) || response.try(:location)
         JSON.parse(rest_get(url))['status']
       end

--- a/lib/azure/armrest/armrest_service.rb
+++ b/lib/azure/armrest/armrest_service.rb
@@ -166,7 +166,8 @@ module Azure
       # such as create or delete.
       #
       def poll(response)
-        url = response.respond_to?(:azure_asyncoperation) ? response.azure_asyncoperation : response.to_s
+        return 'Succeeded' if [200,201].include?(response.response_code)
+        url = response.try(:azure_asyncoperation) || response.try(:location)
         JSON.parse(rest_get(url))['status']
       end
 

--- a/lib/azure/armrest/model/base_model.rb
+++ b/lib/azure/armrest/model/base_model.rb
@@ -24,6 +24,7 @@ module Azure
       attr_hash :tags
 
       attr_accessor :response_headers
+      attr_accessor :response_code
 
       # Constructs and returns a new JSON wrapper class. Pass in a plain
       # JSON string and it will automatically give you accessor methods
@@ -189,7 +190,9 @@ module Azure
     class Sku < BaseModel; end
     class Usage < BaseModel; end
 
-    class ResponseHeaders < BaseModel; end
+    class ResponseHeaders < BaseModel
+      undef_method :response_headers
+    end
 
     class StorageAccount < BaseModel; end
     class StorageAccountKey < StorageAccount

--- a/lib/azure/armrest/resource_group_based_service.rb
+++ b/lib/azure/armrest/resource_group_based_service.rb
@@ -33,7 +33,7 @@ module Azure
         obj.response_headers = headers
         obj.response_code = headers.response_code
 
-        return obj
+        obj
       end
 
       alias update create

--- a/lib/azure/armrest/storage_account_service.rb
+++ b/lib/azure/armrest/storage_account_service.rb
@@ -44,7 +44,8 @@ module Azure
       # specified parameters.
       #
       # Note that the name of the storage account within the specified
-      # must be 3-24 alphanumeric lowercase characters.
+      # must be 3-24 alphanumeric lowercase characters. This name must be
+      # unique across all subscriptions.
       #
       # The options available are as follows:
       #
@@ -68,15 +69,14 @@ module Azure
       #
       #   sas = Azure::Armrest::StorageAccountService(config)
       #
-      #   sas.create(
-      #     "your_storage_account",
-      #     "your_resource_group",
-      #     {
-      #       :location   => "West US",
-      #       :properties => {:accountType => "Standard_ZRS"},
-      #       :tags       => {:YourCompany => true}
-      #     }
-      #   )
+      #   options = {
+      #     :location => "Central US",
+      #     :tags     => {:redhat => true},
+      #     :sku      => {:name => "Standard_LRS"},
+      #     :kind     => "Storage"
+      #   }
+      #
+      #   sas.create("your_storage_account", "your_resource_group", options)
       #
       def create(account_name, rgroup = configuration.resource_group, options)
         validating = options.delete(:validating)
@@ -85,10 +85,6 @@ module Azure
         acct = super(account_name, rgroup, options) do |url|
           url << "&validating=" << validating if validating
         end
-
-        # An initial create call will return nil because the response body is
-        # empty. In that case, make another call to get the object properties.
-        acct = get(account_name, rgroup) unless acct
 
         acct.proxy       = configuration.proxy
         acct.ssl_version = configuration.ssl_version

--- a/spec/armrest_collection_spec.rb
+++ b/spec/armrest_collection_spec.rb
@@ -9,6 +9,7 @@ describe "ArmrestCollection" do
   before do
     hash = {:x_ms_ratelimit_remaining_subscription_reads => '14999'}
     allow_any_instance_of(String).to receive(:headers).and_return(hash)
+    allow(json_response).to receive(:code).and_return(200)
   end
 
   let(:json_response) do

--- a/spec/insights_event_service_spec.rb
+++ b/spec/insights_event_service_spec.rb
@@ -44,6 +44,8 @@ describe "Insights::EventService" do
     it "returns a single page of results" do
       response = response_bodies.first
       allow(response).to receive(:body).and_return(response)
+      allow(response).to receive(:code).and_return(200)
+
       expect(ies).to receive(:rest_get).and_return(response)
 
       event_list = ies.list
@@ -57,6 +59,7 @@ describe "Insights::EventService" do
     it "returns all the pages of results" do
       response_bodies.each_with_index do |response, index|
         allow(response).to receive(:body).and_return(response_bodies[index])
+        allow(response).to receive(:code).and_return(200)
       end
 
       expect(ies).to receive(:rest_get).and_return(*response_bodies)

--- a/spec/template_deployment_service_spec.rb
+++ b/spec/template_deployment_service_spec.rb
@@ -8,11 +8,8 @@ require 'spec_helper'
 describe "TemplateDeploymentService" do
   before do
     setup_params
-
-    class String
-      def body; self; end
-      def headers; {}; end
-    end
+    allow_any_instance_of(String).to receive(:headers).and_return({})
+    allow_any_instance_of(String).to receive(:code).and_return(200)
   end
 
   let(:tds) { Azure::Armrest::TemplateDeploymentService.new(@conf) }
@@ -32,13 +29,19 @@ describe "TemplateDeploymentService" do
   end
 
   context "instance methods" do
+    let(:empty_hash_string) { "{}" }
+
+    before do
+      allow(empty_hash_string).to receive(:body).and_return(empty_hash_string)
+    end
+
     it "defines a create method" do
       expected = @req.merge(
         :url     => url_prefix + "/deployname?api-version=#{api_version}",
         :method  => :put,
         :payload => "{}"
       )
-      expect(RestClient::Request).to receive(:execute).with(expected).and_return('{}')
+      expect(RestClient::Request).to receive(:execute).with(expected).and_return(empty_hash_string)
       tds.create('deployname', 'groupname', {})
     end
 
@@ -48,10 +51,7 @@ describe "TemplateDeploymentService" do
         :method => :delete
       )
 
-      response = double
-      expect(response).to receive(:code) { 200 }
-      expect(response).to receive(:headers) { {} }
-
+      response = '{}'
       expect(RestClient::Request).to receive(:execute).with(expected).and_return(response)
       tds.delete('deployname', 'groupname')
     end
@@ -71,7 +71,7 @@ describe "TemplateDeploymentService" do
 
     it "defines a get method" do
       expected = @req.merge(:url => url_prefix + "/deployname?api-version=#{api_version}")
-      expect(RestClient::Request).to receive(:execute).with(expected).and_return('{}')
+      expect(RestClient::Request).to receive(:execute).with(expected).and_return(empty_hash_string)
       tds.get('deployname', 'groupname')
     end
 
@@ -83,7 +83,7 @@ describe "TemplateDeploymentService" do
 
     it "defines a get_deployment_operation method" do
       expected = @req.merge(:url => url_prefix + "/deployname/operations/opid?api-version=#{api_version}")
-      expect(RestClient::Request).to receive(:execute).with(expected).and_return('{}')
+      expect(RestClient::Request).to receive(:execute).with(expected).and_return(empty_hash_string)
       tds.get_deployment_operation('opid', 'deployname', 'groupname')
     end
   end


### PR DESCRIPTION
This adds a response_code accessor to our base model, sets it internally for our methods, and uses it within the poll method.

It also modifies the create method to return a response header object instead of a regular object since it's an asynchronous operation, and makes it consistent with the delete method.