### PR TITLE
Use ArmrestCollection#next_link in get_all_results

### DIFF
--- a/lib/azure/armrest/armrest_collection.rb
+++ b/lib/azure/armrest/armrest_collection.rb
@@ -3,6 +3,7 @@
 module Azure
   module Armrest
     class ArmrestCollection < Array
+      attr_accessor :next_link
       attr_accessor :continuation_token
       attr_accessor :response_headers
       attr_accessor :response_code
@@ -21,7 +22,8 @@ module Azure
 
           array.response_code = response.code
           array.response_headers = response.headers
-          array.continuation_token = parse_skip_token(json_response)
+          array.next_link = json_response['nextLink']
+          array.continuation_token = parse_skip_token(array.next_link)
 
           array
         end
@@ -29,9 +31,9 @@ module Azure
         private
 
         # Parse the skip token value out of the nextLink attribute from a response.
-        def parse_skip_token(json)
-          return nil unless json['nextLink']
-          json['nextLink'][/.*?skipToken=(.*?)$/i, 1]
+        def parse_skip_token(next_link)
+          return nil unless next_link
+          next_link[/.*?skipToken=(.*?)$/i, 1]
         end
       end
     end

--- a/lib/azure/armrest/armrest_service.rb
+++ b/lib/azure/armrest/armrest_service.rb
@@ -359,13 +359,13 @@ module Azure
       # Make additional calls and concatenate the results if a continuation URL is found.
       def get_all_results(response)
         results  = Azure::Armrest::ArmrestCollection.create_from_response(response, model_class)
-        nextlink = JSON.parse(response)['nextLink']
+        nextlink = results.next_link
 
         while nextlink
           response = rest_get_without_encoding(nextlink)
           more = Azure::Armrest::ArmrestCollection.create_from_response(response, model_class)
           results.concat(more)
-          nextlink = JSON.parse(response)['nextLink']
+          nextlink = more.next_link
         end
 
         results


### PR DESCRIPTION
Currently, when the `ArmrestService#get_all_results method` is called, it parses the response body (as JSON) once when instantiating the ArmrestCollection, and a second time to determine the `'nextLink'` value for the subsequent `while` loop to get the remaining results (this is duplicated as well for each iteration of the loop).

Since we now have a `next_link` variable on the `ArmrestCollection` instances that is determined in the same fashion from the first `JSON.parse`, we can use that instead of duplicating the same effort twice.

Benchmarks
----------

In practice, this halved the allocations caused by the JSON gem (when using the one from ruby stdlib), and 10% of the total object allocations over all when calling `StorageAccountService#list_all_private_images` on a small to moderate collection of `StorageAccounts` (around 200 in this instance, filtered by location to around 70).  CPU improvements might be observed on larger collections.

A slight uptick on memory is observed in the armrest codebase because of this caching, but it is minimal compared to the savings.


**Before**

```
Total allocated: 13192688 bytes (149972 objects)
Total retained:  35707 bytes (344 objects)

allocated memory by gem
-----------------------------------
   6702920  azure-armrest/lib
   3494509  activesupport/lib
   2279476  json-2.0.4
    330191  addressable-2.4.0
    244959  rest-client-2.0.2
...
```


**After**

```
Total allocated: 12062224 bytes (133571 objects)
Total retained:  35925 bytes (347 objects)

allocated memory by gem
-----------------------------------
   6711976  azure-armrest/lib
   3494509  activesupport/lib
   1139738  json-2.0.4
    330191  addressable-2.4.0
    245177  rest-client-2.0.2
...
```