### PR TITLE
Add a common log method to ArmrestService

### DIFF
--- a/lib/azure/armrest/armrest_service.rb
+++ b/lib/azure/armrest/armrest_service.rb
@@ -353,6 +353,10 @@ module Azure
       def model_class
         @model_class ||= Object.const_get(self.class.to_s.sub(/Service$/, ''))
       end
+
+      def log(level = "info", msg)
+        RestClient.log.try(level, msg)
+      end
     end # ArmrestService
   end # Armrest
 end # Azure

--- a/lib/azure/armrest/configuration.rb
+++ b/lib/azure/armrest/configuration.rb
@@ -215,6 +215,7 @@ module Azure
       # Sets the log to +output+, which can be a file or a handle.
       #
       def self.log=(output)
+        output = Logger.new(output) unless output.kind_of?(Logger)
         RestClient.log = output
       end
 

--- a/lib/azure/armrest/configuration.rb
+++ b/lib/azure/armrest/configuration.rb
@@ -202,17 +202,15 @@ module Azure
         end
       end
 
-      # The name of the file or handle used to log http requests.
-      #--
-      # We have to do a little extra work here to convert a possible
-      # file handle to a file name.
+      # Returns the logger instance. It might be initially set through a log
+      # file path, file handler, or already a logger instance.
       #
       def self.log
-        file = RestClient.log.instance_variable_get("@target_file")
-        file || RestClient.log
+        RestClient.log
       end
 
-      # Sets the log to +output+, which can be a file or a handle.
+      # Sets the log to +output+, which can be a file, a file handle, or
+      # a logger instance
       #
       def self.log=(output)
         output = Logger.new(output) unless output.kind_of?(Logger)

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -248,14 +248,20 @@ describe Azure::Armrest::Configuration do
     context 'logging' do
       it 'accepts a file name for a log' do
         described_class.log = log
-        expect(described_class.log).to eq(log)
+        expect(described_class.log).to be_kind_of(Logger)
       end
 
       it 'accepts a file handle for a log' do
         File.open(log, 'w+') do |fh|
           described_class.log = fh
-          expect(described_class.log).to eq(fh)
+          expect(described_class.log).to be_kind_of(Logger)
         end
+      end
+
+      it 'accepts a Logger instance' do
+        logger = Logger.new(STDOUT)
+        described_class.log = logger
+        expect(described_class.log).to eq(logger)
       end
     end
   end


### PR DESCRIPTION
Ensure the RestClient.log to be an instance of Logger.

Move `VirtualMachineService#log_message` to base `ArmrestService` class. Slight modification - do not log anything unless the user provides a logger. Since this is a library, I feel we should not pollute console if the caller does not want to.

This common `log` method is private, meaning to be used internally by the service classes, not open to caller to write outside the gem.