### PR TITLE
Clear all CacheMethod caches in the clear_caches method

### DIFF
--- a/lib/azure/armrest/configuration.rb
+++ b/lib/azure/armrest/configuration.rb
@@ -5,6 +5,7 @@ module Azure
       def self.clear_caches
         # Used to store unique token information.
         @token_cache = Hash.new { |h, k| h[k] = [] }
+        CacheMethod.config.storage.clear
       end
 
       clear_caches # Clear caches at load time.


### PR DESCRIPTION
This PR updates the `Configuration.clear_caches` method to clear the CacheMethod caches in addition to our own.

This is not only intuitive IMO, but also useful when regenerating VCR cassettes.