### PR TITLE
Add get_by_id and get_subservice_by_id

### DIFF
--- a/lib/azure/armrest/resource_group_based_service.rb
+++ b/lib/azure/armrest/resource_group_based_service.rb
@@ -2,6 +2,22 @@ module Azure
   module Armrest
     # Base class for services that need to run in a resource group
     class ResourceGroupBasedService < ArmrestService
+      # Used to map service name strings to internal classes
+      SERVICE_NAME_MAP = {
+        'availabilitysets'      => Azure::Armrest::AvailabilitySet,
+        'loadbalancers'         => Azure::Armrest::Network::LoadBalancer,
+        'networkinterfaces'     => Azure::Armrest::Network::NetworkInterface,
+        'networksecuritygroups' => Azure::Armrest::Network::NetworkSecurityGroup,
+        'publicipaddresses'     => Azure::Armrest::Network::IpAddress,
+        'storageaccounts'       => Azure::Armrest::StorageAccount,
+        'virtualnetworks'       => Azure::Armrest::Network::VirtualNetwork,
+        'subnets'               => Azure::Armrest::Network::Subnet,
+        'inboundnatrules'       => Azure::Armrest::Network::InboundNat,
+        'securityrules'         => Azure::Armrest::Network::NetworkSecurityRule,
+        'routes'                => Azure::Armrest::Network::Route,
+        'databases'             => Azure::Armrest::Sql::SqlDatabase,
+      }.freeze
+
       # Create a resource +name+ within the resource group +rgroup+, or the
       # resource group that was specified in the configuration, along with
       # a hash of appropriate +options+.
@@ -73,44 +89,40 @@ module Azure
         filter.empty? ? results : results.select { |obj| filter.all? { |k, v| obj.public_send(k) == v } }
       end
 
-      # This method returns a model object based on an ID string.
+      # This method returns a model object based on an ID string for a Service.
       #
       # Example:
       #
       #   vms = Azure::Armrest::VirtualMachineService.new(conf)
       #
-      #   vm  = vms.get('your_vm', 'your_group')
-      #   nic = vm.get_by_id(vm.properties.network_profile.network_interfaces[0].id)
+      #   vm = vms.get('your_vm', 'your_group')
+      #   nic_id = vm.properties.network_profile.network_interfaces[0].id
+      #   nic = vm.get_associated_resource(nic_id)
       #
-      def get_by_id(id_string)
+      def get_associated_resource(id_string)
         info = parse_id_string(id_string)
 
-        api_version = configuration.provider_default_api_version(info[:provider], info[:service_name])
+        if info['subservice_name']
+          full_service_name = info['service_name'] + '/' + info['subservice_name']
+          api_version = configuration.provider_default_api_version(info['provider'], full_service_name)
+          api_version ||= configuration.provider_default_api_version(info['provider'], info['service_name'])
+        else
+          api_version = configuration.provider_default_api_version(info['provider'], info['service_name'])
+        end
+
         api_version ||= configuration.api_version
+        service_name = info['subservice_name'] || info['service_name']
 
         url = File.join(Azure::Armrest::RESOURCE, id_string) + "?api-version=#{api_version}"
 
-        model_class = case info[:service_name].downcase
-          when 'availabilitysets'
-            Azure::Armrest::AvailabilitySet
-          when 'loadbalancers'
-            Azure::Armrest::Network::LoadBalancer
-          when 'networkinterfaces'
-            Azure::Armrest::Network::NetworkInterface
-          when 'networksecuritygroups'
-            Azure::Armrest::Network::NetworkSecurityGroup
-          when 'publicipaddresses'
-            Azure::Armrest::Network::IPAddress
-          when 'storageaccounts'
-            Azure::Armrest::StorageAccount
-          when 'virtualnetworks'
-            Azure::Armrest::Network::VirtualNetwork
-          else
-            raise ArgumentError, "unable to map service name #{info[:service_name]} to model"
+        model_class = SERVICE_NAME_MAP.fetch(service_name.downcase) do
+          raise ArgumentError, "unable to map service name #{service_name} to model"
         end
 
         model_class.new(rest_get(url))
       end
+
+      alias get_by_id get_associated_resource
 
       # Get information about a single resource +name+ within resource group
       # +rgroup+, or the resource group that was set in the configuration.
@@ -161,9 +173,21 @@ module Azure
 
       # Parse the provider and service name out of an ID string.
       def parse_id_string(id_string)
-        regex = /providers\/(.*?)\/(.*?)\//i
+        regex = %r{
+          subscriptions/
+          (?<subscription_id>[\w\-]+)?/
+          resourceGroups/
+          (?<resource_group>\w+)?/
+          providers/
+          (?<provider>[\w\.]+)?/
+          (?<service_name>\w+)?/
+          (?<resource_name>\w+)
+          (/(?<subservice_name>\w+)?/(?<subservice_resource_name>\w+))*
+          \z
+        }x
+
         match = regex.match(id_string)
