### PR TITLE
Explicitly add the resource_group for private images

### DIFF
--- a/lib/azure/armrest/storage_account_service.rb
+++ b/lib/azure/armrest/storage_account_service.rb
@@ -328,7 +328,7 @@ module Azure
           )
         )
 
-        StorageAccount::PrivateImage.new(hash)
+        StorageAccount::PrivateImage.new(hash).tap { |image| image.resource_group = storage_account.resource_group }
       end
 
       # Get the key for the given +storage_acct+ using the appropriate method


### PR DESCRIPTION
At the moment the custom objects we generate for the `list_private_images` method do not include a resource group. This PR explicitly sets it, using the underlying storage account's resource group as its source.