### PR TITLE
Add TemplateDeploymentService#exists? method

### DIFF
--- a/lib/azure/armrest/template_deployment_service.rb
+++ b/lib/azure/armrest/template_deployment_service.rb
@@ -63,6 +63,15 @@ module Azure
         delete_resources(resource_ids, resource_ids.size)
       end
 
+      # Returns whether or not the given deployment exists.
+      #
+      def exists?(deploy_name, resource_group = configuration.resource_group)
+        url = build_url(resource_group, deploy_name)
+        rest_head(url) and true
+      rescue Azure::Armrest::NotFoundException
+        false
+      end
+
       private
 
       def delete_resources(ids, retry_cnt)

--- a/spec/template_deployment_service_spec.rb
+++ b/spec/template_deployment_service_spec.rb
@@ -85,6 +85,16 @@ describe "TemplateDeploymentService" do
       tds.get('deployname', 'groupname')
     end
 
+    it "defines an exists? method" do
+      allow(tds).to receive(:rest_head).and_return('')
+      expect(tds.exists?('deployname', 'groupname')).to eql(true)
+    end
+
+    it "returns false for the exists method if a 404 is raised" do
+      allow(tds).to receive(:rest_head).and_raise(Azure::Armrest::NotFoundException.new(404, "not found", nil))
+      expect(tds.exists?('deployname', 'groupname')).to eql(false)
+    end
+
     it "defines a list_deployment_operations method" do
       expected = @req.merge(:url => url_prefix + "/deployname/operations?api-version=#{api_version}")
       expect(RestClient::Request).to receive(:execute).with(expected).and_return('{"value":{}}')


### PR DESCRIPTION
This adds the `exists?` method to the `TemplateDeploymentService` class. Ideally we could use this method to speed up template collection, as well as reduce memory, since it uses a HEAD request.