### PR TITLE
Add environment name to hash method

### DIFF
--- a/lib/azure/armrest/configuration.rb
+++ b/lib/azure/armrest/configuration.rb
@@ -130,7 +130,7 @@ module Azure
       end
 
       def hash
-        [tenant_id, client_id, client_key].join('_').hash
+        [environment.name, tenant_id, client_id, client_key].join('_').hash
       end
 
       # Allow for strings or URI objects when assigning a proxy.


### PR DESCRIPTION
This updates the `hash` method to include the environment name for cases where users are in mixed environments. Otherwise conflicts can arise from cached tokens that were generated for a  different environment.