### PR TITLE
Add a :timeout option that is passed along to all http requests

### DIFF
--- a/lib/azure/armrest/armrest_service.rb
+++ b/lib/azure/armrest/armrest_service.rb
@@ -288,6 +288,7 @@ module Azure
           :proxy       => configuration.proxy,
           :ssl_version => configuration.ssl_version,
           :ssl_verify  => configuration.ssl_verify,
+          :timeout     => configuration.timeout,
           :headers => {
             :accept        => configuration.accept,
             :content_type  => configuration.content_type,

--- a/lib/azure/armrest/configuration.rb
+++ b/lib/azure/armrest/configuration.rb
@@ -59,6 +59,9 @@ module Azure
       # SSL verify mode for all http requests.
       attr_accessor :ssl_verify
 
+      # Timeout value for http requests in seconds. The default is 60.
+      attr_accessor :timeout
+
       # Namespace providers, their resource types, locations and supported api-version strings.
       attr_reader :providers
 
@@ -105,6 +108,7 @@ module Azure
           :grant_type    => 'client_credentials',
           :proxy         => ENV['http_proxy'],
           :ssl_version   => 'TLSv1',
+          :timeout       => 60,
           :max_threads   => 10,
           :max_retries   => 3,
           :environment   => Azure::Armrest::Environment::Public
@@ -295,6 +299,7 @@ module Azure
             :proxy       => proxy,
             :ssl_version => ssl_version,
             :ssl_verify  => ssl_verify,
+            :timeout     => timeout,
             :payload     => {
               :grant_type    => grant_type,
               :client_id     => client_id,

--- a/lib/azure/armrest/model/storage_account.rb
+++ b/lib/azure/armrest/model/storage_account.rb
@@ -306,7 +306,8 @@ module Azure
           :headers     => headers,
           :proxy       => configuration.proxy,
           :ssl_version => configuration.ssl_version,
-          :ssl_verify  => configuration.ssl_verify
+          :ssl_verify  => configuration.ssl_verify,
+          :timeout     => configuration.timeout
         )
 
         Azure::Armrest::ResponseHeaders.new(response.headers).tap do |rh|
@@ -351,7 +352,8 @@ module Azure
           :headers     => headers,
           :proxy       => configuration.proxy,
           :ssl_version => configuration.ssl_version,
-          :ssl_verify  => configuration.ssl_verify
+          :ssl_verify  => configuration.ssl_verify,
+          :timeout     => configuration.timeout
         )
 
         Azure::Armrest::ResponseHeaders.new(response.headers).tap do |rh|
@@ -401,7 +403,8 @@ module Azure
           :headers     => headers,
           :proxy       => configuration.proxy,
           :ssl_version => configuration.ssl_version,
-          :ssl_verify  => configuration.ssl_verify
+          :ssl_verify  => configuration.ssl_verify,
+          :timeout     => configuration.timeout
         )
 
         Azure::Armrest::ResponseHeaders.new(response.headers).tap do |rh|
@@ -516,7 +519,8 @@ module Azure
           :headers     => headers,
           :proxy       => configuration.proxy,
           :ssl_version => configuration.ssl_version,
-          :ssl_verify  => configuration.ssl_verify
+          :ssl_verify  => configuration.ssl_verify,
+          :timeout     => configuration.timeout
         )
 
         BlobProperty.new(response.headers.merge(:container => container, :name => blob), options[:skip_accessors_definition])
@@ -555,7 +559,8 @@ module Azure
           :headers     => headers,
           :proxy       => configuration.proxy,
           :ssl_version => configuration.ssl_version,
-          :ssl_verify  => configuration.ssl_verify
+          :ssl_verify  => configuration.ssl_verify,
+          :timeout     => configuration.timeout
         )
 
         BlobProperty.new(response.headers.merge(:container => container, :name => blob))
@@ -717,7 +722,8 @@ module Azure
           :headers     => headers,
           :proxy       => configuration.proxy,
           :ssl_version => configuration.ssl_version,
