### PR TITLE
Added the get_template method

### DIFF
--- a/lib/azure/armrest/model/base_model.rb
+++ b/lib/azure/armrest/model/base_model.rb
@@ -179,6 +179,7 @@ module Azure
     # Initial class definitions. Reopen these classes as needed.
 
     class AvailabilitySet < BaseModel; end
+    class DeploymentTemplate < BaseModel; end
     class Event < BaseModel; end
     class ImageVersion < BaseModel; end
     class Offer < BaseModel; end

--- a/lib/azure/armrest/template_deployment_service.rb
+++ b/lib/azure/armrest/template_deployment_service.rb
@@ -37,6 +37,18 @@ module Azure
         response = rest_get(url)
         TemplateDeploymentOperation.new(response)
       end
+
+      # Returns the json template as an object for the given deployment.
+      #
+      # If you want the plain JSON text then call .to_json on the returned object.
+      #
+      def get_template(deploy_name, resource_group = configuration.resource_group)
+        validate_resource_group(resource_group)
+        validate_resource(deploy_name)
+        url = build_url(resource_group, deploy_name, 'exportTemplate')
+        response = JSON.parse(rest_post(url))['template']
+        DeploymentTemplate.new(response)
+      end
     end
   end
 end

--- a/spec/template_deployment_service_spec.rb
+++ b/spec/template_deployment_service_spec.rb
@@ -42,6 +42,16 @@ describe "TemplateDeploymentService" do
       tds.create('deployname', 'groupname', {})
     end
 
+    it "defines a get_template method" do
+      expected = @req.merge(
+        :url     => url_prefix + "/deployname/exportTemplate?api-version=#{api_version}",
+        :method  => :post,
+        :payload => ''
+      )
+      expect(RestClient::Request).to receive(:execute).with(expected).and_return('{"template":{}}')
+      tds.get_template('deployname', 'groupname')
+    end
+
     it "defines a delete method" do
       expected = @req.merge(
         :url    => url_prefix + "/deployname?api-version=#{api_version}",


### PR DESCRIPTION
This adds the :get_template method to the TemplateDeploymentService class. This will allow us to get templates without resorting to inspecting deployment objects and then using raw URI calls.