### PR TITLE
Modify the ResourceService list and list_all methods to get more that 1000 results

### DIFF
--- a/lib/azure/armrest/resource_group_based_service.rb
+++ b/lib/azure/armrest/resource_group_based_service.rb
@@ -190,21 +190,6 @@ module Azure
         Hash[match.names.zip(match.captures)]
       end
 
-      # Make additional calls and concatenate the results if a continuation URL is found.
-      def get_all_results(response)
-        results  = Azure::Armrest::ArmrestCollection.create_from_response(response, model_class)
-        nextlink = JSON.parse(response)['nextLink']
-
-        while nextlink
-          response = rest_get_without_encoding(nextlink)
-          more = Azure::Armrest::ArmrestCollection.create_from_response(response, model_class)
-          results.concat(more)
-          nextlink = JSON.parse(response)['nextLink']
-        end
-
-        results
-      end
-
       def validate_resource_group(name)
         raise ArgumentError, "must specify resource group" unless name
       end
@@ -222,10 +207,6 @@ module Azure
         url = File.join(url, 'providers', @provider, @service_name)
         url = File.join(url, *args) unless args.empty?
         url << "?api-version=#{@api_version}"
-      end
-
-      def model_class
-        @model_class ||= Object.const_get(self.class.to_s.sub(/Service$/, ''))
       end
 
       # Aggregate resources from all resource groups.

--- a/lib/azure/armrest/resource_service.rb
+++ b/lib/azure/armrest/resource_service.rb
@@ -14,6 +14,9 @@ module Azure
       # resource group. You can optionally pass :top or :filter options as well
       # to restrict returned results.
       #
+      # Normally this is capped at 1000 results, but you may specify the :all
+      # option to get everything.
+      #
       # Examples:
       #
       #   rs = Azure::Armrest::ResourceService.new
@@ -23,16 +26,29 @@ module Azure
       def list(resource_group, options = {})
         url = build_url(resource_group, options)
         response = rest_get(url)
-        Azure::Armrest::ArmrestCollection.create_from_response(response, Azure::Armrest::Resource)
+
+        if options[:all]
+          get_all_results(response)
+        else
+          Azure::Armrest::ArmrestCollection.create_from_response(response, Azure::Armrest::Resource)
+        end
       end
 
       # Same as Azure::Armrest::ResourceService#list but returns all resources
       # for all resource groups.
       #
+      # Normally this is capped at 1000 results, but you may specify the :all
+      # option to get everything.
+      #
       def list_all(options = {})
         url = build_url(nil, options)
         response = rest_get(url)
-        Azure::Armrest::ArmrestCollection.create_from_response(response, Azure::Armrest::Resource)
+
+        if options[:all]
+          get_all_results(response)
+        else
+          Azure::Armrest::ArmrestCollection.create_from_response(response, Azure::Armrest::Resource)
+        end
       end
 
       # Move the resources from +source_group+ under +source_subscription+,


### PR DESCRIPTION
This modifies the ResourceService so that a user may optionally retrieve all resources for the `:list` and `:list_all` methods. Currently the results are capped at 1000.

Because this could retrieve a lot of data for a subscription, a user must specify `:all => true` for this behavior.

This PR required moving the :get_all_resources and :model_class methods from the ResourceGroupBasedService class to the ArmrestService class. That way all service classes inherit those methods.