### PR TITLE
Use respond_to? instead of methods.include?

### DIFF
--- a/lib/azure/armrest/model/base_model.rb
+++ b/lib/azure/armrest/model/base_model.rb
@@ -180,7 +180,7 @@ module Azure
       end
 
       def add_accessor_methods(method, key)
-        method = "_#{method}" if methods.include?(method.to_sym)
+        method = "_#{method}" if respond_to?(method)
         instance_eval { define_singleton_method(method) { __getobj__[key] } }
         instance_eval { define_singleton_method("#{method}=") { |val| __getobj__[key] = val } }
       end


### PR DESCRIPTION
When calling `Object.methods`, we are generating an array of symbols (maybe strings as well) every time to determine every one of the public and protected that exist on the given target, and this is generated every time this is called (though don't quote me).

By using `respond_to?`, we are avoiding generating that array, and simply determining if that method is defined and not the definitions of any other methods.


Benchmarks
----------

When making a call to `.list_all` of the storage accounts from an example azure account, the difference after this change was applied can easily be shown (metrics gathered using the `memory_profiler` gem):

**Before**

```
Total allocated: 25509365 bytes (198470 objects)
Total retained:  37155 bytes (353 objects)

allocated memory by gem
-----------------------------------
  15232252  azure-armrest-0.8.2
   7396499  activesupport-5.0.6
   2164831  json-2.0.4
    330191  addressable-2.4.0
    244959  rest-client-2.0.2
       ...  ...
```

**After**

```
Total allocated: 18764397 bytes (192606 objects)
Total retained:  37091 bytes (352 objects)

allocated memory by gem
-----------------------------------
   8487284  azure-armrest/lib
   7396499  activesupport-5.0.6
   2164831  json-2.0.4
    330191  addressable-2.4.0
    244959  rest-client-2.0.2
       ...  ...
```

A %30 speedup in time taken to do sample calls to compounded API methods, such as `list_all_private_images`, was also observed because of this change.