### PR TITLE
Add a service_name accessor

### DIFF
--- a/lib/azure/armrest/armrest_service.rb
+++ b/lib/azure/armrest/armrest_service.rb
@@ -18,6 +18,9 @@ module Azure
       # Provider for service specific API calls
       attr_accessor :provider
 
+      # The service name for the Service class
+      attr_accessor :service_name
+
       # The api-version string for this particular service
       attr_accessor :api_version
 

--- a/spec/armrest_service_spec.rb
+++ b/spec/armrest_service_spec.rb
@@ -111,6 +111,12 @@ describe Azure::Armrest::ArmrestService do
       expect(subject).to respond_to(:base_url=)
       expect(subject.base_url).to eq(Azure::Armrest::RESOURCE)
     end
+
+    it "defines a service_name accessor" do
+      expect(subject).to respond_to(:service_name)
+      expect(subject).to respond_to(:service_name=)
+      expect(subject.service_name).to eq('servicename')
+    end
   end
 
   context "api exception handling" do


### PR DESCRIPTION
This adds a :service_name accessor. We store this information in an instance variable, e.g. "virtualMachines", but apparently never created an accessor for it.

This can be useful for URL building in internal methods.