### PR TITLE
Replace custom inspect with the one provided by pp.

### DIFF
--- a/lib/azure/armrest/model/base_model.rb
+++ b/lib/azure/armrest/model/base_model.rb
@@ -1,4 +1,5 @@
 require 'active_support/core_ext/string/inflections'
+require 'pp'
 
 module Azure
   module Armrest
@@ -91,19 +92,9 @@ module Azure
         @json
       end
 
-      def inspect_method_list
-        methods(false).reject { |m| m.to_s.end_with?('=') }
-      end
-      private :inspect_method_list
-
-      def inspect
-        Kernel.instance_method(:to_s).bind(self).call.chomp!('>') <<
-          ' ' <<
-          inspect_method_list.map { |m| "#{m}=#{send(m).inspect}" }.join(', ') <<
-          '>'
-      end
-
       def pretty_print(q)
+        inspect_method_list = methods(false).reject { |m| m.to_s.end_with?('=') }
+
         q.object_address_group(self) {
           q.seplist(inspect_method_list, lambda { q.text ',' }) {|v|
             q.breakable
@@ -116,6 +107,8 @@ module Azure
           }
         }
       end
+
+      alias_method :inspect, :pretty_print_inspect
 
       def ==(other)
         return false unless other.kind_of?(BaseModel)

--- a/spec/models/base_model_spec.rb
+++ b/spec/models/base_model_spec.rb
@@ -117,10 +117,9 @@ describe "BaseModel" do
     end
 
     it "defines a pretty_print method when pp is available" do
-      require 'pp'
       json = {:name => 'test', :age => 33, :array => ["stuff"]}.to_json
       base = Azure::Armrest::BaseModel.new(json)
-      expected = /^#<Azure::Armrest::BaseModel:0x\h+\n.*?$/
+      expected = /\A#<Azure::Armrest::BaseModel:0x\h+\n/
       expect(base.pretty_inspect).to match(expected)
       expect(base.pretty_inspect).to include('name="test"')
       expect(base.pretty_inspect).to include('age=33')


### PR DESCRIPTION
Since we are already implementing the pretty_print method, we can rely
on the built-in pretty_print_inspect method, whose purpose is to
provide an inspect method directly from a custom pretty_print method.

This is a follow on from #165 , now I've learned a bit more about PP and found out about this pretty_print_inspect method.  By reusing that method, we can eliminate our custom inspect method entirely.

@djberg96 In the original PR, you were concerned it would affect AP, which it didn't.  Can you also verify it doesn't affect AP here as well?