### PR TITLE
Use filter from list_all (remove duplicate code)

### DIFF
--- a/lib/azure/armrest/storage_account_service.rb
+++ b/lib/azure/armrest/storage_account_service.rb
@@ -172,16 +172,7 @@ module Azure
       # Note that for string values the comparison is caseless.
       #
       def list_all_private_images(filter = {})
-        storage_accounts = list_all.select do |acct|
-          filter.all? do |method_name, value|
-            if value.kind_of?(String)
-              acct.public_send(method_name).casecmp(value).zero?
-            else
-              acct.public_send(method_name) == value
-            end
-          end
-        end
-
+        storage_accounts = list_all(filter)
         get_private_images(storage_accounts)
       end
 


### PR DESCRIPTION
The `ResourceGroupBasedService#list_all` method, which the `StorageAccountService` inherits from, has the exact same filter code in place as what is used in the `list_all_private_images` method, so use that instead of maintaining duplicate versions of this code.

Found this while poking around in the gem, so thought I would make a quick PR to address.  All of the tests seem to pass with these changes in place.  Will do some testing where I know this is used to also confirm the same functionality.