### PR TITLE
Lazy load json strings when possible

### DIFF
--- a/lib/azure/armrest/model/base_model.rb
+++ b/lib/azure/armrest/model/base_model.rb
@@ -58,7 +58,6 @@ module Azure
 
         if json.kind_of?(Hash)
           @hash = json
-          @json = json.to_json
         else
           @hash = JSON.parse(json)
           @json = json
@@ -90,15 +89,15 @@ module Azure
       # is for interface compatibility only.
       #
       def to_json(_options = nil)
-        @json
+        @json ||= @hash ? @hash.to_json : ""
       end
 
       def to_s
-        @json
+        @json ||= @hash ? @hash.to_json : ""
       end
 
       def to_str
-        @json
+        @json ||= @hash ? @hash.to_json : ""
       end
 
       def pretty_print(q)


### PR DESCRIPTION
The `@json` field in any `BaseModel` based classes is only used when inspecting the object or converting the `@hash` value to a json string (this only happens when the object is instantiated using a json string instead of a ruby Hash).

In most cases, this means that the `@json` that is instantiated is never actually accessed, so deferring the call to `.to_json` on `@hash` to when it is actually used improves performance in most cases.

Benchmarks
----------

Notice the change in the number of allocations for `String` and `JSON::Ext::Generator::State`:

**Before**

```
Total allocated: 18764397 bytes (192606 objects)
Total retained:  37091 bytes (352 objects)

allocated memory by gem
-----------------------------------
   8487284  azure-armrest/lib
   7396499  activesupport-5.0.6
   2164831  json-2.0.4
    330191  addressable-2.4.0
    244959  rest-client-2.0.2

...

allocated memory by class
-----------------------------------
   8533680  String
   2094624  RubyVM::Env
   2060792  MatchData
   1949280  Proc
   1430205  Regexp
   1231688  Hash
    755432  Class
    353880  Array
    253344  JSON::Ext::Generator::State
     19536  Azure::Armrest::StorageAccount
     17072  Azure::Armrest::StorageAccount::Properties
     17072  Azure::Armrest::StorageAccount::Properties::PrimaryEndpoints
     17072  Azure::Armrest::StorageAccount::Sku
```


**After**

```
Total allocated: 17094678 bytes (167982 objects)
Total retained:  35707 bytes (344 objects)

allocated memory by gem
-----------------------------------
   7396499  activesupport-5.0.6
   6702920  azure-armrest/lib
   2279476  json-2.0.4
    330191  addressable-2.4.0
    244959  rest-client-2.0.2

...

allocated memory by class
-----------------------------------
   7327401  String
   2094624  RubyVM::Env
   2060792  MatchData
   1949280  Proc
   1430205  Regexp
   1231688  Hash
    755432  Class
    174368  Array
     17632  Azure::Armrest::StorageAccount
      9480  Azure::Armrest::StorageAccount::Properties
      9480  Azure::Armrest::StorageAccount::Properties::PrimaryEndpoints
      9480  Azure::Armrest::StorageAccount::Sku
      5960  Fiber
```