### PR TITLE
Refactor get_blob_raw method

### DIFF
--- a/lib/azure/armrest/armrest_service.rb
+++ b/lib/azure/armrest/armrest_service.rb
@@ -189,8 +189,8 @@ module Azure
       # For most resources the +max_time+ argument should be more than sufficient.
       # Certain resources, such as virtual machines, could take longer.
       #
-      def wait(response, max_time = 60)
-        sleep_time = response.respond_to?(:retry_after) ? response.retry_after.to_i : 10
+      def wait(response, max_time = 60, default_interval = 10)
+        sleep_time = response.respond_to?(:retry_after) ? response.retry_after.to_i : default_interval
         total_time = 0
 
         until (status = poll(response)) =~ /^succe/i # success or succeeded

--- a/spec/storage_disk_service_spec.rb
+++ b/spec/storage_disk_service_spec.rb
@@ -58,17 +58,20 @@ describe "Storage::DiskService" do
       headers = Azure::Armrest::ResponseHeaders.new(:headers => {:azure_asyncoperation => "https://www.foo.bar"})
       body    = Azure::Armrest::ResponseBody.new(:body => {:properties => {:output => {:access_sas => 'xyz'}}})
 
+      allow(disk).to receive(:wait).and_return('succeeded')
       allow(disk).to receive(:rest_post).and_return(headers)
       allow(disk).to receive(:rest_get).and_return(body)
 
       expect { disk.get_blob_raw('foo', 'bar') }.to raise_error(ArgumentError, /must specify byte range/)
     end
 
-    it "will raise an error if azure_asyncoperation and location headers cannot be found" do
-      headers = Azure::Armrest::ResponseHeaders.new(:code => 200, :body => '', :headers => {:location => nil, :response_code => 200})
+    it "will raise an error if it cannot acquire an access token" do
+      headers = Azure::Armrest::ResponseHeaders.new(:headers => {:stuff => 1}, :code => 404, :body => "oops")
+
+      allow(disk).to receive(:wait).and_return('failed')
       allow(disk).to receive(:rest_post).and_return(headers)
-      expect { disk.get_blob_raw('foo', 'bar') }.to raise_error(Azure::Armrest::NotFoundException)
-      expect { disk.get_blob_raw('foo', 'bar') }.to raise_error(Azure::Armrest::NotFoundException, /Unable to find an operations URL*/i)
+
+      expect { disk.get_blob_raw('foo', 'bar') }.to raise_error(Azure::Armrest::NotFoundException, /Unable to obtain an operations URL/)
     end
   end
 end

--- a/spec/storage_snapshot_service_spec.rb
+++ b/spec/storage_snapshot_service_spec.rb
@@ -64,11 +64,13 @@ describe "Storage::SnapshotService" do
       expect { snapshot.get_blob_raw('foo', 'bar') }.to raise_error(ArgumentError, /must specify byte range/)
     end
 
-    it "will raise an error if azure_asyncoperation and location headers cannot be found" do
-      headers = Azure::Armrest::ResponseHeaders.new(:code => 200, :body => '', :headers => {:location => nil, :response_code => 200})
+    it "will raise an error if it cannot acquire an access token" do
+      headers = Azure::Armrest::ResponseHeaders.new(:headers => {:stuff => 1}, :code => 404, :body => "oops")
+
+      allow(snapshot).to receive(:wait).and_return('failed')
       allow(snapshot).to receive(:rest_post).and_return(headers)
-      expect { snapshot.get_blob_raw('foo', 'bar') }.to raise_error(Azure::Armrest::NotFoundException)
-      expect { snapshot.get_blob_raw('foo', 'bar') }.to raise_error(Azure::Armrest::NotFoundException, /Unable to find an operations URL*/i)
+
+      expect { snapshot.get_blob_raw('foo', 'bar') }.to raise_error(Azure::Armrest::NotFoundException, /Unable to obtain an operations URL/)
     end
   end
 end


### PR DESCRIPTION
This revamps the get_blob_raw method to use a proper `wait` approach on the `BeginGetAccess` call, and bails after two minutes if unsuccessful. The various `try` blocks are unnecessary now, since they were an artifact of trying to reference properties before we actually succeeded in getting access.

This also updates it so that the `EndGetAccess` call is only made if the `BeginGetAccess` call was successful.

In addition, it modifies the `wait` method to accept a `wait_interval` argument (default 10 seconds), and updates the specs.