### PR TITLE
Add a log accessor and basic specs.

### DIFF
--- a/lib/azure/armrest/armrest_service.rb
+++ b/lib/azure/armrest/armrest_service.rb
@@ -1,4 +1,5 @@
 require 'time'
+require 'logger'
 require_relative 'model/base_model'
 
 module Azure
@@ -20,6 +21,9 @@ module Azure
 
       # The api-version string for this particular service
       attr_accessor :api_version
+
+      # A Logger instance for this service.
+      attr_accessor :log
 
       # Returns a new Armrest::Configuration object.
       #

--- a/spec/armrest_service_spec.rb
+++ b/spec/armrest_service_spec.rb
@@ -64,6 +64,11 @@ describe Azure::Armrest::ArmrestService do
     it "defines a wait method" do
       expect(subject).to respond_to(:wait)
     end
+
+    it "defines a log accessor" do
+      expect(subject).to respond_to(:log)
+      expect(subject).to respond_to(:log=)
+    end
   end
 
   context "poll and wait" do


### PR DESCRIPTION
This adds a :log accessor to the ArmrestService class, the assumption being that it would be a Logger instance. This allows users to do logging for individual service classes without having to use the class level log, which is really only meant for logging the underlying http requests being made by rest-client.