### PR TITLE
Modify the StorageAccountService class to pass full configuration object to model

### DIFF
--- a/lib/azure/armrest/model/storage_account.rb
+++ b/lib/azure/armrest/model/storage_account.rb
@@ -28,24 +28,15 @@ module Azure
       # request. The default is 2016-05-31.
       attr_accessor :storage_api_version
 
-      # An http proxy to use per request. Defaults to ENV['http_proxy'] if set.
-      attr_accessor :proxy
-
-      # The SSL version to use per request. Defaults to TLSv1.
-      attr_accessor :ssl_version
-
-      # The SSL verification method used for each request. The default is VERIFY_PEER.
-      attr_accessor :ssl_verify
-
       # The default access key used when creating a signature for internal http requests.
       attr_accessor :access_key
+
+      # The parent configuration object
+      attr_accessor :configuration
 
       def initialize(json)
         super
         @storage_api_version = '2016-05-31'
-        @proxy = ENV['http_proxy']
-        @ssl_version = 'TLSv1'
-        @ssl_verify = nil
       end
 
       # Returns a list of tables for the given storage account +key+. Note
@@ -290,9 +281,9 @@ module Azure
           :url         => url,
           :payload     => '',
           :headers     => headers,
-          :proxy       => proxy,
-          :ssl_version => ssl_version,
-          :ssl_verify  => ssl_verify
+          :proxy       => configuration.proxy,
+          :ssl_version => configuration.ssl_version,
+          :ssl_verify  => configuration.ssl_verify
         )
 
         Azure::Armrest::ResponseHeaders.new(response.headers).tap do |rh|
@@ -335,9 +326,9 @@ module Azure
           :url         => dst_url,
           :payload     => '',
           :headers     => headers,
-          :proxy       => proxy,
-          :ssl_version => ssl_version,
-          :ssl_verify  => ssl_verify
+          :proxy       => configuration.proxy,
+          :ssl_version => configuration.ssl_version,
+          :ssl_verify  => configuration.ssl_verify
         )
 
         Azure::Armrest::ResponseHeaders.new(response.headers).tap do |rh|
@@ -385,9 +376,9 @@ module Azure
           :url         => url,
           :payload     => content,
           :headers     => headers,
-          :proxy       => proxy,
-          :ssl_version => ssl_version,
-          :ssl_verify  => ssl_verify
+          :proxy       => configuration.proxy,
+          :ssl_version => configuration.ssl_version,
+          :ssl_verify  => configuration.ssl_verify
         )
 
         Azure::Armrest::ResponseHeaders.new(response.headers).tap do |rh|
@@ -486,9 +477,9 @@ module Azure
           :rest_head,
           :url         => url,
           :headers     => headers,
-          :proxy       => proxy,
-          :ssl_version => ssl_version,
-          :ssl_verify  => ssl_verify
+          :proxy       => configuration.proxy,
+          :ssl_version => configuration.ssl_version,
+          :ssl_verify  => configuration.ssl_verify
         )
 
         BlobProperty.new(response.headers.merge(:container => container, :name => blob))
@@ -525,9 +516,9 @@ module Azure
           :rest_put,
           :url         => url,
           :headers     => headers,
-          :proxy       => proxy,
-          :ssl_version => ssl_version,
-          :ssl_verify  => ssl_verify
+          :proxy       => configuration.proxy,
+          :ssl_version => configuration.ssl_version,
+          :ssl_verify  => configuration.ssl_verify
         )
 
         BlobProperty.new(response.headers.merge(:container => container, :name => blob))
@@ -670,9 +661,9 @@ module Azure
           :url         => dst_url,
           :payload     => '',
           :headers     => headers,
-          :proxy       => proxy,
-          :ssl_version => ssl_version,
-          :ssl_verify  => ssl_verify
+          :proxy       => configuration.proxy,
+          :ssl_version => configuration.ssl_version,
+          :ssl_verify  => configuration.ssl_verify
         )
 
         blob = blob_properties(dst_container, dst_blob, key)
@@ -697,9 +688,9 @@ module Azure
           :rest_delete,
           :url         => url,
           :headers     => headers,
-          :proxy       => proxy,
-          :ssl_version => ssl_version,
-          :ssl_verify  => ssl_verify
+          :proxy       => configuration.proxy,
+          :ssl_version => configuration.ssl_version,
+          :ssl_verify  => configuration.ssl_verify
         )
 
         headers = Azure::Armrest::ResponseHeaders.new(response.headers)
@@ -752,7 +743,7 @@ module Azure
         end
 
         hash['x-ms-date'] ||= Time.now.httpdate
-        hash['x-ms-version'] ||= @storage_api_version
+        hash['x-ms-version'] ||= storage_api_version
         hash['verb'] = 'PUT'
 
         # Content length must be 0 (blank) for Page or Append blobs
@@ -772,9 +763,9 @@ module Azure
           :url         => url,
           :payload     => payload,
           :headers     => headers,
-          :proxy       => proxy,
-          :ssl_version => ssl_version,
-          :ssl_verify  => ssl_verify
+          :proxy       => configuration.proxy,
+          :ssl_version => configuration.ssl_version,
+          :ssl_verify  => configuration.ssl_verify
         )
 
         resp_headers = Azure::Armrest::ResponseHeaders.new(response.headers)
@@ -823,9 +814,9 @@ module Azure
           :url         => url,
           :payload     => '',
           :headers     => headers,
-          :proxy       => proxy,
-          :ssl_version => ssl_version,
-          :ssl_verify  => ssl_verify
+          :proxy       => configuration.proxy,
+          :ssl_version => configuration.ssl_version,
+          :ssl_verify  => configuration.ssl_verify
         )
 
         headers = Azure::Armrest::ResponseHeaders.new(response.headers)
