### PR TITLE
Update nokogiri dependency to 1.7.2

### DIFF
--- a/azure-armrest.gemspec
+++ b/azure-armrest.gemspec
@@ -24,7 +24,7 @@ behind the scenes.
   spec.add_dependency 'memoist', '~> 0.15.0'
   spec.add_dependency 'azure-signature', '~> 0.2.3'
   spec.add_dependency 'activesupport', '>= 4.2.2'
-  spec.add_dependency 'nokogiri', '~> 1.7.1'
+  spec.add_dependency 'nokogiri', '~> 1.7.2'
   spec.add_dependency 'addressable', '~> 2.4.0'
   spec.add_dependency 'parallel', '~> 1.9.0'
 


### PR DESCRIPTION
Addresses a CVE for Nokogiri/libxslt:

https://www.ubuntu.com/usn/usn-3271-1/