### PR TITLE
Add list_all method to VirtualMachineImageService

### DIFF
--- a/lib/azure/armrest/virtual_machine_image_service.rb
+++ b/lib/azure/armrest/virtual_machine_image_service.rb
@@ -22,6 +22,35 @@ module Azure
         @publisher = options[:publisher]
       end
 
+      # Return a list of all VM image offers from the given +location+.
+      #
+      # Example:
+      #
+      #   vmis.list_all('eastus')
+      #
+      def list_all(location = @location)
+        raise ArgumentError, "No location specified" unless location
+
+        images = []
+        publishers(location).each do |publisher|
+          offers(location, publisher.name).each do |offer|
+            skus(offer.name, location, publisher.name).each do |sku|
+              versions(sku.name, offer.name, location, publisher.name).each do |version|
+                images << Azure::Armrest::VirtualMachineImage.new(
+                    :location  => version.location,
+                    :publisher => publisher.name,
+                    :offer     => offer.name,
+                    :sku       => sku.name,
+                    :version   => version.name,
+                    :id        => "#{publisher.name}:#{offer.name}:#{sku.name}:#{version.name}"
+                )
+              end
+            end
+          end
+        end
+        images
+      end
+
       # Return a list of VM image offers from the given +publisher+ and +location+.
       #
       # Example:

--- a/spec/virtual_machine_image_service_spec.rb
+++ b/spec/virtual_machine_image_service_spec.rb
@@ -37,6 +37,10 @@ describe "VirtualMachineImageService" do
   end
 
   context "instance methods" do
+    it "defines an list_all method" do
+      expect(vmis).to respond_to(:list_all)
+    end
+
     it "defines an offers method" do
       expect(vmis).to respond_to(:offers)
     end


### PR DESCRIPTION
Essentially just the commit message. This adds a list_all method to the ```VirtualMachineImageService``` class. This method is used in ManageIQ/manageiq-providers-azure#95