### PR TITLE
Add an options argument to BaseModel#to_json

### DIFF
--- a/lib/azure/armrest/model/base_model.rb
+++ b/lib/azure/armrest/model/base_model.rb
@@ -81,7 +81,10 @@ module Azure
         @hash
       end
 
-      def to_json
+      # Return the original JSON for the model object. The +options+ argument
+      # is for interface compatibility only.
+      #
+      def to_json(_options = nil)
         @json
       end
 

--- a/spec/models/base_model_spec.rb
+++ b/spec/models/base_model_spec.rb
@@ -125,6 +125,10 @@ describe "BaseModel" do
       expect(base.pretty_inspect).to include('age=33')
       expect(base.pretty_inspect).to include('array=["stuff"]')
     end
+
+    it "handles an array of models when converting to json" do
+      expect([base, base].to_json).to include(json)
+    end
   end
 
   context "dynamic method generation" do


### PR DESCRIPTION
In order to maintain interface compatibility with existing to_json methods, we must add an options argument to the `to_json` method. Otherwise, attempting to call `to_json' on an array of model objects will fail.

Addresses https://github.com/ManageIQ/azure-armrest/issues/270