### PR TITLE
Add subscription id to BaseModel

### DIFF
--- a/lib/azure/armrest/model/base_model.rb
+++ b/lib/azure/armrest/model/base_model.rb
@@ -68,10 +68,15 @@ module Azure
       end
 
       def resource_group
-        @resource_group ||= id[/resourceGroups\/(.+?)\//i, 1] rescue nil
+        @resource_group ||= id[/resourcegroups\/(.*?[^\/]+)?/i, 1] rescue nil
+      end
+
+      def subscription_id
+        @subscription_id ||= id[/subscriptions\/(.*?[^\/]+)?/i, 1] rescue nil
       end
 
       attr_writer :resource_group
+      attr_writer :subscription_id
 
       def to_h
         @hash

--- a/spec/models/base_model_spec.rb
+++ b/spec/models/base_model_spec.rb
@@ -52,6 +52,29 @@ describe "BaseModel" do
       base = Azure::Armrest::BaseModel.new(json)
       expect(base.resource_group).to eq('foo')
     end
+
+    it "returns the expected value for the resource_group if no trailing slash" do
+      json = {:id => '/foo/bar/resourceGroups/foo'}
+      base = Azure::Armrest::BaseModel.new(json)
+      expect(base.resource_group).to eq('foo')
+    end
+
+    it "defines a subscription_id method that returns nil by default" do
+      expect(base).to respond_to(:subscription_id)
+      expect(base.subscription_id).to eq(nil)
+    end
+
+    it "returns the expected value for the subscription_id method" do
+      json = {:id => '/subscriptions/bar_sub/resourceGroups/foo/x/y/z'}
+      base = Azure::Armrest::BaseModel.new(json)
+      expect(base.subscription_id).to eq('bar_sub')
+    end
+
+    it "returns the expected value for the subscription_id if no trailing slash" do
+      json = {:id => '/subscriptions/bar_sub'}
+      base = Azure::Armrest::BaseModel.new(json)
+      expect(base.subscription_id).to eq('bar_sub')
+    end
   end
 
   context "reserved hashes" do


### PR DESCRIPTION
At the moment we have an `Object#resource_group` method but no `Object#subscription_id` method.

This PR adds a subscription_id method, and improves the existing regex for `resource_group` to account for the possibility that the trailing slash and/or more characters might not be present.