### PR TITLE
Refactor the locations method

### DIFF
--- a/lib/azure/armrest/armrest_service.rb
+++ b/lib/azure/armrest/armrest_service.rb
@@ -77,15 +77,25 @@ module Azure
       # +provider+. If you do not specify a provider, then the locations for
       # all providers will be returned.
       #
-      # If you need individual details on a per-provider basis, use the
-      # provider_info method instead.
-      #--
+      # If you need individual details on a per-provider basis, use the methods
+      # of the ResourceProviderService instead.
+      #
+      # Deprecated.
       #
       def locations(provider = nil)
         list = configuration.providers
         list = list.select { |rp| rp.namespace.casecmp(provider) == 0 } if provider
-
         list.collect { |rp| rp.resource_types.map(&:locations) }.flatten.uniq.sort
+      end
+
+      deprecate :locations, :list_locations, 2019, 1
+
+      # Returns a list of Location objects for the current subscription.
+      #
+      def list_locations
+        url = url_with_api_version(configuration.api_version, base_url, 'locations')
+        response = rest_get(url)
+        Azure::Armrest::ArmrestCollection.create_from_response(response, Location)
       end
 
       # Returns a list of subscriptions for the current tenant.

--- a/lib/azure/armrest/model/base_model.rb
+++ b/lib/azure/armrest/model/base_model.rb
@@ -191,6 +191,7 @@ module Azure
     class Container < BaseModel; end
     class Event < BaseModel; end
     class ImageVersion < BaseModel; end
+    class Location < BaseModel; end
     class Offer < BaseModel; end
     class Publisher < BaseModel; end
     class Resource < BaseModel; end

--- a/spec/armrest_service_spec.rb
+++ b/spec/armrest_service_spec.rb
@@ -21,6 +21,11 @@ describe Azure::Armrest::ArmrestService do
       expect(subject).to respond_to(:locations)
     end
 
+    it "defines a list_locations method that does not accept any arguments" do
+      expect(subject).to respond_to(:list_locations)
+      expect { subject.list_locations('foo') }.to raise_error(ArgumentError)
+    end
+
     it "defines a providers method" do
       expect(subject).to respond_to(:providers)
     end


### PR DESCRIPTION
The ArmrestService#locations method originally iterated over the providers list because I didn't think there was a direct way to get a list of supported locations. The only documentation I could find applied only to classic Azure. However, it turns out that you *can* get a list of locations directly.

Consequently I would like to refactor the ArmrestService#locations method so that it returns a list of Location objects. Also, to be consistent with our other methods, change the method name to `list_locations` with a deprecated alias for backwards compatibility. Here's an example of what the proposed method returns:

    "id"          => "/subscriptions/xxx/locations/koreasouth",
    "name"        => "koreasouth",
    "displayName" => "Korea South",
    "longitude"   => "129.0756",
    "latitude"    => "35.1796"

Getting locations by provider can still be accomplished by using the `ResourceProviderService` if users desire.

Since this is a backwards incompatible change, it should be part of the 0.8.0 release, along with my proposed changes to `StorageAccount#create_blob` and `StorageAccount#create_blob_snapshot`.

FYI, this does cause some minor breakage in ManageIQ for discovery, but the fix is very simple (a modification to 1 line), and we wouldn't have to worry about it until we upgraded to 0.8.x of the armrest gem.