### PR TITLE
Fix regex for #parse_id_string

### DIFF
--- a/lib/azure/armrest/resource_group_based_service.rb
+++ b/lib/azure/armrest/resource_group_based_service.rb
@@ -169,11 +169,11 @@ module Azure
       # Parse the provider and service name out of an ID string.
       def parse_id_string(id_string)
         regex = %r{
-          subscriptions/(?<subscription_id>[^\/]+)?/
-          (resourceGroups/(?<resource_group>[^\/]+)?/)?
-          (providers/(?<provider>[^\/]+)?/)?
-          ((?<service_name>[^\/]+)?/(?<resource_name>[^\/]+)/)?
-          ((?<subservice_name>[^\/]+)?/(?<subservice_resource_name>[^\/]+))?
+          subscriptions/(?<subscription_id>[^\/]+)?
+          (/resourceGroups/(?<resource_group>[^\/]+)?)?
+          (/providers/(?<provider>[^\/]+)?)?
+          (/(?<service_name>[^\/]+)?/(?<resource_name>[^\/]+))?
+          (/(?<subservice_name>[^\/]+)?/(?<subservice_resource_name>[^\/]+))?
           \z
         }x
 


### PR DESCRIPTION
Switch ending slash to leading slash. Fix the bug that cannot parse id without a subservice.