### PR TITLE
Fix for network security group deletion

### DIFF
--- a/lib/azure/armrest/virtual_machine_service.rb
+++ b/lib/azure/armrest/virtual_machine_service.rb
@@ -200,9 +200,10 @@ module Azure
           end
 
           if options[:network_security_groups]
-            nic.properties.network_security_group
-            nsg = get_associated_resource(nic.properties.network_security_group.id)
-            delete_and_wait(nsgs, nsg.name, nsg.resource_group, options)
+            if nic.properties.respond_to?(:network_security_group)
+              nsg = get_associated_resource(nic.properties.network_security_group.id)
+              delete_and_wait(nsgs, nsg.name, nsg.resource_group, options)
+            end
           end
         end
       end


### PR DESCRIPTION
This fixes a bug for network security group deletion in the `delete_associated_resource` method. 

Currently, if a user chooses the option to delete a network security group, but one doesn't actually exist, the method crashes.