### PR TITLE
Fix Billage::Usage model and update Usage#list method

### DIFF
--- a/lib/azure/armrest/billing/usage_service.rb
+++ b/lib/azure/armrest/billing/usage_service.rb
@@ -18,15 +18,42 @@ module Azure
         #   :showDetails              # Either true or false. Default is true.
         #   :continuationToken        # Token received from previous call. No default.
         #
+        # You may also pass ':all => true' to retrieve all records instead of
+        # dealing with continuation tokens yourself. By default Azure will only
+        # return the first 1000 records.
+        #
         # The :reportedStartTime and :reportedEndTime values should be in
         # UTC + iso8601 format. For "Daily" aggregation, the time should be set
         # to midnight. For "Hourly" aggregation, only the hour should be
         # set, with minutes and seconds set to "00".
         #
+        # Example:
+        #
+        #   require 'azure-armrest'
+        #   require 'time'
+        #
+        #   conf = Azure::Armrest::Configuration.new(<your_credentials>)
+        #   bill = Azure::Armrest::Billing::UsageService.new(conf)
+        #
+        #   options = {
+        #     :reportedStartTime      => Time.new(2016,10,1,0,0,0,0).utc.iso8601,
+        #     :reportedEndTime        => Time.new(2016,10,31,0,0,0,0).utc.iso8601,
+        #     :showDetails            => true,
+        #     :aggregationGranularity => 'Daily',
+        #     :all                    => true
+        #   }
+        #
+        #   list = bill.list(options)
+        #
         def list(options = {})
           url = build_url(options)
           response = rest_get(url)
-          JSON.parse(response)['value'].map { |hash| Azure::Armrest::Usage.new(hash) }
+
+          if options[:all]
+            get_all_results(response)
+          else
+            Azure::Armrest::ArmrestCollection.create_from_response(response, Azure::Armrest::Billing::Usage)
+          end
         end
 
         private

--- a/lib/azure/armrest/model/base_model.rb
+++ b/lib/azure/armrest/model/base_model.rb
@@ -189,7 +189,10 @@ module Azure
     class ResourceGroup < BaseModel; end
     class ResourceProvider < BaseModel; end
     class Sku < BaseModel; end
-    class Usage < BaseModel; end
+
+    module Billing
+      class Usage < BaseModel; end
+    end
 
     class ResponseHeaders < BaseModel
       undef_method :response_headers


### PR DESCRIPTION
This PR fixes the Billing::Usage model scoping (it was missing the Billing module), and updates the list method to return an ArmrestCollection instead of a plain array.

In addition, it now supports the `:all` option so that users can automatically retrieve more than 1k records. I also added a code example.