### PR TITLE
Add max_retries accessor and retry on rest_execute in certain conditions

### DIFF
--- a/lib/azure/armrest/configuration.rb
+++ b/lib/azure/armrest/configuration.rb
@@ -69,6 +69,10 @@ module Azure
       # default is Azure::Armrest::Environment::Public.
       attr_accessor :environment
 
+      # Maximum number of attempts to retry an http request in the case of
+      # request throttling or server side service issues.
+      attr_accessor :max_retries
+
       # Yields a new Azure::Armrest::Configuration objects. Note that you must
       # specify a client_id, client_key, tenant_id. The subscription_id is optional
       # but should be specified in most cases. All other parameters are optional.
@@ -102,6 +106,7 @@ module Azure
           :proxy         => ENV['http_proxy'],
           :ssl_version   => 'TLSv1',
           :max_threads   => 10,
+          :max_retries   => 3,
           :environment   => Azure::Armrest::Environment::Public
         }.merge(args.symbolize_keys)
 


### PR DESCRIPTION
This adds the Configuration#max_retries accessor. This, in turn, controls the maximum number of retry attempts on 429 and most 50x errors.

The `rest_execute` method is then modified to automatically retry X number of times (default: 3) if a 429 or 50x HTTP error code occurs. The 429 error is returned if the user exceeds their rate limit. The 50x errors that I rescue are server side issues that are typically temporary and transient.

For both 429 and 503 errors the server will return a `Retry-After` header that we can use to determine the amount of time we should sleep between tries. If that header isn't found, it defaults to 30 seconds. If a logger object is set, a warning is logged as well.

Update: I've added 409 (Conflict) as well since it can happen with blob operations.