### PR TITLE
Add Environment class and predefined Public and USGovernment instances

### DIFF
--- a/lib/azure/armrest.rb
+++ b/lib/azure/armrest.rb
@@ -30,6 +30,7 @@ end
 
 require 'azure/armrest/version'
 require 'azure/armrest/configuration'
+require 'azure/armrest/environment'
 require 'azure/armrest/exception'
 require 'azure/armrest/armrest_collection'
 require 'azure/armrest/armrest_service'

--- a/lib/azure/armrest.rb
+++ b/lib/azure/armrest.rb
@@ -7,24 +7,9 @@ require 'cache_method'
 
 # The Azure module serves as a namespace.
 module Azure
-
   # The Armrest module mostly serves as a namespace, but also contains any
   # common constants shared by subclasses.
   module Armrest
-    # The default (public) Azure resource
-    RESOURCE = "https://management.azure.com/"
-
-    # The resource for US Government clients
-    USGOV_RESOURCE = "https://management.core.usgovcloudapi.net/"
-
-    # The default (public) authority resource
-    AUTHORITY = "https://login.microsoftonline.com/"
-
-    # The authority for US Government clients
-    USGOV_AUTHORITY = "https://login-us.microsoftonline.com/"
-
-    # Environment string used to indicate US Government
-    USGOV_ENVIRONMENT = 'usgov'
   end
 end
 

--- a/lib/azure/armrest/armrest_service.rb
+++ b/lib/azure/armrest/armrest_service.rb
@@ -46,7 +46,11 @@ module Azure
         end
 
         # Base URL used for REST calls. Modify within method calls as needed.
-        @base_url = File.join(configuration.resource_url, 'subscriptions', configuration.subscription_id)
+        @base_url = File.join(
+          configuration.environment.resource_url,
+          'subscriptions',
+          configuration.subscription_id
+        )
 
         set_service_api_version(options, service_name)
       end

--- a/lib/azure/armrest/environment.rb
+++ b/lib/azure/armrest/environment.rb
@@ -74,13 +74,15 @@ module Azure
           instance_variable_set("@#{key}", value)
         end
 
-        [:name, :active_directory_authority, :active_directory_resource_id].each do |key|
-          raise ArgumentError, "Mandatory argument '#{key}' not set" unless key
+        [:name, :active_directory_authority, :resource_manager_url].each do |key|
+          unless instance_variable_get("@#{key}")
+            raise ArgumentError, "Mandatory argument '#{key}' not set"
+          end
         end
       end
 
       alias authority_url active_directory_authority
-      alias resource_url active_directory_resource_id
+      alias resource_url resource_manager_url
 
       # Pre-generated environments
 

