### PR TITLE
Add resource and authority accessors to Configuration class

### DIFF
--- a/lib/azure/armrest.rb
+++ b/lib/azure/armrest.rb
@@ -15,10 +15,16 @@ module Azure
     RESOURCE = "https://management.azure.com/"
 
     # The resource for US Government clients
-    GOV_RESOURCE = "https://management.usgovcloudapi.net/"
+    USGOV_RESOURCE = "https://management.core.usgovcloudapi.net/"
 
     # The default (public) authority resource
     AUTHORITY = "https://login.windows.net/"
+
+    # The authority for US Government clients
+    USGOV_AUTHORITY = "https://login-us.windows.net/"
+
+    # Environment string used to indicate US Government
+    USGOV_ENVIRONMENT = 'USGov'
 
     # A common URI for all subclasses
     COMMON_URI = RESOURCE + "subscriptions/"

--- a/lib/azure/armrest/armrest_service.rb
+++ b/lib/azure/armrest/armrest_service.rb
@@ -46,7 +46,7 @@ module Azure
         end
 
         # Base URL used for REST calls. Modify within method calls as needed.
-        @base_url = armrest_configuration.resource
+        @base_url = armrest_configuration.resource_url
 
         set_service_api_version(options, service_name)
       end

--- a/lib/azure/armrest/armrest_service.rb
+++ b/lib/azure/armrest/armrest_service.rb
@@ -46,7 +46,7 @@ module Azure
         end
 
         # Base URL used for REST calls. Modify within method calls as needed.
-        @base_url = Azure::Armrest::RESOURCE
+        @base_url = armrest_configuration.resource
 
         set_service_api_version(options, service_name)
       end

--- a/lib/azure/armrest/configuration.rb
+++ b/lib/azure/armrest/configuration.rb
@@ -68,10 +68,10 @@ module Azure
       attr_reader :environment
 
       # The authority URL used to acquire a valid token.
-      attr_accessor :resource
+      attr_accessor :resource_url
 
       # The resource URL used to acquire a valid token.
-      attr_accessor :authority
+      attr_accessor :authority_url
 
       # Yields a new Azure::Armrest::Configuration objects. Note that you must
       # specify a client_id, client_key, tenant_id. The subscription_id is optional
@@ -99,15 +99,15 @@ module Azure
       def initialize(args)
         # Use defaults, and override with provided arguments
         options = {
-          :api_version  => '2015-01-01',
-          :accept       => 'application/json',
-          :content_type => 'application/json',
-          :grant_type   => 'client_credentials',
-          :proxy        => ENV['http_proxy'],
-          :ssl_version  => 'TLSv1',
-          :max_threads  => 10,
-          :authority    => Azure::Armrest::AUTHORITY,
-          :resource     => Azure::Armrest::RESOURCE
+          :api_version   => '2015-01-01',
+          :accept        => 'application/json',
+          :content_type  => 'application/json',
+          :grant_type    => 'client_credentials',
+          :proxy         => ENV['http_proxy'],
+          :ssl_version   => 'TLSv1',
+          :max_threads   => 10,
+          :authority_url => Azure::Armrest::AUTHORITY,
+          :resource_url  => Azure::Armrest::RESOURCE
         }.merge(args.symbolize_keys)
 
         # Avoid thread safety issues for VCR testing.
@@ -125,8 +125,8 @@ module Azure
         @environment = options.delete(:environment)
 
         if @environment.to_s.casecmp(Azure::Armrest::USGOV_ENVIRONMENT) == 0
-          options[:authority] = Azure::Armrest::USGOV_AUTHORITY
-          options[:resource]  = Azure::Armrest::USGOV_RESOURCE
+          options[:authority_url] = Azure::Armrest::USGOV_AUTHORITY
+          options[:resource_url]  = Azure::Armrest::USGOV_RESOURCE
         end
 
         unless client_id && client_key && tenant_id
@@ -306,7 +306,7 @@ module Azure
       end
 
       def fetch_token
-        token_url = File.join(authority, tenant_id, 'oauth2/token')
+        token_url = File.join(authority_url, tenant_id, 'oauth2/token')
 
         response = JSON.parse(
           ArmrestService.send(
@@ -319,7 +319,7 @@ module Azure
               :grant_type    => grant_type,
               :client_id     => client_id,
               :client_secret => client_key,
-              :resource      => resource
+              :resource      => resource_url
             }
           )
         )

