### PR TITLE
Refactor the fetch_providers method

### DIFF
--- a/lib/azure/armrest.rb
+++ b/lib/azure/armrest.rb
@@ -3,6 +3,7 @@ require 'json'
 require 'thread'
 require 'addressable'
 require 'parallel'
+require 'cache_method'
 
 # The Azure module serves as a namespace.
 module Azure

--- a/lib/azure/armrest/configuration.rb
+++ b/lib/azure/armrest/configuration.rb
@@ -162,7 +162,7 @@ module Azure
 
       # Return the default api version for the given provider and service
       def provider_default_api_version(provider, service)
-        @provider_api_versions[provider.downcase][service.downcase]
+        @provider_api_versions[provider.downcase][service.downcase] rescue nil
       end
 
       # The name of the file or handle used to log http requests.
@@ -266,22 +266,7 @@ module Azure
       end
 
       def fetch_providers
-        uri = Addressable::URI.join(Azure::Armrest::RESOURCE, 'providers')
-        uri.query = "api-version=#{api_version}"
-
-        response = ArmrestService.send(
-          :rest_get,
-          :url         => uri.to_s,
-          :proxy       => proxy,
-          :ssl_version => ssl_version,
-          :ssl_verify  => ssl_verify,
-          :headers     => {
-            :content_type  => content_type,
-            :authorization => token
-          }
-        )
-
-        JSON.parse(response.body)['value'].map { |hash| Azure::Armrest::ResourceProvider.new(hash) }
+        Azure::Armrest::ResourceProviderService.new(self).list
       end
 
       def fetch_token

--- a/lib/azure/armrest/configuration.rb
+++ b/lib/azure/armrest/configuration.rb
@@ -162,7 +162,11 @@ module Azure
 
       # Return the default api version for the given provider and service
       def provider_default_api_version(provider, service)
-        @provider_api_versions[provider.downcase][service.downcase] rescue nil
+        if @provider_api_versions
+          @provider_api_versions[provider.downcase][service.downcase]
+        else
+          nil # Typically only for the fetch_providers method.
+        end
       end
 
       # The name of the file or handle used to log http requests.

--- a/lib/azure/armrest/resource_provider_service.rb
+++ b/lib/azure/armrest/resource_provider_service.rb
@@ -1,5 +1,3 @@
-require 'cache_method'
-
 module Azure
   module Armrest
     class ResourceProviderService < ArmrestService
@@ -39,6 +37,8 @@ module Azure
         _list.map{ |hash| Azure::Armrest::ResourceProvider.new(hash) }
       end
 
+      # This is split out for the cache_method feature.
+      #
       def _list
         response = rest_get(build_url)
         JSON.parse(response)["value"]


### PR DESCRIPTION
This deletes most of the code for the fetch_providers method. Instead, it now uses the ResourceProviderService#list method. Not only is the current code redundant, it doesn't cache the results. This causes a lot of unnecessary calls in the ManageIQ event runner, for example.

I opted to keep it a separate method for the sake of rspec testing. By keeping it separate, it's easier to stub responses for it.

The other change that was necessary was to default to nil in the provider_default_api_version method so that the set_service_api_version method can actually work properly.

Lastly I moved the cache_method require into the armrest.rb file where all the other libraries are required in case we want to use it within any other files.