### PR TITLE
Added some convenience methods to the VirtualMachine model

### DIFF
--- a/lib/azure/armrest/model/base_model.rb
+++ b/lib/azure/armrest/model/base_model.rb
@@ -263,3 +263,4 @@ module Azure
 end
 
 require_relative 'storage_account'
+require_relative 'virtual_machine'

--- a/lib/azure/armrest/model/virtual_machine.rb
+++ b/lib/azure/armrest/model/virtual_machine.rb
@@ -1,0 +1,39 @@
+module Azure
+  module Armrest
+    class VirtualMachine < BaseModel
+      # Indicates whether the VM is backed by a managed disk or a regular
+      # storage account.
+      #
+      def managed_disk?
+        check_for_model_view('managed_disk?')
+        properties.storage_profile.os_disk.try(:managed_disk) ? true : false
+      end
+
+      # Returns the size (aka series) for the VM, e.g. "Standard_A0".
+      #
+      def size
+        check_for_model_view('size')
+        properties.hardware_profile.vm_size
+      end
+
+      alias flavor size
+
+      # The operating system for the image, e.g. "Linux" or "Windows".
+      #
+      def operating_system
+        check_for_model_view('operating_sytem')
+        properties.storage_profile.os_disk.os_type
+      end
+
+      alias os operating_system
+
+      private
+
+      def check_for_model_view(method_name)
+        unless respond_to?(:properties)
+          raise NoMethodError, "The method '#{method_name}' is only valid for model view objects."
+        end
+      end
+    end
+  end
+end

--- a/spec/models/virtual_machine_spec.rb
+++ b/spec/models/virtual_machine_spec.rb
@@ -1,0 +1,71 @@
+########################################################################
+# virtual_machine_spec.rb
+#
+# Test suite for the Azure::Armrest::VirtualMachine json model class.
+########################################################################
+require 'spec_helper'
+
+describe "VirtualMachine" do
+  let(:json) do
+    '{
+      "type": "Microsoft.Compute/virtualMachines",
+      "location": "westus",
+      "id": "/subscriptions/xxx/resourceGroups/yyy/providers/Microsoft.Compute/virtualMachines/a-managed-disk",
+      "name": "a-managed-disk",
+      "properties": {
+        "vmId": "229b17b2-1424-469f-a194-5a14f742be4e",
+          "hardwareProfile": {
+            "vmSize": "Standard_A0"
+          },
+        "storageProfile": {
+          "imageReference": {
+            "publisher": "RedHat",
+            "offer": "RHEL",
+            "sku": "7.3",
+            "version": "latest"
+          },
+          "osDisk": {
+            "osType": "Linux",
+            "name": "dberger-managed-disk",
+            "createOption": "FromImage",
+            "caching": "ReadWrite",
+            "managedDisk": {
+              "storageAccountType": "Standard_LRS",
+              "id": "/subscriptions/xxx/resourceGroups/yyy/providers/Microsoft.Compute/disks/a-managed-disk"
+            },
+            "diskSizeGB": 32
+          }
+        }
+      }
+    }'
+  end
+
+  let(:vm) { Azure::Armrest::VirtualMachine.new(json) }
+
+  context "custom methods" do
+    it "defines a managed_disk? method that returns the expected result" do
+      expect(vm).to respond_to(:managed_disk?)
+      expect(vm.managed_disk?).to eql(true)
+    end
+
+    it "defines a size method that returns the expected result" do
+      expect(vm).to respond_to(:size)
+      expect(vm.size).to eql("Standard_A0")
+    end
+
+    it "defines a flavor alias for size" do
+      expect(vm).to respond_to(:flavor)
+      expect(vm.method(:size)).to eql(vm.method(:flavor))
+    end
+
+    it "defines an operating_system method that returns the expected result" do
+      expect(vm).to respond_to(:operating_system)
+      expect(vm.operating_system).to eql("Linux")
+    end
+
+    it "defines an os alias for operating_system" do
+      expect(vm).to respond_to(:os)
+      expect(vm.method(:os)).to eql(vm.method(:operating_system))
+    end
+  end
+end


### PR DESCRIPTION
This just adds some convenient shortcut methods for the VirtualMachine model. They are:

* managed_disk?
* size (alias: flavor)
* operating_system (alias: os)