### PR TITLE
Add the KeyVaultService class

### DIFF
--- a/lib/azure/armrest.rb
+++ b/lib/azure/armrest.rb
@@ -59,6 +59,7 @@ require 'azure/armrest/role/definition_service'
 require 'azure/armrest/sql/sql_server_service'
 require 'azure/armrest/sql/sql_database_service'
 require 'azure/armrest/billing/usage_service'
+require 'azure/armrest/key_vault_service'
 
 # JSON wrapper classes. The service classes should require their own
 # wrappers from this point on.

--- a/lib/azure/armrest/key_vault_service.rb
+++ b/lib/azure/armrest/key_vault_service.rb
@@ -1,0 +1,40 @@
+# Azure namespace
+module Azure
+  # Armrest namespace
+  module Armrest
+    # Base class for managing key vaults.
+    class KeyVaultService < ResourceGroupBasedService
+      # Create and return a new KeyVaultService instance.
+      #
+      def initialize(configuration, options = {})
+        super(configuration, 'vaults', 'Microsoft.KeyVault', options)
+      end
+
+      # Gets the deleted Azure key vault.
+      #
+      def get_deleted(vault_name, location)
+        url = File.join(base_url, 'providers', provider, 'locations', location, 'deletedVaults', vault_name)
+        url << "?api-version=#{api_version}"
+        response = rest_get(url)
+        get_all_results(response)
+      end
+
+      # Gets information about the deleted vaults in a subscription.
+      #
+      def list_deleted
+        url = File.join(base_url, 'providers', provider, 'deletedVaults') + "?api-version=#{api_version}"
+        response = rest_get(url)
+        get_all_results(response)
+      end
+
+      # Permanently removes the deleted +vault_name+ at +location+.
+      #
+      def purge_deleted(vault_name, location)
+        url = File.join(base_url, 'providers', provider, 'locations', location, 'deletedVaults', vault_name, 'purge')
+        url << "?api-version=#{api_version}"
+        response = rest_post(url)
+        get_all_results(response)
+      end
+    end
+  end
+end

--- a/lib/azure/armrest/model/base_model.rb
+++ b/lib/azure/armrest/model/base_model.rb
@@ -198,6 +198,7 @@ module Azure
     class ResourceGroup < BaseModel; end
     class ResourceProvider < BaseModel; end
     class Sku < BaseModel; end
+    class KeyVault < BaseModel; end
 
     module Billing
       class Usage < BaseModel; end

--- a/spec/key_vault_service_spec.rb
+++ b/spec/key_vault_service_spec.rb
@@ -1,0 +1,58 @@
+########################################################################
+# key_vault_service_spec.rb
+#
+# Test suite for the Azure::Armrest::KeyVaultService class.
+########################################################################
+require 'spec_helper'
+
+describe "KeyVaultService" do
+  before { setup_params }
+  let(:vault) { Azure::Armrest::KeyVaultService.new(@conf) }
+
+  context "inheritance" do
+    it "is a subclass of ArmrestService" do
+      expect(Azure::Armrest::KeyVaultService.ancestors).to include(Azure::Armrest::ArmrestService)
+    end
+  end
+
+  context "constructor" do
+    it "returns an Azure::Armrest::KeyVaultService instance as expected" do
+      expect(vault).to be_kind_of(Azure::Armrest::KeyVaultService)
+    end
+  end
+
+  context "instance methods" do
+    it "defines a create method" do
+      expect(vault).to respond_to(:create)
+    end
+
+    it "defines an update alias" do
+      expect(vault).to respond_to(:update)
+      expect(vault.method(:update)).to eql(vault.method(:create))
+    end
+
+    it "defines a delete method" do
+      expect(vault).to respond_to(:delete)
+    end
+
+    it "defines a get method" do
+      expect(vault).to respond_to(:get)
+    end
+
+    it "defines a list_all method" do
+      expect(vault).to respond_to(:list_all)
+    end
+
+    it "defines a list_deleted method" do
+      expect(vault).to respond_to(:list_deleted)
+    end
+
+    it "defines a purge_deleted method" do
+      expect(vault).to respond_to(:purge_deleted)
+    end
+
+    it "defines a get_deleted method" do
+      expect(vault).to respond_to(:get_deleted)
+    end
+  end
+end


### PR DESCRIPTION
This PR adds the KeyVault service class and specs. This could potentially be used for the Azure provider keys option.