### PR TITLE
Revert "Remove token caching"

### DIFF
--- a/lib/azure/armrest/configuration.rb
+++ b/lib/azure/armrest/configuration.rb
@@ -1,6 +1,28 @@
 module Azure
   module Armrest
     class Configuration
+      # Clear all class level caches. Typically used for testing only.
+      def self.clear_caches
+        token_cache.clear
+      end
+
+      # Used to store unique token information.
+      def self.token_cache
+        @token_cache ||= Hash.new { |h, k| h[k] = [] }
+      end
+
+      # Retrieve the cached token for a configuration.
+      # Return both the token and its expiration date, or nil if not cached
+      def self.retrieve_token(configuration)
+        token_cache[configuration.hash]
+      end
+
+      # Cache the token for a configuration that a token has been fetched from Azure
+      def self.cache_token(configuration)
+        raise ArgumentError, "Configuration does not have a token" if configuration.token.nil?
+        token_cache[configuration.hash] = [configuration.token, configuration.token_expiration]
+      end
+
       # The api-version string
       attr_accessor :api_version
 
@@ -113,6 +135,10 @@ module Azure
         end
       end
 
+      def hash
+        [environment.name, tenant_id, client_id, client_key].join('_').hash
+      end
+
       # Allow for strings or URI objects when assigning a proxy.
       #
       def proxy=(value)
@@ -149,7 +175,9 @@ module Azure
       #
       def set_token(token, token_expiration)
         validate_token_time(token_expiration)
+
         @token, @token_expiration = token, token_expiration.utc
+        self.class.cache_token(self)
       end
 
       # Returns the expiration datetime of the current token
@@ -214,6 +242,7 @@ module Azure
       end
 
       def ensure_token
+        @token, @token_expiration = self.class.retrieve_token(self) if @token.nil?
         fetch_token if @token.nil? || Time.now.utc > @token_expiration
       end
 
@@ -277,6 +306,8 @@ module Azure
 
         @token = 'Bearer ' + response['access_token']
         @token_expiration = Time.now.utc + response['expires_in'].to_i
+
+        self.class.cache_token(self)
       end
     end
   end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -179,6 +179,12 @@ describe Azure::Armrest::Configuration do
       end
 
       context 'token generation' do
+        it 'caches the token to be reused for the same client' do
+          token = "Bearer eyJ0eXAiOiJKV1Q"
+          expect(RestClient::Request).to receive(:execute).exactly(1).times.and_return(token_response)
+          expect(subject.token).to eql(token)
+        end
+
         it 'generates different tokens for different clients' do
           expect(RestClient::Request).to receive(:execute).exactly(2).times.and_return(token_response)
           subject.token
@@ -202,6 +208,35 @@ describe Azure::Armrest::Configuration do
   end
 
   context 'singletons' do
+    before do
+      Azure::Armrest::Configuration.clear_caches
+    end
+
+    context 'cache_token' do
+      before do
+        subject.set_token('test_token', Time.now.utc + 1.month)
+        described_class.cache_token(subject)
+      end
+
+      let(:config_copy) { described_class.new(options) }
+
+      it 'caches and retrieves token through configuration object' do
+        retrieved_token, retrieved_expiration = described_class.retrieve_token(config_copy)
+
+        expect(retrieved_token).to eql(subject.token)
+        expect(retrieved_expiration).to eql(subject.token_expiration)
+      end
+
+      it 'allows to clear caches' do
+        described_class.clear_caches
+
+        retrieved_token, retrieved_expiration = described_class.retrieve_token(config_copy)
+
+        expect(retrieved_token).to be_nil
+        expect(retrieved_expiration).to be_nil
+      end
+    end
+
     context 'logging' do
       before(:all) { @log = 'azure-armrest.log' }
       after(:all) { File.delete(@log) if File.exist?(@log) }


### PR DESCRIPTION
I want to revert this for now as to avoid backwards compatibility issues. If possible, we should create a "0.9.0" milestone and tag it with that.