### PR TITLE
Fix breakage caused by change to base_url

### DIFF
--- a/lib/azure/armrest/armrest_service.rb
+++ b/lib/azure/armrest/armrest_service.rb
@@ -135,13 +135,7 @@ module Azure
       # Returns a list of tags for the current subscription.
       #
       def tags
-        url = url_with_api_version(
-          configuration.api_version,
-          @base_url,
-          'subscriptions',
-          configuration.subscription_id,
-          'tagNames'
-        )
+        url = url_with_api_version(configuration.api_version, base_url, 'tagNames')
         resp = rest_get(url)
         JSON.parse(resp.body)["value"].map{ |hash| Azure::Armrest::Tag.new(hash) }
       end
@@ -149,7 +143,7 @@ module Azure
       # Returns a list of tenants that can be accessed.
       #
       def tenants
-        url = url_with_api_version(configuration.api_version, @base_url, 'tenants')
+        url = url_with_api_version(configuration.api_version, configuration.resource_url, 'tenants')
         resp = rest_get(url)
         JSON.parse(resp.body)['value'].map{ |hash| Azure::Armrest::Tenant.new(hash) }
       end

--- a/lib/azure/armrest/virtual_machine_service.rb
+++ b/lib/azure/armrest/virtual_machine_service.rb
@@ -28,8 +28,7 @@ module Azure
         end
 
         url = url_with_api_version(
-          version, @base_url, 'subscriptions', configuration.subscription_id,
-          'providers', provider, 'locations', location, 'vmSizes'
+          version, base_url, 'providers', provider, 'locations', location, 'vmSizes'
         )
 
         JSON.parse(rest_get(url))['value'].map{ |hash| VirtualMachineSize.new(hash) }


### PR DESCRIPTION
A change in `@base_url` caused some breakage in methods that weren't updated. Specifically, this broke the `tags` and `tenants` methods in the base ArmrestService class, as well as the `VirtualMachineService#series` method.