### PR TITLE
Add a configuration singleton accessor 

### DIFF
--- a/lib/azure/armrest/model/base_model.rb
+++ b/lib/azure/armrest/model/base_model.rb
@@ -12,6 +12,16 @@ module Azure
         @excl_list ||= superclass.respond_to?(:excl_list, true) ? superclass.send(:excl_list) : Set.new
       end
 
+      # Set the configuration for all instances of the service class.
+      def self.configuration=(config)
+        @configuration = config
+      end
+
+      # Retrieve the configuration for the service class.
+      def self.configuration
+        @configuration
+      end
+
       private_class_method :excl_list
 
       # Merge the declared exclusive attributes to the existing list.

--- a/lib/azure/armrest/resource_group_based_service.rb
+++ b/lib/azure/armrest/resource_group_based_service.rb
@@ -33,6 +33,7 @@ module Azure
       def create(name, rgroup = configuration.resource_group, options = {})
         validate_resource_group(rgroup)
         validate_resource(name)
+        set_model_class_configuration
 
         url = build_url(rgroup, name)
         url = yield(url) || url if block_given?
@@ -63,6 +64,7 @@ module Azure
       #
       def list(rgroup = configuration.resource_group)
         validate_resource_group(rgroup)
+        set_model_class_configuration
 
         url = build_url(rgroup)
         url = yield(url) || url if block_given?
@@ -81,6 +83,8 @@ module Azure
       #   vms.list_all(:location => "eastus", :resource_group => "rg1")
       #
       def list_all(filter = {})
+        model_class.configuration = configuration
+
         url = build_url
         url = yield(url) || url if block_given?
 
@@ -120,6 +124,8 @@ module Azure
           raise ArgumentError, "unable to map service name #{service_name} to model"
         end
 
+        model_class.configuration = configuration
+
         model_class.new(rest_get(url))
       end
 
@@ -131,6 +137,7 @@ module Azure
       def get(name, rgroup = configuration.resource_group)
         validate_resource_group(rgroup)
         validate_resource(name)
+        set_model_class_configuration
 
         url = build_url(rgroup, name)
         url = yield(url) || url if block_given?
@@ -197,6 +204,10 @@ module Azure
 
       def validate_resource(name)
         raise ArgumentError, "must specify #{@service_name.singularize.underscore.humanize}" unless name
+      end
+
+      def set_model_class_configuration
+        model_class.configuration = configuration
       end
 
       # Builds a URL based on subscription_id an resource_group and any other

--- a/spec/models/base_model_spec.rb
+++ b/spec/models/base_model_spec.rb
@@ -221,4 +221,14 @@ describe "BaseModel" do
       expect(base.eql?(Azure::Armrest::BaseModel.new(json))).to be true
     end
   end
+
+  context "configuration singleton accessor" do
+    it "defines a configuration singleton method" do
+      expect(Azure::Armrest::BaseModel).to respond_to(:configuration)
+    end
+
+    it "defines a configuration= singleton method" do
+      expect(Azure::Armrest::BaseModel).to respond_to(:configuration=)
+    end
+  end
 end


### PR DESCRIPTION
This adds a :configuration accessor to the BaseModel class, and sets it within the various methods of the ResourceGroupBasedService. This will set the configuration information on a per model class basis, and would allow access to it within the models.

By allowing the models to access configuration information, models like StorageAccount can access and use that information directly, instead of having to set everything manually as we do now for StorageAccountService methods, for example.