-        {:provider => match[1], :service_name => match[2]}
+        Hash[match.names.zip(match.captures)]
       end
 
       # Make additional calls and concatenate the results if a continuation URL is found.

--- a/spec/resource_group_based_service_spec.rb
+++ b/spec/resource_group_based_service_spec.rb
@@ -1,0 +1,63 @@
+########################################################################
+# resource_group_based_service_spec.rb
+#
+# Test suite for the Azure::Armrest::ResourceGroupBasedService class.
+########################################################################
+require 'spec_helper'
+
+describe "ResourceGroupBasedService" do
+  before { setup_params }
+  let(:rgbs) { Azure::Armrest::ResourceGroupBasedService.new(@conf, 'virtualMachines', 'Microsoft.Compute', {}) }
+
+  context "inheritance" do
+    it "is a subclass of ArmrestService" do
+      expect(Azure::Armrest::ResourceGroupBasedService.ancestors).to include(Azure::Armrest::ArmrestService)
+    end
+  end
+
+  context "constructor" do
+    it "returns a rgbs instance as expected" do
+      expect(rgbs).to be_kind_of(Azure::Armrest::ResourceGroupBasedService)
+    end
+  end
+
+  context "instance methods" do
+    it "defines a list method" do
+      expect(rgbs).to respond_to(:list)
+    end
+
+    it "defines a list_all method" do
+      expect(rgbs).to respond_to(:list_all)
+    end
+
+    it "defines a get method" do
+      expect(rgbs).to respond_to(:get)
+    end
+
+    it "defines a get_by_id method" do
+      expect(rgbs).to respond_to(:get_by_id)
+    end
+  end
+
+  context "get_by_id" do
+    let(:id_string) {
+      "/subscriptions/#{@sub}/resourceGroups/#{@res}/providers/Microsoft.Network/networkInterfaces/test123"
+    }
+
+    let(:hash){
+      {
+        'name'       => 'test123',
+        'id'         => id_string,
+        'location'   => 'westus',
+        'properties' => { 'provisioningState' => 'Succeeded' }
+      }
+    }
+
+    it "returns the expected result" do
+      allow(rgbs).to receive(:rest_get).and_return(hash)
+      result = rgbs.get_by_id(id_string)
+      expect(result).to be_kind_of(Azure::Armrest::Network::NetworkInterface)
+      expect(result.name).to eql('test123')
+    end
+  end
+end

--- a/spec/resource_group_based_service_spec.rb
+++ b/spec/resource_group_based_service_spec.rb
@@ -39,24 +39,46 @@ describe "ResourceGroupBasedService" do
     end
   end
 
-  context "get_by_id" do
-    let(:id_string) {
+  context "get associated resource for service" do
+    let(:id_string) do
       "/subscriptions/#{@sub}/resourceGroups/#{@res}/providers/Microsoft.Network/networkInterfaces/test123"
-    }
+    end
 
-    let(:hash){
+    let(:hash) do
       {
         'name'       => 'test123',
         'id'         => id_string,
         'location'   => 'westus',
-        'properties' => { 'provisioningState' => 'Succeeded' }
+        'properties' => {'provisioningState' => 'Succeeded'}
       }
-    }
+    end
 
     it "returns the expected result" do
       allow(rgbs).to receive(:rest_get).and_return(hash)
-      result = rgbs.get_by_id(id_string)
+      result = rgbs.get_associated_resource(id_string)
       expect(result).to be_kind_of(Azure::Armrest::Network::NetworkInterface)
+      expect(result.name).to eql('test123')
+    end
+  end
+
+  context "get associated resource for subservice" do
+    let(:sub_id_string) do
+      "/subscriptions/#{@sub}/resourceGroups/#{@res}/providers/Microsoft.Network/virtualNetworks/testx/subnets/default"
+    end
+
+    let(:hash) do
+      {
+        'name'       => 'test123',
+        'id'         => sub_id_string,
+        'location'   => 'westus',
+        'properties' => {'provisioningState' => 'Succeeded'}
+      }
+    end
+
+    it "returns the expected result" do
+      allow(rgbs).to receive(:rest_get).and_return(hash)
+      result = rgbs.get_associated_resource(sub_id_string)
+      expect(result).to be_kind_of(Azure::Armrest::Network::Subnet)
       expect(result.name).to eql('test123')
     end
   end


### PR DESCRIPTION
This adds two methods to the ResourceGroupBasedService that will allow users to get objects based on an ID string without having to parse that information out themselves.

For example, a VM contains an ID for its NIC like this:

    "id": "/subscriptions/xyz/resourceGroups/some_group/providers/Microsoft.Network/networkInterfaces/some_nic"

With that information we can then get a model object like so:

    nic_id = vm.properties.network_profile.network_interfaces[0].id
    vms.get_by_id(nic_id)

This will also make deleting associated resources easier.