### PR TITLE
Update delete method to handle 204 response.

### DIFF
--- a/lib/azure/armrest/model/base_model.rb
+++ b/lib/azure/armrest/model/base_model.rb
@@ -174,6 +174,8 @@ module Azure
     class ResourceProvider < BaseModel; end
     class Sku < BaseModel; end
 
+    class ResponseHeaders < BaseModel; end
+
     class StorageAccount < BaseModel; end
     class StorageAccountKey < StorageAccount
       def key1; key_name == 'key1' ? value : nil; end

--- a/lib/azure/armrest/resource_group_based_service.rb
+++ b/lib/azure/armrest/resource_group_based_service.rb
@@ -40,14 +40,28 @@ module Azure
         model_class.new(response)
       end
 
+      # Delete the resource with the given +name+ for the provided +resource_group+,
+      # or the resource group specified in your original configuration object. If
+      # successful, returns a ResponseHeaders object.
+      #
+      # If the delete operation returns a 204 (no body), which is what the Azure
+      # REST API typically returns if the resource is not found, it is treated
+      # as an error and a ResourceNotFoundException is raised.
+      #
       def delete(name, rgroup = configuration.resource_group)
         validate_resource_group(rgroup)
         validate_resource(name)
 
         url = build_url(rgroup, name)
         url = yield(url) || url if block_given?
-        rest_delete(url)
-        nil
+        response = rest_delete(url)
+
+        if response.code == 204
+          msg = "#{self.class} resource #{rgroup}/#{name} not found"
+          raise Azure::Armrest::ResourceNotFoundException.new(response.code, msg, response)
+        end
+
+        Azure::Armrest::ResponseHeaders.new(response.headers)
       end
 
       private

--- a/spec/template_deployment_service_spec.rb
+++ b/spec/template_deployment_service_spec.rb
@@ -39,7 +39,12 @@ describe "TemplateDeploymentService" do
         :url    => url_prefix + "/deployname?api-version=#{api_version}",
         :method => :delete
       )
-      expect(RestClient::Request).to receive(:execute).with(expected)
+
+      response = double
+      expect(response).to receive(:code) { 200 }
+      expect(response).to receive(:headers) { {} }
+
+      expect(RestClient::Request).to receive(:execute).with(expected).and_return(response)
       tds.delete('deployname', 'groupname')
     end
 


### PR DESCRIPTION
Backports https://github.com/ManageIQ/azure-armrest/pull/203

Update delete spec for TemplateDeploymentService.
Update delete method to return ResponseHeaders object.