### PR TITLE
Fix singleton level logging

### DIFF
--- a/lib/azure/armrest/armrest_service.rb
+++ b/lib/azure/armrest/armrest_service.rb
@@ -214,8 +214,8 @@ module Azure
           if [409, 429, 500, 502, 503, 504].include?(err.http_code)
             tries += 1
             if tries <= max_retries
-              msg = "A rate limit or server side issue has occurred. Retry number #{tries}."
-              log('warn', msg)
+              msg = "A rate limit or server side issue has occurred [#{err.http_code}]. Retry number #{tries}."
+              Azure::Armrest::Configuration.log.try(:log, Logger::WARN, msg)
               sleep_time = err.response.headers[:retry_after] || 30
               sleep(sleep_time)
               retry


### PR DESCRIPTION
This fixes an issue in the `rest_execute` method where I accidentally tried to use the instance level `log` method, which doesn't work. Instead, we use the singleton method to access the log, and log a message if it exists.

In addition, I added the http err code to the log message.