### PR TITLE
Explicit return if subscription ID is nil or blank

### DIFF
--- a/lib/azure/armrest/configuration.rb
+++ b/lib/azure/armrest/configuration.rb
@@ -144,6 +144,7 @@ module Azure
       #
       def subscription_id=(value)
         @subscription_id = value
+        return if value.nil? || value.empty?
         validate_subscription
         @providers = fetch_providers
         set_provider_api_versions


### PR DESCRIPTION
For the `Configuration#subscription_id=` method, do not attempt validation or gather provider info if the argument is nil or blank since it will fail.