### PR TITLE
Allow the all_blobs method to accept an options hash

### DIFF
--- a/lib/azure/armrest/model/storage_account.rb
+++ b/lib/azure/armrest/model/storage_account.rb
@@ -306,9 +306,11 @@ module Azure
         results.concat(next_marker_results(doc, :blobs, container, key, options))
       end
 
-      # Returns an array of all blobs for all containers.
+      # Returns an array of all blobs for all containers. The +options+ hash
+      # may contain the same arguments that a call to StorageAccount#blobs
+      # would accept.
       #
-      def all_blobs(key = access_key, max_threads = 10)
+      def all_blobs(key = access_key, max_threads = 10, options = {})
         raise ArgumentError, "No access key specified" unless key
 
         array = []
@@ -316,7 +318,7 @@ module Azure
 
         Parallel.each(containers(key), :in_threads => max_threads) do |container|
           begin
-            mutex.synchronize { array.concat(blobs(container.name, key)) }
+            mutex.synchronize { array.concat(blobs(container.name, key, options)) }
           rescue Errno::ECONNREFUSED, Azure::Armrest::TimeoutException => err
             msg "Unable to gather blob information for #{container.name}: #{err}"
             log('warn', msg)

--- a/spec/models/storage_account_spec.rb
+++ b/spec/models/storage_account_spec.rb
@@ -86,6 +86,12 @@ describe "StorageAccount" do
       expect(storage).to respond_to(:all_blobs)
     end
 
+    it "allows an optional hash for the all_blobs method" do
+      allow(storage).to receive(:containers).with("abc").and_return([])
+      expect(storage.all_blobs("abc", 5)).to eql([])
+      expect(storage.all_blobs("abc", 5, :maxresults => 5)).to eql([])
+    end
+
     it "defines a blob_properties method" do
       expect(storage).to respond_to(:blob_properties)
     end


### PR DESCRIPTION
The `StorageAccount#all_blobs` method should allow a hash of options. This is then passed to the `StorageAccount#blobs` method as part of the call when collecting blobs.