### PR TITLE
Add the ResourceGroupService#exists? method

### DIFF
--- a/lib/azure/armrest/resource_group_service.rb
+++ b/lib/azure/armrest/resource_group_service.rb
@@ -10,6 +10,15 @@ module Azure
         super(configuration, 'resourceGroups', 'Microsoft.Resources', options)
       end
 
+      # Returns whether or not the given resource group exists.
+      #
+      def exists?(group)
+        url = build_url(group)
+        rest_head(url) and true
+      rescue Azure::Armrest::NotFoundException
+        false
+      end
+
       # List all the resources for the current subscription. You can optionally
       # pass :top or :filter options as well to restrict returned results. The
       # :filter option only applies to tags.

--- a/spec/resource_group_service_spec.rb
+++ b/spec/resource_group_service_spec.rb
@@ -30,6 +30,10 @@ describe "ResourceGroupService" do
       expect(rgsrv).to respond_to(:delete)
     end
 
+    it "defines an exists? method" do
+      expect(rgsrv).to respond_to(:exists?)
+    end
+
     it "defines a get method" do
       expect(rgsrv).to respond_to(:get)
     end
@@ -40,6 +44,19 @@ describe "ResourceGroupService" do
 
     it "defines an update method" do
       expect(rgsrv).to respond_to(:update)
+    end
+  end
+
+  context "exists?" do
+    it "returns true if no exception is raised" do
+      allow(rgsrv).to receive(:rest_head).and_return("")
+      expect(rgsrv.exists?('foo')).to eql(true)
+    end
+
+    it "returns false if an exception is raised" do
+      expected_error = Azure::Armrest::NotFoundException.new(404, "not_found", nil)
+      allow(rgsrv).to receive(:rest_head).and_raise(expected_error)
+      expect(rgsrv.exists?('foo')).to eql(false)
     end
   end
 end


### PR DESCRIPTION
Adds the ResourceGroupService#exists? method. Unlike a `get` this is a faster HEAD request, and only returns a boolean value.