@@ -899,9 +890,9 @@ module Azure
           :rest_get,
           :url         => url,
           :headers     => headers,
-          :proxy       => proxy,
-          :ssl_version => ssl_version,
-          :ssl_verify  => ssl_verify,
+          :proxy       => configuration.proxy,
+          :ssl_version => configuration.ssl_version,
+          :ssl_verify  => configuration.ssl_verify
         )
       end
 
@@ -954,9 +945,9 @@ module Azure
           :rest_get,
           :url         => url,
           :headers     => headers,
-          :proxy       => proxy,
-          :ssl_version => ssl_version,
-          :ssl_verify  => ssl_verify,
+          :proxy       => configuration.proxy,
+          :ssl_version => configuration.ssl_version,
+          :ssl_verify  => configuration.ssl_verify
         )
       end
 
@@ -973,9 +964,9 @@ module Azure
         params = {
           :url         => url,
           :headers     => headers,
-          :proxy       => proxy,
-          :ssl_version => ssl_version,
-          :ssl_verify  => ssl_verify,
+          :proxy       => configuration.proxy,
+          :ssl_version => configuration.ssl_version,
+          :ssl_verify  => configuration.ssl_verify
         }
 
         if %w[put post].include?(request_type.to_s.downcase)
@@ -1002,9 +993,9 @@ module Azure
           :rest_get,
           :url         => url,
           :headers     => headers,
-          :proxy       => proxy,
-          :ssl_version => ssl_version,
-          :ssl_verify  => ssl_verify,
+          :proxy       => configuration.proxy,
+          :ssl_version => configuration.ssl_version,
+          :ssl_verify  => configuration.ssl_verify
         )
       end
 
@@ -1022,7 +1013,7 @@ module Azure
         headers = {
           'content-type' => content_type,
           'x-ms-date'    => Time.now.httpdate,
-          'x-ms-version' => @storage_api_version,
+          'x-ms-version' => storage_api_version,
           'auth_string'  => true
         }
 

--- a/lib/azure/armrest/storage_account_service.rb
+++ b/lib/azure/armrest/storage_account_service.rb
@@ -13,31 +13,19 @@ module Azure
       # Same as other resource based get methods, but also sets the proxy on the model object.
       #
       def get(name, resource_group = configuration.resource_group)
-        super.tap do |m|
-          m.proxy       = configuration.proxy
-          m.ssl_version = configuration.ssl_version
-          m.ssl_verify  = configuration.ssl_verify
-        end
+        super.tap { |model| model.configuration = configuration }
       end
 
       # Same as other resource based list methods, but also sets the proxy on each model object.
       #
       def list(resource_group = configuration.resource_group)
-        super.each do |m|
-          m.proxy       = configuration.proxy
-          m.ssl_version = configuration.ssl_version
-          m.ssl_verify  = configuration.ssl_verify
-        end
+        super.each { |model| model.configuration = configuration }
       end
 
       # Same as other resource based list_all methods, but also sets the proxy on each model object.
       #
       def list_all(filter = {})
-        super(filter).each do |m|
-          m.proxy       = configuration.proxy
-          m.ssl_version = configuration.ssl_version
-          m.ssl_verify  = configuration.ssl_verify
-        end
+        super(filter).each { |model| model.configuration = configuration }
       end
 
       # Creates a new storage account, or updates an existing account with the
@@ -86,9 +74,7 @@ module Azure
           url << "&validating=" << validating if validating
         end
 
-        acct.proxy       = configuration.proxy
-        acct.ssl_version = configuration.ssl_version
-        acct.ssl_verify  = configuration.ssl_verify
+        acct.configuration = configuration
 
         acct
       end
@@ -230,6 +216,8 @@ module Azure
           acct = list_all(:name => name).first
           raise err unless acct
         end
+
+        acct.configuration = configuration
 
         acct
       end

--- a/spec/models/storage_account_spec.rb
+++ b/spec/models/storage_account_spec.rb
@@ -41,22 +41,8 @@ describe "StorageAccount" do
       expect(storage.storage_api_version).to eq('2016-05-31')
     end
 
-    it "defines a proxy accessor that defaults to the http_proxy environment variable" do
-      proxy = "http://www.somewebsiteyyyyzzzz.com/bogusproxy"
-      allow(ENV).to receive(:[]).with('http_proxy').and_return(proxy)
-
-      expect(storage).to respond_to(:proxy)
-      expect(storage.proxy).to eq(proxy)
-    end
-
-    it "defines an ssl_version accessor that defaults to TLSv1" do
-      expect(storage).to respond_to(:ssl_version)
-      expect(storage.ssl_version).to eq('TLSv1')
-    end
-
-    it "defines an ssl_verify accessor that defaults to nil" do
-      expect(storage).to respond_to(:ssl_verify)
-      expect(storage.ssl_verify).to be_nil
+    it "defines a configuration accessor" do
+      expect(storage).to respond_to(:configuration)
     end
 
     it "defines an access_key accessor that defaults to nil" do


### PR DESCRIPTION
Currently we are only passing specific parameters to each StorageAccount object from the Configuration object. This PR modifies the StorageAccountService and StorageAccount model classes so that the full configuration object is passed along.

This eliminates the need for separate accessors for each property, and makes it easier to handle configuration properties that we may need to handle in the future within the model. For example, I want to add a `:timeout` property to the Configuration object that I will need to pass along to the models. With this approach, the model will automatically have access to it.