### PR TITLE
Use Oga instead of Nokogiri

### DIFF
--- a/azure-armrest.gemspec
+++ b/azure-armrest.gemspec
@@ -22,7 +22,7 @@ behind the scenes.
   spec.add_dependency 'memoist', '~> 0.15.0'
   spec.add_dependency 'azure-signature', '~> 0.2.3'
   spec.add_dependency 'activesupport', '>= 4.2.2'
-  spec.add_dependency 'nokogiri', '>= 1.8.1', '~> 1.8'
+  spec.add_dependency 'oga', '~> 2.11'
   spec.add_dependency 'addressable', '~> 2.4.0'
   spec.add_dependency 'parallel', '~> 1.12.0'
 


### PR DESCRIPTION
Due to a fairly steady stream of CVE's for nokogiri (usually because of underlying issues in libxml), along with issues sync'ing versions against the core ManageIQ repo, I think it's best if we switch off of Nokogiri to another parser.

I've chosen Oga because it's still relatively fast and doesn't have a libxml dependency. I'm not too worried about any speed issues, since the amount of xml parsing that we do overall is fairly minimal, limited to certain methods on `StorageAccount` objects.

For more information see https://github.com/YorickPeterse/oga

I've added some specs for the affected methods as well.