### PR TITLE
Replace cache_method with memoist gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,3 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in azure-armrest.gemspec
 gemspec
-
-group :test do
-  gem "simplecov", :require => false
-  gem "codeclimate-test-reporter", "~> 1.0.0", :require => false
-end

--- a/azure-armrest.gemspec
+++ b/azure-armrest.gemspec
@@ -21,7 +21,7 @@ behind the scenes.
 
   spec.add_dependency 'json', '~> 2.0.1'
   spec.add_dependency 'rest-client', '~> 2.0.0'
-  spec.add_dependency 'cache_method', '~> 0.2.7'
+  spec.add_dependency 'memoist', '~> 0.15.0'
   spec.add_dependency 'azure-signature', '~> 0.2.3'
   spec.add_dependency 'activesupport', '>= 4.2.2'
   spec.add_dependency 'nokogiri', '~> 1.6.8'

--- a/lib/azure/armrest.rb
+++ b/lib/azure/armrest.rb
@@ -3,7 +3,8 @@ require 'json'
 require 'thread'
 require 'addressable'
 require 'parallel'
-require 'cache_method'
+require 'memoist'
+require 'active_support/core_ext/hash/keys'
 
 # The Azure module serves as a namespace.
 module Azure

--- a/lib/azure/armrest/armrest_service.rb
+++ b/lib/azure/armrest/armrest_service.rb
@@ -63,10 +63,6 @@ module Azure
       alias providers list_providers
       deprecate :providers, :list_providers, 2018, 1
 
-      # Need an "as_cache_key" method for the cache_method library interface.
-      delegate :hash, :to => :configuration
-      alias as_cache_key hash
-
       # Returns information about the specific provider +namespace+.
       #
       def get_provider(provider)

--- a/lib/azure/armrest/configuration.rb
+++ b/lib/azure/armrest/configuration.rb
@@ -3,23 +3,24 @@ module Azure
     class Configuration
       # Clear all class level caches. Typically used for testing only.
       def self.clear_caches
-        # Used to store unique token information.
-        @token_cache = Hash.new { |h, k| h[k] = [] }
-        CacheMethod.config.storage.clear
+        token_cache.clear
       end
 
-      clear_caches # Clear caches at load time.
+      # Used to store unique token information.
+      def self.token_cache
+        @token_cache ||= Hash.new { |h, k| h[k] = [] }
+      end
 
       # Retrieve the cached token for a configuration.
       # Return both the token and its expiration date, or nil if not cached
       def self.retrieve_token(configuration)
-        @token_cache[configuration.hash]
+        token_cache[configuration.hash]
       end
 
       # Cache the token for a configuration that a token has been fetched from Azure
       def self.cache_token(configuration)
         raise ArgumentError, "Configuration does not have a token" if configuration.token.nil?
-        @token_cache[configuration.hash] = [configuration.token, configuration.token_expiration]
+        token_cache[configuration.hash] = [configuration.token, configuration.token_expiration]
       end
 
       # The api-version string

--- a/lib/azure/armrest/resource_provider_service.rb
+++ b/lib/azure/armrest/resource_provider_service.rb
@@ -1,89 +1,54 @@
 module Azure
   module Armrest
     class ResourceProviderService < ArmrestService
+      extend Memoist
+
       # The provider used in http requests. The default is 'Microsoft.Resources'
       attr_reader :provider
 
-      # The amount of time in seconds to cache certain methods. The default is 24 hours.
-      @cache_time = 24 * 60 * 60
-
-      class << self
-        # Get or set the cache time for all methods. The default is 24 hours.
-        attr_accessor :cache_time
-      end
-
       # Creates and returns a new ResourceProviderService object.
       #