--- a/lib/azure/armrest/insights/diagnostic_service.rb
+++ b/lib/azure/armrest/insights/diagnostic_service.rb
@@ -80,7 +80,7 @@ module Azure
 
         def build_url(resource_id)
           url = File.join(
-            configuration.resource,
+            configuration.resource_url,
             resource_id,
             'providers',
             provider,

--- a/lib/azure/armrest/insights/diagnostic_service.rb
+++ b/lib/azure/armrest/insights/diagnostic_service.rb
@@ -80,7 +80,7 @@ module Azure
 
         def build_url(resource_id)
           url = File.join(
-            Azure::Armrest::RESOURCE,
+            configuration.resource,
             resource_id,
             'providers',
             provider,

--- a/lib/azure/armrest/resource_group_based_service.rb
+++ b/lib/azure/armrest/resource_group_based_service.rb
@@ -114,7 +114,7 @@ module Azure
         api_version ||= configuration.api_version
         service_name = info['subservice_name'] || info['service_name']
 
-        url = File.join(configuration.resource, id_string) + "?api-version=#{api_version}"
+        url = File.join(configuration.resource_url, id_string) + "?api-version=#{api_version}"
 
         model_class = SERVICE_NAME_MAP.fetch(service_name.downcase) do
           raise ArgumentError, "unable to map service name #{service_name} to model"

--- a/lib/azure/armrest/resource_group_based_service.rb
+++ b/lib/azure/armrest/resource_group_based_service.rb
@@ -114,7 +114,7 @@ module Azure
         api_version ||= configuration.api_version
         service_name = info['subservice_name'] || info['service_name']
 
-        url = File.join(Azure::Armrest::RESOURCE, id_string) + "?api-version=#{api_version}"
+        url = File.join(configuration.resource, id_string) + "?api-version=#{api_version}"
 
         model_class = SERVICE_NAME_MAP.fetch(service_name.downcase) do
           raise ArgumentError, "unable to map service name #{service_name} to model"

--- a/lib/azure/armrest/resource_provider_service.rb
+++ b/lib/azure/armrest/resource_provider_service.rb
@@ -61,7 +61,7 @@ module Azure
       end
 
       def _list_all
-        url = File.join(Azure::Armrest::RESOURCE, 'providers')
+        url = File.join(configuration.resource, 'providers')
         url << "?api-version=#{@api_version}"
         response = rest_get(url)
         JSON.parse(response)['value']

--- a/lib/azure/armrest/resource_provider_service.rb
+++ b/lib/azure/armrest/resource_provider_service.rb
@@ -61,7 +61,7 @@ module Azure
       end
 
       def _list_all
-        url = File.join(configuration.resource, 'providers')
+        url = File.join(configuration.resource_url, 'providers')
         url << "?api-version=#{@api_version}"
         response = rest_get(url)
         JSON.parse(response)['value']

--- a/lib/azure/armrest/subscription_service.rb
+++ b/lib/azure/armrest/subscription_service.rb
@@ -28,7 +28,7 @@ module Azure
       private
 
       def subscriptions_url
-        File.join(Azure::Armrest::RESOURCE, 'subscriptions')
+        File.join(configuration.resource, 'subscriptions')
       end
     end
   end

--- a/lib/azure/armrest/subscription_service.rb
+++ b/lib/azure/armrest/subscription_service.rb
@@ -28,7 +28,7 @@ module Azure
       private
 
       def subscriptions_url
-        File.join(configuration.resource, 'subscriptions')
+        File.join(configuration.resource_url, 'subscriptions')
       end
     end
   end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -53,6 +53,13 @@ describe Azure::Armrest::Configuration do
       options[:token_expiration] = Time.now.utc + 1.month
       expect(described_class.new(options).token).to eq('token_string')
     end
+
+    it 'sets the authority and resource to appropriate values for US Gov' do
+      options[:environment] = 'usgov'
+      config = described_class.new(options)
+      expect(config.resource).to eql(Azure::Armrest::USGOV_RESOURCE) 
+      expect(config.authority).to eql(Azure::Armrest::USGOV_AUTHORITY) 
+    end
   end
 
   context 'instances' do
@@ -137,6 +144,18 @@ describe Azure::Armrest::Configuration do
         expect(subject.max_threads).to eql(10)
         subject.max_threads = 8
         expect(subject.max_threads).to eql(8)
+      end
+
+      it 'defines a resource accessor' do
+        expect(subject.resource).to eql(Azure::Armrest::RESOURCE)
+        subject.resource = 'https://foo.bar/'
+        expect(subject.resource).to eql('https://foo.bar/')
+      end
+
+      it 'defines an authority accessor' do
+        expect(subject.authority).to eql(Azure::Armrest::AUTHORITY)
+        subject.authority = 'https://foo.bar/'
+        expect(subject.authority).to eql('https://foo.bar/')
       end
     end
 

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -54,11 +54,11 @@ describe Azure::Armrest::Configuration do
       expect(described_class.new(options).token).to eq('token_string')
     end
 
-    it 'sets the authority and resource to appropriate values for US Gov' do
+    it 'sets the authority url and resource url to appropriate values for US Gov' do
       options[:environment] = 'usgov'
       config = described_class.new(options)
-      expect(config.resource).to eql(Azure::Armrest::USGOV_RESOURCE) 
-      expect(config.authority).to eql(Azure::Armrest::USGOV_AUTHORITY) 
+      expect(config.resource_url).to eql(Azure::Armrest::USGOV_RESOURCE) 
+      expect(config.authority_url).to eql(Azure::Armrest::USGOV_AUTHORITY) 
     end
   end
 
@@ -146,16 +146,16 @@ describe Azure::Armrest::Configuration do
         expect(subject.max_threads).to eql(8)
       end
 
-      it 'defines a resource accessor' do
-        expect(subject.resource).to eql(Azure::Armrest::RESOURCE)
-        subject.resource = 'https://foo.bar/'
-        expect(subject.resource).to eql('https://foo.bar/')
+      it 'defines a resource_url accessor' do
+        expect(subject.resource_url).to eql(Azure::Armrest::RESOURCE)
+        subject.resource_url = 'https://foo.bar/'
+        expect(subject.resource_url).to eql('https://foo.bar/')
       end
 
-      it 'defines an authority accessor' do
-        expect(subject.authority).to eql(Azure::Armrest::AUTHORITY)
-        subject.authority = 'https://foo.bar/'
-        expect(subject.authority).to eql('https://foo.bar/')
+      it 'defines an authority_url accessor' do
+        expect(subject.authority_url).to eql(Azure::Armrest::AUTHORITY)
+        subject.authority_url = 'https://foo.bar/'
+        expect(subject.authority_url).to eql('https://foo.bar/')
       end
     end
 


### PR DESCRIPTION
This continues our goal of supporting US Gov for Azure by adding both `:resource` and `:authority` accessors to the Configuration class. If the `:environment` is set to 'usgov' then those accessors are set to the appropriate values automatically.

Service classes that were using the RESOURCE constants internally have been refactored to use the configuration accessor, and specs have been added.

Lastly, the resource for usgov needed a fix.