### PR TITLE
Relax nokogiri gem version

### DIFF
--- a/azure-armrest.gemspec
+++ b/azure-armrest.gemspec
@@ -22,7 +22,7 @@ behind the scenes.
   spec.add_dependency 'memoist', '~> 0.15.0'
   spec.add_dependency 'azure-signature', '~> 0.2.3'
   spec.add_dependency 'activesupport', '>= 4.2.2'
-  spec.add_dependency 'nokogiri', '~> 1.7.2'
+  spec.add_dependency 'nokogiri', '~> 1.7'
   spec.add_dependency 'addressable', '~> 2.4.0'
   spec.add_dependency 'parallel', '~> 1.12.0'
 


### PR DESCRIPTION
There is currently a CVE out for `libxml2`, that affects `nokogiri`:

https://access.redhat.com/security/cve/cve-2017-9050

Unfortunately, so projects that depend on `azure-armrest` expect that the version of nokogiri is within the `1.7.x` release.  To allow for that (as insecure as it is), but make sure we try to use the latest version of `nokogiri` when possible, relax the version requirement on this gem so that we are secure as we can be without breaking other projects.

That said, we probably should make nokogiri-1.8.1 a minimum requirement in the v1.0 release though.