-      # Note that many ResourceProviderService instance methods are cached. You
-      # can set the cache_time for certain methods in the constructor, but keep in
-      # mind that it is a global setting for the class. You can also set this
-      # at the class level if desired. The default cache time is 24 hours.
+      # Note that many ResourceProviderService instance methods are cached.
       #
       # You can also set the provider. The default is 'Microsoft.Resources'.
       #
       def initialize(configuration, options = {})
         super(configuration, 'resourceGroups', 'Microsoft.Resources', options)
-
-        if options[:cache_time]
-          @cache_time = options[:cache_time]
-          self.class.send(:cache_time=, @cache_time)
-        end
       end
 
       # List all the providers for the current subscription. The results of
       # this method are cached.
       #
       def list
-        _list.map{ |hash| Azure::Armrest::ResourceProvider.new(hash) }
-      end
-
-      # This is split out for the cache_method feature.
-      #
-      def _list
         response = rest_get(build_url)
-        JSON.parse(response)["value"]
+        resources = JSON.parse(response)["value"]
+        resources.map{ |hash| Azure::Armrest::ResourceProvider.new(hash) }
       end
-
-      private :_list
-
-      # Cannot directly cache list method, because Marshal used by cache_method
-      # cannot dump anonymous classes, including the ones derived from
-      # Azure::Armrest::BaseModel.
-      #
-      # The same applies to other cached methods in this class.
-      cache_method(:_list, cache_time)
+      memoize :list
 
       # List all the providers for Azure. This may include results that are
-      # not available for the current subscription.
+      # not available for the current subscription. The results of this method
+      # are cached.
       #
       def list_all
-        _list_all.map{ |hash| Azure::Armrest::ResourceProvider.new(hash) }
-      end
-
-      def _list_all
         url = File.join(configuration.environment.resource_url, 'providers')
         url << "?api-version=#{@api_version}"
         response = rest_get(url)
-        JSON.parse(response)['value']
-      end
+        resources = JSON.parse(response)['value']
 
-      cache_method(:_list_all, cache_time)
+        resources.map{ |hash| Azure::Armrest::ResourceProvider.new(hash) }
+      end
+      memoize :list_all
 
       # Return information about a specific +namespace+ provider. The results
       # of this method are cached.
       #
       def get(namespace)
-        Azure::Armrest::ResourceProvider.new(_get(namespace))
-      end
-
-      def _get(namespace)
         url = build_url(namespace)
-        rest_get(url).body
+        body = rest_get(url).body
+        Azure::Armrest::ResourceProvider.new(body)
       end
-
-      private :_get
-
-      cache_method(:_get, cache_time)
+      memoize :get
 
       # Returns an array of geo-locations for the given +namespace+ provider.
       # The results of this method are cached.
@@ -93,8 +58,7 @@ module Azure
         response = rest_get(url)
         JSON.parse(response)['resourceTypes'].first['locations']
       end
-
-      cache_method(:list_geo_locations, cache_time)
+      memoize :list_geo_locations
 
       # Returns an array of supported api-versions for the given +namespace+ provider.
       # The results of this method are cached.
@@ -104,8 +68,7 @@ module Azure
         response = rest_get(url)
         JSON.parse(response)['resourceTypes'].first['apiVersions']
       end
-
-      cache_method(:list_api_versions, cache_time)
+      memoize :list_api_versions
 
       # Register the current subscription with the +namespace+ provider.
       #


### PR DESCRIPTION
@djberg96 Please review.  I've chosen memoist because it solves the same problem of "caching methods that have parameters", but it just uses "normal" memory memoization via ivars under the covers.  Additionally, it's already a dependency of manageiq (we use it for caching of Relationship records).

Note that this removes the `cache_time` class accessor method.  I don't see it used anywhere in manageiq nor in manageiq-providers-amazon, which means it must always be defaulting to 24 hours.  At 24 hours for a instance method cache, that's practically infinity, so I'm not sure what purpose it actually serves.  Additionally, it was implemented as a class-level shared timeout, even though setting it is at an instance level, which is strange.

The first commit was just so I wouldn't get "double gem" warnings when bundling, so technically it can be a separate PR if you want.