### PR TITLE
Dynamically define our own exception classes based on the RestClient

### DIFF
--- a/lib/azure/armrest/exception.rb
+++ b/lib/azure/armrest/exception.rb
@@ -52,18 +52,100 @@ module Azure
       end
     end
 
-    # A list of predefined exceptions that we wrap around RestClient exceptions.
-
-    class ResourceNotFoundException < ApiException; end
-
-    class BadRequestException < ApiException; end
-
-    class UnauthorizedException < ApiException; end
-
+    # Rewrapped HTTP errors
     class BadGatewayException < ApiException; end
-
+    class BadRequestException < ApiException; end
+    class BandwidthLimitExceededException < ApiException; end
+    class BlockedByWindowsParentalControlsException < ApiException; end
+    class ConflictException < ApiException; end
+    class ExpectationFailedException < ApiException; end
+    class FailedDependencyException < ApiException; end
+    class ForbiddenException < ApiException; end
     class GatewayTimeoutException < ApiException; end
-
+    class GoneException < ApiException; end
+    class HTTPVersionNotSupportedException < ApiException; end
+    class ImATeapotException < ApiException; end
+    class InsufficientStorageException < ApiException; end
+    class InternalServerErrorException < ApiException; end
+    class LengthRequiredException < ApiException; end
+    class LockedException < ApiException; end
+    class LoopDetectedException < ApiException; end
+    class MethodNotAllowedException < ApiException; end
+    class NetworkAuthenticationRequiredException < ApiException; end
+    class NotAcceptableException < ApiException; end
+    class NotExtendedException < ApiException; end
+    class NotFoundException < ApiException; end
+    class NotImplementedException < ApiException; end
+    class PayloadTooLargeException < ApiException; end
+    class PaymentRequiredException < ApiException; end
+    class PreconditionFailedException < ApiException; end
+    class PreconditionRequiredException < ApiException; end
+    class ProxyAuthenticationRequiredException < ApiException; end
+    class RangeNotSatisfiableException < ApiException; end
+    class RequestHeaderFieldsTooLargeException < ApiException; end
+    class RequestTimeoutException < ApiException; end
+    class RetryWithException < ApiException; end
+    class ServiceUnavailableException < ApiException; end
+    class TooManyConnectionsFromThisIPException < ApiException; end
     class TooManyRequestsException < ApiException; end
+    class URITooLongException < ApiException; end
+    class UnauthorizedException < ApiException; end
+    class UnorderedCollectionException < ApiException; end
+    class UnprocessableEntityException < ApiException; end
+    class UnsupportedMediaTypeException < ApiException; end
+    class UpgradeRequiredException < ApiException; end
+    class VariantAlsoNegotiatesException < ApiException; end
+
+    # Custom errors or other wrapped exceptions
+    class ResourceNotFoundException < ApiException; end
+    class TimeoutException < RequestTimeoutException; end
+    class OpenTimeoutException < TimeoutException; end
+    class ReadTimeoutException < TimeoutException; end
+
+    # Map HTTP error codes to our exception classes
+    EXCEPTION_MAP = {
+      400 => BadRequestException,
+      401 => UnauthorizedException,
+      402 => PaymentRequiredException,
+      403 => ForbiddenException,
+      404 => NotFoundException,
+      405 => MethodNotAllowedException,
+      406 => NotAcceptableException,
+      407 => ProxyAuthenticationRequiredException,
+      408 => RequestTimeoutException,
+      409 => ConflictException,
+      410 => GoneException,
+      411 => LengthRequiredException,
+      412 => PreconditionFailedException,
+      413 => PayloadTooLargeException,
+      414 => URITooLongException,
+      415 => UnsupportedMediaTypeException,
+      416 => RangeNotSatisfiableException,
+      417 => ExpectationFailedException,
+      418 => ImATeapotException,
+      421 => TooManyConnectionsFromThisIPException,
+      422 => UnprocessableEntityException,
+      423 => LockedException,
+      424 => FailedDependencyException,
+      425 => UnorderedCollectionException,
+      426 => UpgradeRequiredException,
+      428 => PreconditionRequiredException,
+      429 => TooManyRequestsException,
+      431 => RequestHeaderFieldsTooLargeException,
+      449 => RetryWithException,
+      450 => BlockedByWindowsParentalControlsException,
+      500 => InternalServerErrorException,
+      501 => NotImplementedException,
+      502 => BadGatewayException,
+      503 => ServiceUnavailableException,
+      504 => GatewayTimeoutException,
+      505 => HTTPVersionNotSupportedException,
+      506 => VariantAlsoNegotiatesException,
+      507 => InsufficientStorageException,
+      508 => LoopDetectedException,
+      509 => BandwidthLimitExceededException,
+      510 => NotExtendedException,
+      511 => NetworkAuthenticationRequiredException
+    }.freeze
   end
 end

