### PR TITLE
Upgrade Nokogiri to 1.7.x

### DIFF
--- a/azure-armrest.gemspec
+++ b/azure-armrest.gemspec
@@ -24,7 +24,7 @@ behind the scenes.
   spec.add_dependency 'memoist', '~> 0.15.0'
   spec.add_dependency 'azure-signature', '~> 0.2.3'
   spec.add_dependency 'activesupport', '>= 4.2.2'
-  spec.add_dependency 'nokogiri', '~> 1.6.8'
+  spec.add_dependency 'nokogiri', '~> 1.7.1'
   spec.add_dependency 'addressable', '~> 2.4.0'
   spec.add_dependency 'parallel', '~> 1.9.0'
 


### PR DESCRIPTION
This PR upgrades the Nokogiri dependency from 1.6.x to 1.7.x. This addresses complaints from Hakiri which indicated that there have been security patches to nokogiri/libxml2.

See CVE-2016-4658 for details:

http://cve.mitre.org/cgi-bin/cvename.cgi?name=cve-2016-4658

Both this PR and https://github.com/ManageIQ/manageiq-gems-pending/pull/117 should be merged together.