### PR TITLE
Explicitly handle the possibility of a space in json key

### DIFF
--- a/lib/azure/armrest/model/base_model.rb
+++ b/lib/azure/armrest/model/base_model.rb
@@ -147,7 +147,7 @@ module Azure
         @hashobj = obj
         excl_list = self.class.send(:excl_list)
         obj.each do |key, value|
-          snake = key.to_s.underscore
+          snake = key.to_s.tr(' ', '_').underscore
 
           unless excl_list.include?(snake) # Must deal with nested models
             if value.kind_of?(Array)

--- a/spec/models/base_model_spec.rb
+++ b/spec/models/base_model_spec.rb
@@ -172,6 +172,13 @@ describe "BaseModel" do
       expect(base).to respond_to(:_timestamp)
       expect(base._timestamp).to eq(456)
     end
+
+    it "handles strings with spaces as expected" do
+      json = {'Foo Bar' => 123}
+      base = Azure::Armrest::BaseModel.new(json)
+      expect(base).to respond_to(:foo_bar)
+      expect(base.foo_bar).to eq(123)
+    end
   end
 
   context "dynamic accessors" do


### PR DESCRIPTION
This PR deals with the possibility that a json key might have a space in it in the BaseModel class. Somewhat surprisingly, it turns out the `.underscore` method does NOT convert spaces to underscores. So, we have to do it manually, or we can't auto generate a model and/or method name for it.

Thus, a key of "foo bar" will be converted to "foo_bar".

Addresses https://github.com/ManageIQ/azure-armrest/issues/264

