### PR TITLE
Retry Getting SAS URL Token

### DIFF
--- a/lib/azure/armrest/storage/managed_storage_helper.rb
+++ b/lib/azure/armrest/storage/managed_storage_helper.rb
@@ -58,10 +58,11 @@ module Azure::Armrest::Storage::ManagedStorageHelper
     }
 
     # This call will give us an operations URL in the headers.
-    initial_url = build_url(resource_group, disk_name, 'BeginGetAccess')
-    response    = rest_post(initial_url, post_options.to_json)
+    begin_get_access_url      = build_url(resource_group, disk_name, 'BeginGetAccess')
+    begin_get_access_response = rest_post(begin_get_access_url, post_options.to_json)
+
     begin
-      headers = Azure::Armrest::ResponseHeaders.new(response.headers)
+      headers = Azure::Armrest::ResponseHeaders.new(begin_get_access_response.headers)
 
       # Using the URL returned from the above call, make another call that
       # will return the URL + SAS token.
@@ -69,7 +70,8 @@ module Azure::Armrest::Storage::ManagedStorageHelper
 
       unless op_url
         msg = "Unable to find an operations URL for #{disk_name}/#{resource_group}"
-        raise Azure::Armrest::NotFoundException.new(response.code, msg, response.body)
+        log('debug', "#{msg}: #{begin_get_access_response.headers}")
+        raise Azure::Armrest::NotFoundException.new(begin_get_access_response.code, msg, begin_get_access_response.body)
       end
 
       # Dig the URL + SAS token URL out of the response
@@ -77,9 +79,25 @@ module Azure::Armrest::Storage::ManagedStorageHelper
       body     = Azure::Armrest::ResponseBody.new(response.body)
       sas_url  = body.try(:properties).try(:output).try(:access_sas)
 
-      unless sas_url
-        msg = "Unable to find an SAS URL for #{disk_name}/#{resource_group}"
-        raise Azure::Armrest::NotFoundException.new(response.code, msg, response.body)
+      max_sas_url_retries = 20
+      sas_url_retries     = 0
+
+      until sas_url
+        sas_url_retries += 1
+        if sas_url_retries < max_sas_url_retries
+          msg = "Unable to find a SAS URL for #{disk_name}/#{resource_group}. Retry #{sas_url_retries}."
+          log('warn', "#{msg}: #{op_url}")
+        else
+          msg = "Unable to find a SAS URL for #{disk_name}/#{resource_group}"
+          log('debug', "#{msg}: #{response.body}")
+          raise Azure::Armrest::NotFoundException.new(response.code, msg, response.body)
+        end
+        sleep_time = response.headers[:retry_after] || 5
+        sleep(sleep_time)
+
+        response = rest_get(op_url)
+        body     = Azure::Armrest::ResponseBody.new(response.body)
+        sas_url  = body.try(:properties).try(:output).try(:access_sas)
       end
 
       # The same restrictions that apply to the StorageAccont method also apply here.
@@ -100,6 +118,7 @@ module Azure::Armrest::Storage::ManagedStorageHelper
       # but without encoding the URL or passing our configuration token.
       max_retries = 5
       retries     = 0
+
       begin
         RestClient::Request.execute(
           :method      => :get,
@@ -116,8 +135,10 @@ module Azure::Armrest::Storage::ManagedStorageHelper
         retry
       end
     ensure
-      end_url = build_url(resource_group, disk_name, 'EndGetAccess')
-      rest_post(end_url)
+      if begin_get_access_response
+        end_url = build_url(resource_group, disk_name, 'EndGetAccess')
+        rest_post(end_url)
+      end
     end
   end
 end


### PR DESCRIPTION
After calling BeginGetAccess the SAS URL Token may not be immediately available.
Retry several times for up to 100 seconds finally raising the previously returned exception
if it fails to be acquired.  Note that we use the response.headers[:retry_after] value or a default of 5 seconds for the sleep.  Larger default sleep values slow down turnaround time too much.

Also do not call EndGetAccess unless the BeginGetAccess was successful.

This is in support of BZ https://bugzilla.redhat.com/show_bug.cgi?id=1475540
and the downstream clone https://bugzilla.redhat.com/show_bug.cgi?id=1488967

These is a high-priority issue and we need to review, merge, back port to Fine,
and create a hot fix as soon as we can.

@djberg96 @bronaghs @roliveri please review.
Tested successfully at the customer location exhibiting the issue.