### PR TITLE
Allow options to the list and list_all methods for ResourceProviderService

### DIFF
--- a/lib/azure/armrest/model/base_model.rb
+++ b/lib/azure/armrest/model/base_model.rb
@@ -156,6 +156,7 @@ module Azure
         excl_list = self.class.send(:excl_list)
         obj.each do |key, value|
           snake = key.to_s.tr(' ', '_').underscore
+          snake.tr!('.', '_')
 
           unless excl_list.include?(snake) # Must deal with nested models
             if value.kind_of?(Array)


### PR DESCRIPTION
This PR allows the `list` and `list_all` methods to accept a hash of options that could potentially modify the results. The possible options are `:top` and `:expand`.

It also fixes an issue I ran into when I used the `:expand` option, which is that a hash key with a "." in it would blow up our model generator. This converts them to underscores.