--- a/spec/exception_spec.rb
+++ b/spec/exception_spec.rb
@@ -68,13 +68,40 @@ describe Azure::Armrest::Exception do
   end
 
   context "subclasses of ApiException" do
+    let(:badrequest) { RestClient::BadRequest.new }
+    let(:timeout) { RestClient::Exceptions::Timeout.new }
+    let(:armrest_service) { Azure::Armrest::ArmrestService }
+
+    let(:body) do
+      %({
+        "error":{
+          "code":"MissingSomething",
+          "message":"The request did not work."
+        }
+      })
+    end
+
+    before do
+      allow(badrequest).to receive(:http_body).and_return(body)
+      allow(badrequest).to receive(:http_code).and_return(400)
+      allow(timeout).to receive(:http_body).and_return(body)
+    end
+
     it "defines the expected subclasses" do
-      expect(Azure::Armrest::ResourceNotFoundException).to_not be_nil
-      expect(Azure::Armrest::BadRequestException).to_not be_nil
-      expect(Azure::Armrest::UnauthorizedException).to_not be_nil
-      expect(Azure::Armrest::BadGatewayException).to_not be_nil
-      expect(Azure::Armrest::GatewayTimeoutException).to_not be_nil
-      expect(Azure::Armrest::TooManyRequestsException).to_not be_nil
+      expect(Azure::Armrest.const_defined?(:ResourceNotFoundException)).to be_truthy
+      expect(Azure::Armrest.const_defined?(:BadRequestException)).to be_truthy
+      expect(Azure::Armrest.const_defined?(:UnauthorizedException)).to be_truthy
+      expect(Azure::Armrest.const_defined?(:BadGatewayException)).to be_truthy
+      expect(Azure::Armrest.const_defined?(:GatewayTimeoutException)).to be_truthy
+      expect(Azure::Armrest.const_defined?(:TooManyRequestsException)).to be_truthy
+      expect(Azure::Armrest.const_defined?(:PayloadTooLargeException)).to be_truthy
+      expect(Azure::Armrest.const_defined?(:ServiceUnavailableException)).to be_truthy
+      expect(Azure::Armrest.const_defined?(:LoopDetectedException)).to be_truthy
+    end
+
+    it "re-raises the expected error class" do
+      expect { armrest_service.send(:raise_api_exception, badrequest) }.to raise_error(Azure::Armrest::BadRequestException)
+      expect { armrest_service.send(:raise_api_exception, timeout) }.to raise_error(Azure::Armrest::TimeoutException)
     end
   end
 end


### PR DESCRIPTION
Addresses https://github.com/ManageIQ/azure-armrest/issues/218

At the moment we're hard coding our exception classes in exception.rb, as well as rescuing and re-raising them individually in armrest_service.rb. While this works, whenever RestClient raises an error that we don't explicitly define, it defaults to ApiException.

Defaulting to ApiException is unfriendly for debugging purposes and leads to unnecessary guesswork, and there are a lot of exceptions that we don't define ourselves. This dynamically defines an exception class for each RestClient exception, and dynamically determines which one to use if an error is raised. The only ones we need to define ourselves are the ones that aren't defined by RestClient.

