### PR TITLE
Remove COMMON constant and modify base_url to include subscription

### DIFF
--- a/lib/azure/armrest.rb
+++ b/lib/azure/armrest.rb
@@ -25,9 +25,6 @@ module Azure
 
     # Environment string used to indicate US Government
     USGOV_ENVIRONMENT = 'usgov'
-
-    # A common URI for all subclasses
-    COMMON_URI = RESOURCE + "subscriptions/"
   end
 end
 

--- a/lib/azure/armrest/armrest_service.rb
+++ b/lib/azure/armrest/armrest_service.rb
@@ -12,7 +12,7 @@ module Azure
 
       alias configuration armrest_configuration
 
-      # Base url used for REST calls.
+      # Base url with subscription information used for most REST calls.
       attr_accessor :base_url
 
       # Provider for service specific API calls
@@ -46,7 +46,7 @@ module Azure
         end
 
         # Base URL used for REST calls. Modify within method calls as needed.
-        @base_url = armrest_configuration.resource_url
+        @base_url = File.join(configuration.resource_url, 'subscriptions', configuration.subscription_id)
 
         set_service_api_version(options, service_name)
       end

--- a/lib/azure/armrest/billing/usage_service.rb
+++ b/lib/azure/armrest/billing/usage_service.rb
@@ -59,14 +59,7 @@ module Azure
         private
 
         def build_url(options = {})
-          url = File.join(
-            Azure::Armrest::COMMON_URI,
-            configuration.subscription_id,
-            'providers',
-            @provider,
-            'UsageAggregates'
-          )
-
+          url = File.join(base_url, 'providers', @provider, 'UsageAggregates')
           url << "?api-version=#{@api_version}"
 
           options.each do |key, value|

--- a/lib/azure/armrest/insights/event_service.rb
+++ b/lib/azure/armrest/insights/event_service.rb
@@ -66,19 +66,7 @@ module Azure
         private
 
         def build_url(options = {})
-          sub_id = armrest_configuration.subscription_id
-
-          url =
-            File.join(
-              Azure::Armrest::COMMON_URI,
-              sub_id,
-              'providers',
-              provider,
-              'eventtypes',
-              'management',
-              'values'
-            )
-
+          url = File.join(base_url, 'providers', provider, 'eventtypes', 'management', 'values')
           url << "?api-version=#{@api_version}"
           url << "&$filter=#{options[:filter]}" if options[:filter]
           url << "&$select=#{options[:select]}" if options[:select]

--- a/lib/azure/armrest/insights/metrics_service.rb
+++ b/lib/azure/armrest/insights/metrics_service.rb
@@ -34,11 +34,8 @@ module Azure
         private
 
         def build_url(provider, resource_type, resource_name, resource_group, options)
