### PR TITLE
Update regex for parse_id_string, add support for extensions.

### DIFF
--- a/lib/azure/armrest/resource_group_based_service.rb
+++ b/lib/azure/armrest/resource_group_based_service.rb
@@ -16,6 +16,7 @@ module Azure
         'securityrules'         => Azure::Armrest::Network::NetworkSecurityRule,
         'routes'                => Azure::Armrest::Network::Route,
         'databases'             => Azure::Armrest::Sql::SqlDatabase,
+        'extensions'            => Azure::Armrest::VirtualMachineExtension
       }.freeze
 
       # Create a resource +name+ within the resource group +rgroup+, or the
@@ -175,14 +176,14 @@ module Azure
       def parse_id_string(id_string)
         regex = %r{
           subscriptions/
-          (?<subscription_id>[\w\-]+)?/
+          (?<subscription_id>[^\/]+)?/
           resourceGroups/
-          (?<resource_group>\w+)?/
+          (?<resource_group>[^\/]+)?/
           providers/
-          (?<provider>[\w\.]+)?/
-          (?<service_name>\w+)?/
-          (?<resource_name>\w+)
-          (/(?<subservice_name>\w+)?/(?<subservice_resource_name>\w+))*
+          (?<provider>[^\/]+)?/
+          (?<service_name>[^\/]+)?/
+          (?<resource_name>[^\/]+)
+          (/(?<subservice_name>[^\/]+)?/(?<subservice_resource_name>[^\/]+))*
           \z
         }x
 

--- a/spec/resource_group_based_service_spec.rb
+++ b/spec/resource_group_based_service_spec.rb
@@ -75,10 +75,19 @@ describe "ResourceGroupBasedService" do
       }
     end
 
-    it "returns the expected result" do
+    it "returns the expected result for a basic ID string" do
       allow(rgbs).to receive(:rest_get).and_return(hash)
       result = rgbs.get_associated_resource(sub_id_string)
       expect(result).to be_kind_of(Azure::Armrest::Network::Subnet)
+      expect(result.name).to eql('test123')
+    end
+
+    it "returns the expected result for an ID string that contains hyphens and periods" do
+      sub_id_string = "/subscriptions/#{@sub}/resourceGroups/foo-bar/providers/Microsoft.Compute"
+      sub_id_string << "/virtualMachines/some_vm/extensions/Microsoft.Insights.VMDiagnosticsSettings"
+      allow(rgbs).to receive(:rest_get).and_return(hash)
+      result = rgbs.get_associated_resource(sub_id_string)
+      expect(result).to be_kind_of(Azure::Armrest::VirtualMachineExtension)
       expect(result.name).to eql('test123')
     end
   end


### PR DESCRIPTION
This updates the parse_id_string method to handle hyphens and periods within resource groups and resource names, respectively. It also handles the "extension" service name, converting it to `VirtualMachineExtension`.

This is actually part 1 to fixing https://bugzilla.redhat.com/show_bug.cgi?id=1390715 because I need to get the extension information to get the correct storage account for metrics.