### PR TITLE
Handle possibility of dollar sign in key for model generation.

### DIFF
--- a/lib/azure/armrest/model/base_model.rb
+++ b/lib/azure/armrest/model/base_model.rb
@@ -225,6 +225,7 @@ module Azure
         @hashobj.each do |key, value|
           snake = key.to_s.tr(' ', '_').underscore
           snake.tr!('.', '_')
+          snake.tr!('$', '_')
 
           unless excl_list.include?(snake) # Must deal with nested models
             if value.kind_of?(Array)

--- a/spec/models/base_model_spec.rb
+++ b/spec/models/base_model_spec.rb
@@ -161,7 +161,7 @@ describe "BaseModel" do
       expect(base).to respond_to(:address)
     end
 
-    it "does not respond to removes camel_case methods" do
+    it "does not respond to camel_case methods" do
       expect(base).not_to respond_to(:firstName)
       expect(base).not_to respond_to(:lastName)
     end
@@ -205,6 +205,20 @@ describe "BaseModel" do
       base = Azure::Armrest::BaseModel.new(json)
       expect(base).to respond_to(:foo_bar)
       expect(base.foo_bar).to eq(123)
+    end
+
+    it "handles strings with periods as expected" do
+      json = {'Foo.Bar' => 123}
+      base = Azure::Armrest::BaseModel.new(json)
+      expect(base).to respond_to(:foo_bar)
+      expect(base.foo_bar).to eq(123)
+    end
+
+    it "handles strings with dollar signs as expected" do
+      json = {'$FooBar' => 123}
+      base = Azure::Armrest::BaseModel.new(json)
+      expect(base).to respond_to(:_foo_bar)
+      expect(base._foo_bar).to eq(123)
     end
   end
 


### PR DESCRIPTION
Apparently it's possible for the keys returned by the `TemplateDeploymentService#list_deployment_operations` to contain a key with a "$" in it. Since we have no idea where else this could potentially happen, we need to account for that possibility anywhere. So, it is now replaced with a "_" as well.

Addresses https://bugzilla.redhat.com/show_bug.cgi?id=1495318

I added some specs and fixed one unrelated spec description while I was in there.