### PR TITLE
Added the registered? method

### DIFF
--- a/lib/azure/armrest/resource_provider_service.rb
+++ b/lib/azure/armrest/resource_provider_service.rb
@@ -123,6 +123,15 @@ module Azure
         nil
       end
 
+      # Returns whether or not the +namespace+ provider is registered. If
+      # the provider cannot be found, false is returned.
+      #
+      def registered?(namespace)
+        get(namespace).registration_state.casecmp("registered").zero?
+      rescue Azure::Armrest::NotFoundException
+        false
+      end
+
       private
 
       def build_url(namespace = nil, *args)

--- a/spec/resource_provider_spec.rb
+++ b/spec/resource_provider_spec.rb
@@ -59,5 +59,9 @@ describe "ResourceProviderService" do
     it "defines an unregister method" do
       expect(rpsrv).to respond_to(:unregister)
     end
+
+    it "defines a registered? method" do
+      expect(rpsrv).to respond_to(:registered?)
+    end
   end
 end


### PR DESCRIPTION
This PR adds the `registered?` method to the ResourceProviderService class. This is basically a shortcut for:

    ResourceProviderService#get(namespace).regisration_state == "Registered"

But with case and exception handling baked in.

This will be useful in our effort to disable events and metrics collection for ManageIQ in unsupported regions.