-          sub_id = configuration.subscription_id
-
           url = File.join(
-            Azure::Armrest::COMMON_URI,
-            sub_id,
+            base_url,
             'resourceGroups',
             resource_group,
             'providers',

--- a/lib/azure/armrest/resource_group_based_service.rb
+++ b/lib/azure/armrest/resource_group_based_service.rb
@@ -203,7 +203,7 @@ module Azure
       # arguments provided, and appends it with the api_version.
       #
       def build_url(resource_group = nil, *args)
-        url = File.join(Azure::Armrest::COMMON_URI, configuration.subscription_id)
+        url = base_url
         url = File.join(url, 'resourceGroups', resource_group) if resource_group
         url = File.join(url, 'providers', @provider, @service_name)
         url = File.join(url, *args) unless args.empty?

--- a/lib/azure/armrest/resource_group_service.rb
+++ b/lib/azure/armrest/resource_group_service.rb
@@ -69,8 +69,7 @@ module Azure
       private
 
       def build_url(group = nil, *args)
-        id = configuration.subscription_id
-        url = File.join(Azure::Armrest::COMMON_URI, id, 'resourcegroups')
+        url = File.join(base_url, 'resourcegroups')
         url = File.join(url, group) if group
         url = File.join(url, *args) unless args.empty?
         url << "?api-version=#{@api_version}"

--- a/lib/azure/armrest/resource_provider_service.rb
+++ b/lib/azure/armrest/resource_provider_service.rb
@@ -127,7 +127,7 @@ module Azure
 
       def build_url(namespace = nil, *args)
         id = configuration.subscription_id
-        url = File.join(Azure::Armrest::COMMON_URI, id, 'providers')
+        url = File.join(base_url, 'providers')
         url = File.join(url, namespace) if namespace
         url = File.join(url, *args) unless args.empty?
         url << "?api-version=#{@api_version}"

--- a/lib/azure/armrest/resource_service.rb
+++ b/lib/azure/armrest/resource_service.rb
@@ -56,8 +56,12 @@ module Azure
       #
       def move(source_group, source_subscription = configuration.subscription_id)
         url = File.join(
-          Azure::Armrest::COMMON_URI, source_subscription,
-          'resourcegroups', source_group, 'moveresources'
+          configuration.resource_url,
+          'subscriptions',
+          source_subscription,
+          'resourcegroups',
+          source_group,
+          'moveresources'
         )
 
         url << "?api-version=#{@api_version}"
@@ -90,12 +94,10 @@ module Azure
       private
 
       def build_url(resource_group = nil, options = {})
-        url = File.join(Azure::Armrest::COMMON_URI, configuration.subscription_id)
-
         if resource_group
-          url = File.join(url, 'resourceGroups', resource_group, 'resources')
+          url = File.join(base_url, 'resourceGroups', resource_group, 'resources')
         else
-          url = File.join(url, 'resources')
+          url = File.join(base_url, 'resources')
         end
 
         url << "?api-version=#{@api_version}"

--- a/lib/azure/armrest/virtual_machine_extension_service.rb
+++ b/lib/azure/armrest/virtual_machine_extension_service.rb
@@ -117,8 +117,7 @@ module Azure
       #
       def build_url(resource_group, vm, *args)
         url = File.join(
-          Azure::Armrest::COMMON_URI,
-          configuration.subscription_id,
+          base_url,
           'resourceGroups',
           resource_group,
           'providers',

--- a/lib/azure/armrest/virtual_machine_image_service.rb
+++ b/lib/azure/armrest/virtual_machine_image_service.rb
@@ -98,15 +98,7 @@ module Azure
       # arguments provided, and appends it with the api_version.
       #
       def build_url(location, *args)
-        url = File.join(
-          Azure::Armrest::COMMON_URI,
-          configuration.subscription_id,
-          'providers',
-          provider,
-          'locations',
-          location
-        )
-
+        url = File.join(base_url, 'providers', provider, 'locations', location)
         url = File.join(url, *args) unless args.empty?
         url << "?api-version=#{@api_version}"
       end

--- a/spec/armrest_module_spec.rb
+++ b/spec/armrest_module_spec.rb
@@ -24,11 +24,5 @@ describe "Armrest" do
       expect(Azure::Armrest::RESOURCE).to be_a_kind_of(String)
       expect(Azure::Armrest::RESOURCE).to eql("https://management.azure.com/")
     end
-
-    it "defines the COMMON_URI constant" do
-      expect(Azure::Armrest::COMMON_URI).not_to be_nil
-      expect(Azure::Armrest::COMMON_URI).to be_a_kind_of(String)
-      expect(Azure::Armrest::COMMON_URI).to eql("https://management.azure.com/subscriptions/")
-    end
   end
 end

--- a/spec/armrest_service_spec.rb
+++ b/spec/armrest_service_spec.rb
@@ -109,7 +109,7 @@ describe Azure::Armrest::ArmrestService do
     it "defines a base_url accessor" do
       expect(subject).to respond_to(:base_url)
       expect(subject).to respond_to(:base_url=)
-      expect(subject.base_url).to eq(Azure::Armrest::RESOURCE)
+      expect(subject.base_url).to eq(File.join(Azure::Armrest::RESOURCE, 'subscriptions', 'abc-123-def-456'))
     end
 
     it "defines a service_name accessor" do


### PR DESCRIPTION
This PR removes the Azure::Armrest::COMMON constant because it was tied to a specific resource. Instead, the ArmrestService#base_url method was altered to include "subscriptions/subscription_id", since this method was primarily intended for internal use.

All classes that used COMMON were refactored to use the updated build_url method, and the specs were updated as well. I also did some sanity checking to make sure all the changed service classes still worked properly.