--- a/lib/azure/armrest/environment.rb
+++ b/lib/azure/armrest/environment.rb
@@ -1,0 +1,122 @@
+module Azure
+  module Armrest
+    class Environment
+      # A list of valid keys that can be passed to the constructor
+      VALID_KEYS = [ 
+        :name,
+        :active_directory_authority,
+        :active_directory_resource_id,
+        :gallery_url,
+        :graph_url,
+        :graph_api_version,
+        :key_vault_dns_suffix,
+        :key_vault_service_resource_id,
+        :publish_settings_file_url,
+        :resource_manager_url,
+        :service_management_url,
+        :sql_database_dns_suffix,
+        :storage_suffix,
+        :traffic_manager_dns_suffix
+      ]
+
+      # The Environment name
+      attr_reader :name
+
+      # The authority used to acquire an AD token
+      attr_reader :active_directory_authority
+
+      # The resource ID used to obtain an AD token
+      attr_reader :active_directory_resource_id
+
+      # The template gallery endpoint
+      attr_reader :gallery_url
+
+      # The Active Directory resource ID
+      attr_reader :graph_url
+
+      # The api-version for Active Directory
+      attr_reader :graph_api_version
+
+      # The KeyValut service DNS suffix
+      attr_reader :key_vault_dns_suffix
+
+      # The KeyVault service resource ID
+      attr_reader :key_vault_service_resource_id
+
+      # The publish settings file URL
+      attr_reader :publish_settings_file_url
+
+      # The resource management endpoint
+      attr_reader :resource_manager_url
+
+      # The service management URL
+      attr_reader :service_management_url
+
+      # The DNS suffix for SQL Server instances
+      attr_reader :sql_database_dns_suffix
+
+      # The endpoint suffix for storage accounts
+      attr_reader :storage_suffix
+
+      # The DNS suffix for TrafficManager
+      attr_reader :traffic_manager_dns_suffix
+
+      # Creates a new Azure::Armrest::Environment object. At a minimum, the
+      # options hash must include the :name, :active_directory_authority and
+      # :active_directory_resource_id.
+      #
+      # Note that there are pre-generated environments already for Public
+      # and US Government environments.
+      #
+      def initialize(options)
+        options.symbolize_keys.each do |key, value|
+          raise ArgumentError, "Invalid key '#{key}'" unless VALID_KEYS.include?(key)
+          instance_variable_set("@#{key}", value)
+        end
+
+        [:name, :active_directory_authority, :active_directory_resource_id].each do |key|
+          raise ArgumentError, "Mandatory argument '#{key}' not set" unless key
+        end
+      end
+
+      alias authority_url active_directory_authority
+      alias resource_url active_directory_resource_id
+
+      # Pre-generated environments
+
+      Public = self.new(
+        :name                          => 'Public',
+        :active_directory_authority    => 'https://login.microsoftonline.com/',
+        :active_directory_resource_id  => 'https://management.core.windows.net/',
+        :gallery_url                   => 'https://gallery.azure.com/',
+        :graph_url                     => 'https://graph.windows.net/',
+        :graph_api_version             => '1.6',
+        :key_vault_dns_suffix          => 'vault.azure.net',
+        :key_vault_service_resource_id => 'https://vault.azure.net',
+        :publish_settings_file_url     => 'https://manage.windowsazure.com/publishsettings/index',
+        :resource_manager_url          => 'https://management.azure.com/',
+        :service_management_url        => 'https://management.core.windows.net/',
+        :sql_database_dns_suffix       => 'database.windows.net',
+        :storage_suffix                => 'core.windows.net',
+        :traffic_manager_dns_suffix    => 'trafficmanager.net',
+      )
+
+      USGovernment = self.new(
+        :name                          => 'US Government',
+        :active_directory_authority    => 'https://login-us.microsoftonline.com/',
+        :active_directory_resource_id  => 'https://management.core.usgovcloudapi.net/',
+        :gallery_url                   => 'https://gallery.usgovcloudapi.net/',
+        :graph_url                     => 'https://graph.windows.net/',
+        :graph_api_version             => '1.6',
+        :key_vault_dns_suffix          => 'vault.usgovcloudapi.net',
+        :key_vault_service_resource_id => 'https://vault.usgovcloudapi.net',
+        :publish_settings_file_url     => 'https://manage.windowsazure.us/publishsettings/index',
+        :resource_manager_url          => 'https://management.usgovcloudapi.net/',
+        :service_management_url        => 'https://management.core.usgovcloudapi.net/',
+        :sql_database_dns_suffix       => 'database.usgovcloudapi.net',
+        :storage_suffix                => 'core.usgovcloudapi.net',
+        :traffic_manager_dns_suffix    => 'usgovtrafficmanager.net',
+      )
+    end
+  end
+end

--- a/lib/azure/armrest/insights/diagnostic_service.rb
+++ b/lib/azure/armrest/insights/diagnostic_service.rb
@@ -80,7 +80,7 @@ module Azure
 
         def build_url(resource_id)
           url = File.join(
-            configuration.resource_url,
+            configuration.environment.resource_url,
             resource_id,
             'providers',
             provider,

--- a/lib/azure/armrest/resource_group_based_service.rb
+++ b/lib/azure/armrest/resource_group_based_service.rb
@@ -107,7 +107,7 @@ module Azure
                                          info['subservice_name'])
         service_name = info['subservice_name'] || info['service_name'] || 'resourceGroups'
 
-        url = File.join(configuration.resource_url, id_string) + "?api-version=#{api_version}"
+        url = File.join(configuration.environment.resource_url, id_string) + "?api-version=#{api_version}"
 
         model_class = SERVICE_NAME_MAP.fetch(service_name.downcase) do
           raise ArgumentError, "unable to map service name #{service_name} to model"
@@ -120,10 +120,8 @@ module Azure
 
       def delete_by_id(id_string)
         info = parse_id_string(id_string)
-        api_version = api_version_lookup(info['provider'],
-                                         info['service_name'],
-                                         info['subservice_name'])
-        url = File.join(configuration.resource_url, id_string) + "?api-version=#{api_version}"
+        api_version = api_version_lookup(info['provider'], info['service_name'], info['subservice_name'])
+        url = File.join(configuration.environment.resource_url, id_string) + "?api-version=#{api_version}"
 
         delete_by_url(url, id_string)
       end
