### PR TITLE
Add environment support

### DIFF
--- a/lib/azure/armrest.rb
+++ b/lib/azure/armrest.rb
@@ -11,10 +11,13 @@ module Azure
   # The Armrest module mostly serves as a namespace, but also contains any
   # common constants shared by subclasses.
   module Armrest
-    # The default Azure resource
+    # The default (public) Azure resource
     RESOURCE = "https://management.azure.com/"
 
-    # The default authority resource
+    # The resource for US Government clients
+    GOV_RESOURCE = "https://management.usgovcloudapi.net/"
+
+    # The default (public) authority resource
     AUTHORITY = "https://login.windows.net/"
 
     # A common URI for all subclasses

--- a/lib/azure/armrest/configuration.rb
+++ b/lib/azure/armrest/configuration.rb
@@ -64,6 +64,9 @@ module Azure
       # Maximum number of threads to use within methods that use Parallel for thread pooling.
       attr_accessor :max_threads
 
+      # The environment in which to acquire your token.
+      attr_reader :environment
+
       # Yields a new Azure::Armrest::Configuration objects. Note that you must
       # specify a client_id, client_key, tenant_id. The subscription_id is optional
       # but should be specified in most cases. All other parameters are optional.
@@ -109,6 +112,9 @@ module Azure
         @tenant_id = options.delete(:tenant_id)
         @client_id = options.delete(:client_id)
         @client_key = options.delete(:client_key)
+
+        # Delay this to avoid a double call
+        @environment = options.delete(:environment)
 
         unless client_id && client_key && tenant_id
           raise ArgumentError, "client_id, client_key, and tenant_id must all be specified"
@@ -173,6 +179,17 @@ module Azure
       def token_expiration
         ensure_token
         @token_expiration
+      end
+
+      # Sets the environment to authenticate against. The environment
+      # must support ActiveDirectory.
+      #
+      # At the moment, only standard Azure and US Government Azure
+      # environments are supported.
+      #
+      def environment=(env)
+        fetch_token if env != environment
+        @environment = env
       end
 
       # Return the default api version for the given provider and service
@@ -277,6 +294,13 @@ module Azure
       def fetch_token
         token_url = File.join(Azure::Armrest::AUTHORITY, tenant_id, 'oauth2/token')
 
+        # Allows for "AzureUSGovernment", "US Government", etc
+        if environment =~ /US\s*?Government$/i
+          resource = Azure::Armrest::GOV_RESOURCE
+        else
+          resource = Azure::Armrest::RESOURCE
+        end
+
         response = JSON.parse(
           ArmrestService.send(
             :rest_post,
@@ -288,7 +312,7 @@ module Azure
               :grant_type    => grant_type,
               :client_id     => client_id,
               :client_secret => client_key,
-              :resource      => Azure::Armrest::RESOURCE
+              :resource      => resource
             }
           )
         )

--- a/lib/azure/armrest/configuration.rb
+++ b/lib/azure/armrest/configuration.rb
@@ -185,7 +185,8 @@ module Azure
       # must support ActiveDirectory.
       #
       # At the moment, only standard Azure and US Government Azure
-      # environments are supported.
+      # environments are supported. For the US government set the
+      # argument to 'USGov'. Otherwise, set it to nil.
       #
       def environment=(env)
         fetch_token if env != environment
@@ -294,8 +295,7 @@ module Azure
       def fetch_token
         token_url = File.join(Azure::Armrest::AUTHORITY, tenant_id, 'oauth2/token')
 
-        # Allows for "AzureUSGovernment", "US Government", etc
-        if environment =~ /US\s*?Government$/i
+        if environment.to_s.casecmp('USGov') == 0
           resource = Azure::Armrest::GOV_RESOURCE
         else
           resource = Azure::Armrest::RESOURCE

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -64,6 +64,10 @@ describe Azure::Armrest::Configuration do
       it 'defines a subscriptions method' do
         expect(subject).to respond_to(:subscriptions)
       end
+
+      it 'defines an environment= method' do
+        expect(subject).to respond_to(:environment=)
+      end
     end
 
     context 'accessors' do
@@ -115,11 +119,18 @@ describe Azure::Armrest::Configuration do
         expect(subject.tenant_id).to eql('new_id')
       end
 
-      it 'defines a subscription_id accessor' do
+      it 'defines a subscription_id reader' do
         allow(subject).to receive(:validate_subscription).and_return(true)
         expect(subject.subscription_id).to eql(options[:subscription_id])
         subject.subscription_id = 'new_id'
         expect(subject.subscription_id).to eql('new_id')
+      end
+
+      it 'defines an environment reader' do
+        allow(subject).to receive(:fetch_token).and_return('xxx')
+        expect(subject.environment).to eql(options[:environment])
+        subject.environment = 'usgov'
+        expect(subject.environment).to eql('usgov')
       end
 
       it 'defines a max_threads accessor' do


### PR DESCRIPTION
This PR allows US Government clients to acquire the correct auth token by adding an :environment accessor. Government clients use a different endpoint URL, so the proper resource URL is used depending on the environment.

The use of the term "environment" lines up with both Powershell and the Azure CLI.

Addresses https://bugzilla.redhat.com/show_bug.cgi?id=1403366

So in practice you could do:

    conf = Azure::Armrest::Configuration.new(
        :client_id   => 'xxx',
        :client_key  => 'yyy',
        :tenant_id   => 'zzz',
        :environment => 'US Government'
    )

    vms = Azure::Armrest::VirtualMachineService.new(conf)

    # You can also set it after the fact
    conf.environment = nil # would reset it to the public URL
    vms = Azure::Armrest::VirtualMachineService.new(conf)