-          :ssl_verify  => configuration.ssl_verify
+          :ssl_verify  => configuration.ssl_verify,
+          :timeout     => configuration.timeout
         )
 
         blob = blob_properties(dst_container, dst_blob, key)
@@ -744,7 +750,8 @@ module Azure
           :headers     => headers,
           :proxy       => configuration.proxy,
           :ssl_version => configuration.ssl_version,
-          :ssl_verify  => configuration.ssl_verify
+          :ssl_verify  => configuration.ssl_verify,
+          :timeout     => configuration.timeout
         )
 
         headers = Azure::Armrest::ResponseHeaders.new(response.headers)
@@ -819,7 +826,8 @@ module Azure
           :headers     => headers,
           :proxy       => configuration.proxy,
           :ssl_version => configuration.ssl_version,
-          :ssl_verify  => configuration.ssl_verify
+          :ssl_verify  => configuration.ssl_verify,
+          :timeout     => configuration.timeout
         )
 
         resp_headers = Azure::Armrest::ResponseHeaders.new(response.headers)
@@ -870,7 +878,8 @@ module Azure
           :headers     => headers,
           :proxy       => configuration.proxy,
           :ssl_version => configuration.ssl_version,
-          :ssl_verify  => configuration.ssl_verify
+          :ssl_verify  => configuration.ssl_verify,
+          :timeout     => configuration.timeout
         )
 
         headers = Azure::Armrest::ResponseHeaders.new(response.headers)
@@ -946,7 +955,8 @@ module Azure
           :headers     => headers,
           :proxy       => configuration.proxy,
           :ssl_version => configuration.ssl_version,
-          :ssl_verify  => configuration.ssl_verify
+          :ssl_verify  => configuration.ssl_verify,
+          :timeout     => configuration.timeout
         )
       end
 
@@ -1001,7 +1011,8 @@ module Azure
           :headers     => headers,
           :proxy       => configuration.proxy,
           :ssl_version => configuration.ssl_version,
-          :ssl_verify  => configuration.ssl_verify
+          :ssl_verify  => configuration.ssl_verify,
+          :timeout     => configuration.timeout
         )
       end
 
@@ -1020,7 +1031,8 @@ module Azure
           :headers     => headers,
           :proxy       => configuration.proxy,
           :ssl_version => configuration.ssl_version,
-          :ssl_verify  => configuration.ssl_verify
+          :ssl_verify  => configuration.ssl_verify,
+          :timeout     => configuration.timeout
         }
 
         if %w[put post].include?(request_type.to_s.downcase)
@@ -1049,7 +1061,8 @@ module Azure
           :headers     => headers,
           :proxy       => configuration.proxy,
           :ssl_version => configuration.ssl_version,
-          :ssl_verify  => configuration.ssl_verify
+          :ssl_verify  => configuration.ssl_verify,
+          :timeout     => configuration.timeout
         )
       end
 

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -130,6 +130,12 @@ describe Azure::Armrest::Configuration do
         subject.max_threads = 8
         expect(subject.max_threads).to eql(8)
       end
+
+      it 'defines a timeout accessor' do
+        expect(subject.timeout).to eql(60)
+        subject.timeout = 20
+        expect(subject.timeout).to eql(20)
+      end
     end
 
     context 'max_threads' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -85,7 +85,7 @@ def setup_params
     :client_key       => @key,
     :tenant_id        => @ten,
     :token            => @tok,
-    :token_expiration => Time.now + 3600
+    :token_expiration => Time.now + 3600,
   )
 
   @req = {
@@ -93,6 +93,7 @@ def setup_params
     :proxy       => nil,
     :ssl_verify  => nil,
     :ssl_version => 'TLSv1',
+    :timeout     => 60,
     :headers => {
       :accept        => 'application/json',
       :content_type  => 'application/json',


### PR DESCRIPTION
This PR adds a :timeout option that is passed along to each rest-client http request. I've set the default value to 10 seconds for now.

I've tested several of our methods, including private image collection and raw blob data, and it seems to be fine with that value. It can always be configured, too.