@@ -217,7 +215,7 @@ module Azure
       # arguments provided, and appends it with the api_version.
       #
       def build_url(resource_group = nil, *args)
-        url = File.join(configuration.resource_url, build_id_string(resource_group, *args))
+        url = File.join(configuration.environment.resource_url, build_id_string(resource_group, *args))
         url << "?api-version=#{@api_version}"
       end
 

--- a/lib/azure/armrest/resource_provider_service.rb
+++ b/lib/azure/armrest/resource_provider_service.rb
@@ -61,7 +61,7 @@ module Azure
       end
 
       def _list_all
-        url = File.join(configuration.resource_url, 'providers')
+        url = File.join(configuration.environment.resource_url, 'providers')
         url << "?api-version=#{@api_version}"
         response = rest_get(url)
         JSON.parse(response)['value']

--- a/lib/azure/armrest/resource_service.rb
+++ b/lib/azure/armrest/resource_service.rb
@@ -56,7 +56,7 @@ module Azure
       #
       def move(source_group, source_subscription = configuration.subscription_id)
         url = File.join(
-          configuration.resource_url,
+          configuration.environment.resource_url,
           'subscriptions',
           source_subscription,
           'resourcegroups',
@@ -78,7 +78,7 @@ module Azure
       #
       def check_resource(resource_name, resource_type)
         body = JSON.dump(:Name => resource_name, :Type => resource_type)
-        url = File.join(Azure::Armrest::RESOURCE, 'providers', provider, 'checkresourcename')
+        url = File.join(configuration.environment.resource_url, 'providers', provider, 'checkresourcename')
         url << "?api-version=#{@api_version}"
 
         response = rest_post(url, body)

--- a/lib/azure/armrest/subscription_service.rb
+++ b/lib/azure/armrest/subscription_service.rb
@@ -28,7 +28,7 @@ module Azure
       private
 
       def subscriptions_url
-        File.join(configuration.resource_url, 'subscriptions')
+        File.join(configuration.environment.resource_url, 'subscriptions')
       end
     end
   end

--- a/spec/armrest_module_spec.rb
+++ b/spec/armrest_module_spec.rb
@@ -11,18 +11,4 @@ describe "Armrest" do
       expect(Azure::Armrest).to be_a_kind_of(Module)
     end
   end
-
-  context "constants" do
-    it "defines the AUTHORITY constant" do
-      expect(Azure::Armrest::AUTHORITY).not_to be_nil
-      expect(Azure::Armrest::AUTHORITY).to be_a_kind_of(String)
-      expect(Azure::Armrest::AUTHORITY).to eql("https://login.microsoftonline.com/")
-    end
-
-    it "defines the RESOURCE constant" do
-      expect(Azure::Armrest::RESOURCE).not_to be_nil
-      expect(Azure::Armrest::RESOURCE).to be_a_kind_of(String)
-      expect(Azure::Armrest::RESOURCE).to eql("https://management.azure.com/")
-    end
-  end
 end

--- a/spec/armrest_service_spec.rb
+++ b/spec/armrest_service_spec.rb
@@ -109,7 +109,8 @@ describe Azure::Armrest::ArmrestService do
     it "defines a base_url accessor" do
       expect(subject).to respond_to(:base_url)
       expect(subject).to respond_to(:base_url=)
-      expect(subject.base_url).to eq(File.join(Azure::Armrest::RESOURCE, 'subscriptions', 'abc-123-def-456'))
+      resource_url = subject.configuration.environment.resource_url
+      expect(subject.base_url).to eq(File.join(resource_url, 'subscriptions', 'abc-123-def-456'))
     end
 
     it "defines a service_name accessor" do

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -53,13 +53,6 @@ describe Azure::Armrest::Configuration do
       options[:token_expiration] = Time.now.utc + 1.month
       expect(described_class.new(options).token).to eq('token_string')
     end
-
-    it 'sets the authority url and resource url to appropriate values for US Gov' do
-      options[:environment] = 'usgov'
-      config = described_class.new(options)
-      expect(config.resource_url).to eql(Azure::Armrest::USGOV_RESOURCE) 
-      expect(config.authority_url).to eql(Azure::Armrest::USGOV_AUTHORITY) 
-    end
   end
 
   context 'instances' do
@@ -131,25 +124,13 @@ describe Azure::Armrest::Configuration do
 
       it 'defines an environment reader' do
         allow(subject).to receive(:fetch_token).and_return('xxx')
-        expect(subject.environment).to eql(options[:environment])
+        expect(subject.environment).to eql(Azure::Armrest::Environment::Public)
       end
 
       it 'defines a max_threads accessor' do
         expect(subject.max_threads).to eql(10)
         subject.max_threads = 8
         expect(subject.max_threads).to eql(8)
-      end
-
-      it 'defines a resource_url accessor' do
-        expect(subject.resource_url).to eql(Azure::Armrest::RESOURCE)
-        subject.resource_url = 'https://foo.bar/'
-        expect(subject.resource_url).to eql('https://foo.bar/')
-      end
-
-      it 'defines an authority_url accessor' do
-        expect(subject.authority_url).to eql(Azure::Armrest::AUTHORITY)
-        subject.authority_url = 'https://foo.bar/'
-        expect(subject.authority_url).to eql('https://foo.bar/')
       end
     end
 

--- a/spec/environment_spec.rb
+++ b/spec/environment_spec.rb
@@ -1,0 +1,98 @@
+########################################################################
+# configuration_spec.rb
+#
+# Specs for the Azure::Armrest::Environment class
+########################################################################
+require 'spec_helper'
+require 'timecop'
+
+describe Azure::Armrest::Environment do
+  let(:options) do
+    {
+      :name                       => 'test',
+      :active_directory_authority => 'https://login.microsoftonline.com/',
+      :resource_manager_url       => 'https://management.azure.com/'
+    }
+  end
+
+  subject { described_class.new(options) }
+
+  context 'constructor' do
+    it 'requires a single argument' do
+      expect { described_class.new }.to raise_error(ArgumentError)
+    end
+
+    it 'requires a name' do
+      options.delete(:name)
+      expect { described_class.new(options) }.to raise_error(ArgumentError)
+    end
+
+    it 'requires a active_directory_authority' do
+      options.delete(:active_directory_authority)
+      expect { described_class.new(options) }.to raise_error(ArgumentError)
+    end
+
+    it 'requires a resource_manager_url' do
+      options.delete(:resource_manager_url)
+      expect { described_class.new(options) }.to raise_error(ArgumentError)
+    end
+  end
+
+  context 'instances' do
+    it 'defines an name method' do
+      expect(subject.name).to eql('test')
+    end
+
+    it 'defines an active_directory_authority method' do
+      expect(subject.active_directory_authority).to eql('https://login.microsoftonline.com/')
+    end
+
+    it 'defines a resource_manager_url method' do
+      expect(subject.resource_manager_url).to eql('https://management.azure.com/')
+    end
+
+    it 'defines a gallery_url method' do
+      expect(subject).to respond_to(:gallery_url)
+    end
+
+    it 'defines a graph_url method' do
+      expect(subject).to respond_to(:graph_url)
+    end
+
+    it 'defines a graph_api_version method' do
+      expect(subject).to respond_to(:graph_api_version)
+    end
+
+    it 'defines a key_vault_dns_suffix method' do
+      expect(subject).to respond_to(:key_vault_dns_suffix)
+    end
+
+    it 'defines a key_vault_service_resource_id method' do
+      expect(subject).to respond_to(:key_vault_service_resource_id)
+    end
+
+    it 'defines a publish_settings_file_url method' do
+      expect(subject).to respond_to(:publish_settings_file_url)
+    end
+
+    it 'defines a resource_manager_url method' do
+      expect(subject).to respond_to(:resource_manager_url)
+    end
+
+    it 'defines a service_management_url method' do
+      expect(subject).to respond_to(:service_management_url)
+    end
+
+    it 'defines a sql_database_dns_suffix method' do
+      expect(subject).to respond_to(:sql_database_dns_suffix)
+    end
+
+    it 'defines a storage_suffix method' do
+      expect(subject).to respond_to(:storage_suffix)
+    end
+
+    it 'defines a traffic_manager_dns_suffix method' do
+      expect(subject).to respond_to(:traffic_manager_dns_suffix)
+    end
+  end
+end


### PR DESCRIPTION
This PR adds an Environment class that contains all the relevant URL information. It is based mostly on the Azure endpoint mapping docs*, as well as some inspiration from one or two other Azure libraries out in the wild.

The Configuration#environment accessor now takes an instance of an Environment class instead of a string. Two pre-defined instances have been declared as well - Environment::Public and Environment::USGovernment. We can add more as needed later.

Most of the constants have been removed as they are no longer needed.

https://docs.microsoft.com/en-us/azure/azure-government-developer-guide#a-nameendpointaendpoint-mapping