### PR TITLE
Automatically camelize hash keys in the create method

### DIFF
--- a/lib/azure/armrest/armrest_service.rb
+++ b/lib/azure/armrest/armrest_service.rb
@@ -1,4 +1,5 @@
 require 'time'
+require 'active_support/core_ext/hash/conversions'
 require_relative 'model/base_model'
 
 module Azure


### PR DESCRIPTION
At the moment, any resource group based service that calls `create` must match the hash keys to the actual parameters used by Azure. This means they must be in `camelCase` format, so the `options` hash to a `create` currently must look something like this:

```
:properties => {
    :hardwareProfile => { :vmSize => 'Standard_A0' },
    :osProfile => {
      :adminUserName => 'dberger',
      :adminPassword => 'Smartvm123',
      :computerName  => 'miqazure-wincpy'
    },
}
```

With this change users could write `:hardwareProfile` or `:hardware_profile` interchangeably and it would Just Work.

One less thing to worry about. :)

