### PR TITLE
Update the parse_id_string method to ignore case

### DIFF
--- a/lib/azure/armrest/resource_group_based_service.rb
+++ b/lib/azure/armrest/resource_group_based_service.rb
@@ -196,7 +196,7 @@ module Azure
           (/(?<service_name>[^\/]+)?/(?<resource_name>[^\/]+))?
           (/(?<subservice_name>[^\/]+)?/(?<subservice_resource_name>[^\/]+))?
           \z
-        }x
+        }xi
 
         match = regex.match(id_string)
         Hash[match.names.zip(match.captures)]

--- a/spec/resource_group_based_service_spec.rb
+++ b/spec/resource_group_based_service_spec.rb
@@ -94,5 +94,13 @@ describe "ResourceGroupBasedService" do
       expect(result).to be_kind_of(Azure::Armrest::VirtualMachineExtension)
       expect(result.name).to eql('test123')
     end
+
+    it "returns the expected result for an ID string regardless of case" do
+      string = sub_id_string.upcase
+      allow(rgbs).to receive(:rest_get).and_return(hash)
+      result = rgbs.get_by_id(string)
+      expect(result).to be_kind_of(Azure::Armrest::Network::Subnet)
+      expect(result.name).to eql('test123')
+    end
   end
 end


### PR DESCRIPTION
This updates the internal `parse_id_string` method, which is used by the `get_by_id` method, to ignore case.

This came up because we use a lowercased version of the id string for the ems_ref in ManageIQ, which would then fail on the `get_by_id` method.