### PR TITLE
Remove check for key1, add access_key accessor

### DIFF
--- a/spec/models/storage_account_spec.rb
+++ b/spec/models/storage_account_spec.rb
@@ -58,6 +58,11 @@ describe "StorageAccount" do
       expect(storage).to respond_to(:ssl_verify)
       expect(storage.ssl_verify).to be_nil
     end
+
+    it "defines an access_key accessor that defaults to nil" do
+      expect(storage).to respond_to(:access_key)
+      expect(storage.access_key).to be_nil
+    end
   end
 
   context "custom methods" do


### PR DESCRIPTION
When we first wrote the StorageAccount model, the Azure API included `key1` and `key2` in the output when getting information for individual storage accounts. Consequently, the `key` argument for most of the methods defaulted to `properties.key1` if a key wasn't explicitly provided.

However, Microsoft later removed this information from the JSON output, requiring a separate request to get access key information. The oldest supported api-version string (2015-05-01-preview) does not include this output, so there is no point keeping it around. On the contrary, if you don't provide a key explicitly, you will get a cryptic error message about there being no "key1" property.

This PR does three things. First, it adds an `access_key` accessor, so that you can set it once for that particular storage account. Second, it changes the default from `nil` to `access_key` for all of the method signatures. Lastly, it performs a check against the key argument. If both the argument and the accessor are still `nil` then an ArgumentError is raised.

This change is, for all intents and purposes, backwards compatible because currently you must still explicitly provide a key or that cryptic error is raised.