### PR TITLE
Update MetricsService class to include newer REST API

### DIFF
--- a/lib/azure/armrest/insights/metrics_service.rb
+++ b/lib/azure/armrest/insights/metrics_service.rb
@@ -5,12 +5,14 @@ module Azure
         # Creates and returns a new MetricsService object.
         #
         def initialize(armrest_configuration, options = {})
-          options['api_version'] = '2014-04-01' # Must hard code for now
-          super(armrest_configuration, 'metricDefinitions', 'Microsoft.Insights', options)
+          super(armrest_configuration, 'metrics', 'Microsoft.Insights', options)
         end
 
         # Return the metric definitions for the given +provider+, +resource_type+,
         # and +resource_name+ for +resource_group+. You may pass a :filter option as well.
+        #
+        # NOTE: This uses the older REST API. If you want the newer API, use the
+        # list_definitions method below.
         #
         # Example:
         #
@@ -28,11 +30,90 @@ module Azure
 
           response = rest_get(url)
 
-          JSON.parse(response)['value'].map { |hash| Azure::Armrest::Insights::Metric.new(hash) }
+          Azure::Armrest::ArmrestCollection.create_from_response(
+            response,
+            Azure::Armrest::Insights::MetricDefinition
+          )
+        end
+
+        # Returns a list metrics for +resource_id+, which can be
+        # either a resource object or a plain resource string. You
+        # may also provide a +filter+ to limit the results.
+        #
+        # If no filter expression is defined, the first metric defined
+        # for that resource will be returned using the primary aggregation
+        # type in the metric defintion over a time period of the last hour.
+        #
+        #   vms = Azure::Armrest::VirtualMachineService.new(conf)
+        #   mts = Azure::Armrest::Insights::MetricService.new(conf)
+        #
+        #   vm = vms.get('your_vm', 'your_resource_group')
+        #
+        #   filter = "name.value eq 'Percentage CPU' and startTime "
+        #   filter << "eq 2017-01-03 and endTime eq 2017-01-04"
+        #
+        #   definitions = mts.list_metrics(vm.id)
+        #
+        def list_metrics(resource, filter = nil)
+          resource_id = resource.respond_to?(:id) ? resource.id : resource
+
+          url = File.join(
+            configuration.environment.resource_url,
+            resource_id,
+            'providers/microsoft.insights/metrics'
+          )
+
+          url << "?api-version=#{api_version}"
+          url << "&$filter=#{filter}" if filter
+
+          response = rest_get(url)
+
+          Azure::Armrest::ArmrestCollection.create_from_response(response, Azure::Armrest::Insights::Metric)
+        end
+
+        # Get a list of metrics definitions for +resource_id+, which can be
+        # either a resource object or a plain resource string. You may also
+        # provide a +filter+ to limit the results.
+        #
+        # Note that the output for this method is different than the list
+        # method, which uses an older api-version.
+        #
+        # Example:
+        #
+        #   vms = Azure::Armrest::VirtualMachineService.new(conf)
+        #   mts = Azure::Armrest::Insights::MetricService.new(conf)
+        #
+        #   vm = vms.get('your_vm', 'your_resource_group')
+        #
+        #   # With or without filter
+        #   definitions = mts.list_definitions(vm.id)
+        #   definitions = mts.list_definitions(vm.id, "name.value eq 'Percentage CPU'")
+        #
+        def list_definitions(resource, filter = nil)
+          resource_id = resource.respond_to?(:id) ? resource.id : resource
+          version = configuration.provider_default_api_version(provider, 'metricDefinitions')
+
+          url = File.join(
+            configuration.environment.resource_url,
+            resource_id,
+            'providers/microsoft.insights/metricdefinitions'
+          )
+
+          url << "?api-version=#{version}"
+          url << "&$filter=#{filter}" if filter
+
+          response = rest_get(url)
+
+          Azure::Armrest::ArmrestCollection.create_from_response(
+            response,
+            Azure::Armrest::Insights::MetricDefinition
+          )
         end
 
         private
 
+        # Build a URL for the older version of the metrics definitions API.
+        #
         def build_url(provider, resource_type, resource_name, resource_group, options)
           url = File.join(
             base_url,
@@ -45,7 +126,7 @@ module Azure
             'metricDefinitions'
           )
 
-          url << "?api-version=#{@api_version}"
+          url << "?api-version=2014-04-01"
           url << "&$filter=#{options[:filter]}" if options[:filter]
 
           url

--- a/lib/azure/armrest/model/base_model.rb
+++ b/lib/azure/armrest/model/base_model.rb
@@ -224,6 +224,7 @@ module Azure
       class Diagnostic < BaseModel; end
       class Event < BaseModel; end
       class Metric < BaseModel; end
+      class MetricDefinition < BaseModel; end
     end
 
     module Network

--- a/spec/insights_metric_service_spec.rb
+++ b/spec/insights_metric_service_spec.rb
@@ -25,5 +25,13 @@ describe "Insights::MetricsService" do
     it "defines a list method" do
       expect(ms).to respond_to(:list)
     end
+
+    it "defines a list_metrics method" do
+      expect(ms).to respond_to(:list_metrics)
+    end
+
+    it "defines a list_definitions method" do
+      expect(ms).to respond_to(:list_definitions)
+    end
   end
 end


### PR DESCRIPTION
This updates the MetricsService class so that it supports the newer API for metrics and metrics definitions.

The current `list` method, probably somewhat poorly chosen in hindsight, will remain for backwards compatibility. The `list_metrics` and `list_definitions` have been added to support the newer API. I kept the original method because it returns different output. The hardcoded api-version string is now only used for the older method.

In addition, I converted the `list` method to return an ArmrestCollection.

Originally written to try to work get metrics working for usgov regions (it still doesn't), this is a much easier way to get metrics information for public environments than our current approach, which requires accessing the storage account directly.