### PR TITLE
Backport lite model changes

### DIFF
--- a/.rubocop_local.yml
+++ b/.rubocop_local.yml
@@ -1,0 +1,3 @@
+Style/MethodCallWithArgsParentheses:
+  IgnoredMethods:
+    - attr_from_hash

--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,6 @@
+= 0.8.5 - 10-Oct-2017
+* Backported the light model changes from 0.9.0.
+
 = 0.8.4 - 2-Oct-2017
 * Logging bug fix in StorageAccount#all_blobs method.
 * Modified the StorageAccountService#list_all_private_image method. It now

--- a/lib/azure/armrest/armrest_collection.rb
+++ b/lib/azure/armrest/armrest_collection.rb
@@ -16,9 +16,9 @@ module Azure
         # using +klass+ to generate the list elements. In addition, both the
         # response headers and continuation token are set.
         #
-        def create_from_response(response, klass = nil)
+        def create_from_response(response, klass = nil, skip_accessors_definition = false)
           json_response = JSON.parse(response)
-          array = new(json_response['value'].map { |hash| klass.new(hash) })
+          array = new(json_response['value'].map { |hash| klass.new(hash, skip_accessors_definition) })
 
           array.response_code = response.code
           array.response_headers = response.headers

--- a/lib/azure/armrest/armrest_service.rb
+++ b/lib/azure/armrest/armrest_service.rb
@@ -357,13 +357,13 @@ module Azure
       end
 
       # Make additional calls and concatenate the results if a continuation URL is found.
-      def get_all_results(response)
-        results  = Azure::Armrest::ArmrestCollection.create_from_response(response, model_class)
+      def get_all_results(response, skip_accessors_definition = false)
+        results  = Azure::Armrest::ArmrestCollection.create_from_response(response, model_class, skip_accessors_definition)
         nextlink = results.next_link
 
         while nextlink
           response = rest_get_without_encoding(nextlink)
-          more = Azure::Armrest::ArmrestCollection.create_from_response(response, model_class)
+          more = Azure::Armrest::ArmrestCollection.create_from_response(response, model_class, skip_accessors_definition)
           results.concat(more)
           nextlink = more.next_link
         end

--- a/lib/azure/armrest/model/base_model.rb
+++ b/lib/azure/armrest/model/base_model.rb
@@ -68,11 +68,19 @@ module Azure
       end
 
       def resource_group
-        @resource_group ||= id[/resourcegroups\/(.*?[^\/]+)?/i, 1] rescue nil
+        @resource_group ||= begin
+                              id_from_hash[/resourcegroups\/(.*?[^\/]+)?/i, 1]
+                            rescue
+                              nil
+                            end
       end
 
       def subscription_id
-        @subscription_id ||= id[/subscriptions\/(.*?[^\/]+)?/i, 1] rescue nil
+        @subscription_id ||= begin
+                               id_from_hash[/subscriptions\/(.*?[^\/]+)?/i, 1]
+                             rescue
+                               nil
+                             end
       end
 
       attr_writer :resource_group
@@ -147,6 +155,15 @@ module Azure
       # Do not use this method directly.
       def __getobj__
         @hashobj
+      end
+
+      # Do not use this method directly.
+      #
+      # Will only attempt to fetch the id from the @hashobj once, so even it it
+      # is nil, it will cache that value, and return that on subsequent calls.
+      def id_from_hash
+        return @id_from_hash if defined?(@id_from_hash)
+        @id_from_hash = __getobj__[:id] || __getobj__["id"]
       end
 
       # Create snake_case accessor methods for all hash attributes

--- a/lib/azure/armrest/model/base_model.rb
+++ b/lib/azure/armrest/model/base_model.rb
@@ -229,8 +229,11 @@ module Azure
 
     class StorageAccount < BaseModel; end
     class StorageAccountKey < StorageAccount
-      def key1; key_name == 'key1' ? value : nil; end
-      def key2; key_name == 'key2' ? value : nil; end
+      attr_from_hash :key_name => :keyName,
+                     :value    => :value
+
+      def key1; key_name_from_hash == 'key1' ? value_from_hash : nil; end
+      def key2; key_name_from_hash == 'key2' ? value_from_hash : nil; end
       def key; key1 || key2; end
     end
 

--- a/lib/azure/armrest/model/base_model.rb
+++ b/lib/azure/armrest/model/base_model.rb
@@ -63,7 +63,8 @@ module Azure
           @json = json
         end
 
-        __setobj__(@hash.dup)
+        @hashobj = @hash.dup
+        __setobj__
       end
 
       def resource_group
@@ -150,19 +151,18 @@ module Azure
 
       # Create snake_case accessor methods for all hash attributes
       # Use _alias if an accessor conflicts with existing methods
-      def __setobj__(obj)
-        @hashobj = obj
+      def __setobj__
         excl_list = self.class.send(:excl_list)
-        obj.each do |key, value|
+        @hashobj.each do |key, value|
           snake = key.to_s.tr(' ', '_').underscore
           snake.tr!('.', '_')
 
           unless excl_list.include?(snake) # Must deal with nested models
             if value.kind_of?(Array)
               newval = value.map { |elem| elem.kind_of?(Hash) ? nested_object(snake.camelize.singularize, elem) : elem }
-              obj[key] = newval
+              @hashobj[key] = newval
             elsif value.kind_of?(Hash)
-              obj[key] = nested_object(snake.camelize, value)
+              @hashobj[key] = nested_object(snake.camelize, value)
             end
           end
 

--- a/lib/azure/armrest/model/base_model.rb
+++ b/lib/azure/armrest/model/base_model.rb
@@ -48,7 +48,7 @@ module Azure
       #   # Or you can get back the original JSON if necessary.
       #   person.to_json # => Returns original JSON
       #
-      def initialize(json)
+      def initialize(json, skip_accessors_definition = false)
         # Find the exclusion list for the model of next level (@embed_model)
         # '#' is the separator between levels. Remove attributes
         # before the first separator.
@@ -64,7 +64,7 @@ module Azure
         end
 
         @hashobj = @hash.dup
-        __setobj__
+        __setobj__ unless skip_accessors_definition
       end
 
       def resource_group

--- a/lib/azure/armrest/model/base_model.rb
+++ b/lib/azure/armrest/model/base_model.rb
@@ -23,6 +23,36 @@ module Azure
 
       attr_hash :tags
 
+      # Defines attr_reader methods for the given set of attributes and
+      # expected hash key.  Used to define methods that can be used internally
+      # that avoid needing to use methods defined from
+      # `add_accessor_methods`/`__setobj__`
+      #
+      # Example:
+      #   class Vm < Azure::ArmRest::BaseModel
+      #     attr_from_hash :name => :Name
+      #   end
+      #
+      #   json_string = {'name' => 'Deathstar'}
+      #
+      #   vm = Vm.new(json_string)
+      #   vm.name_from_hash
+      #   #=> "Deathstar"
+      #
+      def self.attr_from_hash(attrs = {})
+        file, line, _ = caller.first.split(":")
+        attrs.each do |attr_name, hash_key|
+          class_eval(<<-RUBY, file, line.to_i)
+            def #{attr_name}_from_hash
+              return @#{attr_name}_from_hash if defined?(@#{attr_name}_from_hash)
+              @#{attr_name}_from_hash = __getobj__[:#{hash_key}] || __getobj__["#{hash_key}"]
+            end
+          RUBY
+        end
+      end
+
+      private_class_method :attr_from_hash
+
       attr_accessor :response_headers
       attr_accessor :response_code
 

--- a/lib/azure/armrest/model/storage_account.rb
+++ b/lib/azure/armrest/model/storage_account.rb
@@ -5,10 +5,18 @@ require 'nokogiri'
 module Azure
   module Armrest
     class StorageAccount < BaseModel
+      attr_from_hash :name          => :name,
+                     :blob_endpoint => [:properties, :primaryEndpoints, :blob]
+
       # Classes used to wrap container and blob information.
-      class Container < BaseModel; end
+      class Container < BaseModel
+        attr_from_hash :name => :Name
+      end
       class ContainerProperty < BaseModel; end
-      class Blob < BaseModel; end
+      class Blob < BaseModel
+        attr_from_hash :name        => :Name,
+                       :lease_state => [:Properties, :LeaseState]
+      end
       class BlobProperty < BaseModel; end
       class PrivateImage < BlobProperty; end
       class BlobServiceProperty < BaseModel; end

--- a/lib/azure/armrest/model/storage_account.rb
+++ b/lib/azure/armrest/model/storage_account.rb
@@ -42,7 +42,7 @@ module Azure
       # The parent configuration object
       attr_accessor :configuration
 
-      def initialize(json)
+      def initialize(json, skip_accessors_definition = false)
         super
         @storage_api_version = '2016-05-31'
       end
@@ -432,14 +432,20 @@ module Azure
         raise ArgumentError, "No access key specified" unless key
 
         query = "comp=list"
-        options.each { |okey, ovalue| query += "&#{okey}=#{[ovalue].flatten.join(',')}" }
+        skip_defs = options[:skip_accessors_definition]
+
+        options.each do |okey, ovalue|
+          unless okey == :skip_accessors_definition
+            query += "&#{okey}=#{[ovalue].flatten.join(',')}"
+          end
+        end
 
         response = blob_response(key, query)
 
         doc = Nokogiri::XML(response.body)
 
         results = doc.xpath('//Containers/Container').collect do |element|
-          Container.new(Hash.from_xml(element.to_s)['Container'])
+          Container.new(Hash.from_xml(element.to_s)['Container'], skip_defs)
         end
 
         results.concat(next_marker_results(doc, :containers, key, options))
@@ -476,7 +482,7 @@ module Azure
       def blob_properties(container, blob, key = access_key, options = {})
         raise ArgumentError, "No access key specified" unless key
 
-        url = File.join(properties.primary_endpoints.blob, container, blob)
+        url = File.join(blob_endpoint_from_hash, container, blob)
         url += "?snapshot=" + options[:date] if options[:date]
 
         headers = build_headers(url, key, :blob, :verb => 'HEAD')
@@ -490,7 +496,7 @@ module Azure
           :ssl_verify  => configuration.ssl_verify
         )
 
-        BlobProperty.new(response.headers.merge(:container => container, :name => blob))
+        BlobProperty.new(response.headers.merge(:container => container, :name => blob), options[:skip_accessors_definition])
       end
 
       # Update the given +blob+ in +container+ with the provided options. The
@@ -567,7 +573,13 @@ module Azure
         raise ArgumentError, "No access key specified" unless key
 
         query = "restype=container&comp=list"
-        options.each { |okey, ovalue| query += "&#{okey}=#{[ovalue].flatten.join(',')}" }
+        skip_defs = options[:skip_accessors_definition]
+
+        options.each do |okey, ovalue|
+          unless okey == :skip_accessors_definition
+            query += "&#{okey}=#{[ovalue].flatten.join(',')}"
+          end
+        end
 
         response = blob_response(key, query, container)
 
@@ -575,7 +587,7 @@ module Azure
 
         results = doc.xpath('//Blobs/Blob').collect do |node|
           hash = Hash.from_xml(node.to_s)['Blob'].merge(:container => container)
-          hash.key?('Snapshot') ? BlobSnapshot.new(hash) : Blob.new(hash)
+          hash.key?('Snapshot') ? BlobSnapshot.new(hash, skip_defs) : Blob.new(hash, skip_defs)
         end
 
         results.concat(next_marker_results(doc, :blobs, container, key, options))
@@ -590,10 +602,13 @@ module Azure
 
         array = []
         mutex = Mutex.new
+        opts = {
+          :skip_accessors_definition => options[:skip_accessors_definition]
+        }
 
-        Parallel.each(containers(key), :in_threads => max_threads) do |container|
+        Parallel.each(containers(key, opts), :in_threads => max_threads) do |container|
           begin
-            mutex.synchronize { array.concat(blobs(container.name, key, options)) }
+            mutex.synchronize { array.concat(blobs(container.name_from_hash, key, options)) }
           rescue Errno::ECONNREFUSED, Azure::Armrest::TimeoutException => err
             msg = "Unable to gather blob information for #{container.name}: #{err}"
             Azure::Armrest::Configuration.log.try(:log, Logger::WARN, msg)
@@ -946,7 +961,7 @@ module Azure
       # the url and submit an http request.
       #
       def blob_response(key, query, *args)
-        url = File.join(properties.primary_endpoints.blob, *args) + "?#{query}"
+        url = File.join(blob_endpoint_from_hash, *args) + "?#{query}"
         headers = build_headers(url, key, 'blob')
 
         ArmrestService.send(

--- a/lib/azure/armrest/resource_group_based_service.rb
+++ b/lib/azure/armrest/resource_group_based_service.rb
@@ -97,8 +97,9 @@ module Azure
         url = build_url
         url = yield(url) || url if block_given?
 
+        skip_accessors_definition = filter.delete(:skip_accessors_definition) || false
         response = rest_get(url)
-        results  = get_all_results(response)
+        results  = get_all_results(response, skip_accessors_definition)
 
         if filter.empty?
           results
@@ -106,7 +107,11 @@ module Azure
           results.select do |obj|
             filter.all? do |method_name, value|
               if value.kind_of?(String)
-                obj.public_send(method_name).casecmp(value).zero?
+                if skip_accessors_definition
+                  obj[method_name.to_s].casecmp(value).zero?
+                else
+                  obj.public_send(method_name).casecmp(value).zero?
+                end
               else
                 obj.public_send(method_name) == value
               end

--- a/lib/azure/armrest/version.rb
+++ b/lib/azure/armrest/version.rb
@@ -1,6 +1,6 @@
 module Azure
   module Armrest
     # The version of the azure-armrest library.
-    VERSION = '0.8.4'.freeze
+    VERSION = '0.8.5'.freeze
   end
 end

--- a/spec/models/base_model_spec.rb
+++ b/spec/models/base_model_spec.rb
@@ -255,4 +255,50 @@ describe "BaseModel" do
       expect(base.eql?(Azure::Armrest::BaseModel.new(json))).to be true
     end
   end
+
+  describe "#attr_from_hash" do
+    around(:each) do |example|
+      class ::SubKlass < Azure::Armrest::BaseModel
+        attr_from_hash :first_name => :firstName
+      end
+
+      example.run
+
+      Object.send(:remove_const, :SubKlass)
+    end
+
+    subject { SubKlass.new(json) }
+
+    it "defines the accessor_method for the given attr name/hash key pair" do
+      expect(subject.first_name_from_hash).to eq("jeff")
+    end
+
+    it "maps it source location to the correct file" do
+      expect(subject.method(:first_name_from_hash).source_location).to include(__FILE__)
+    end
+
+    context "with multiple attributes" do
+      around(:each) do |example|
+        class ::SubKlass2 < Azure::Armrest::BaseModel
+          attr_from_hash :first_name => :firstName,
+                         :last_name  => :lastName
+        end
+
+        example.run
+
+        Object.send(:remove_const, :SubKlass2)
+      end
+      subject { SubKlass2.new(json) }
+
+      it "defines the accessor_method for each of the given attr name/hash key pairs" do
+        expect(subject.first_name_from_hash).to eq("jeff")
+        expect(subject.last_name_from_hash).to eq("durand")
+      end
+
+      it "maps it source location of each method to the correct file" do
+        expect(subject.method(:first_name_from_hash).source_location).to include(__FILE__)
+        expect(subject.method(:last_name_from_hash).source_location).to include(__FILE__)
+      end
+    end
+  end
 end

--- a/spec/models/base_model_spec.rb
+++ b/spec/models/base_model_spec.rb
@@ -300,5 +300,26 @@ describe "BaseModel" do
         expect(subject.method(:last_name_from_hash).source_location).to include(__FILE__)
       end
     end
+
+    context "with nested attributes" do
+      around(:each) do |example|
+        class ::SubKlass3 < Azure::Armrest::BaseModel
+          attr_from_hash :street_address => [:address, :street]
+        end
+
+        example.run
+
+        Object.send(:remove_const, :SubKlass3)
+      end
+      subject { SubKlass3.new(json) }
+
+      it "defines the accessor_method for the given attr name/hash key pair" do
+        expect(subject.street_address_from_hash).to eq("22 charlotte rd")
+      end
+
+      it "maps it source location to the correct file" do
+        expect(subject.method(:street_address_from_hash).source_location).to include(__FILE__)
+      end
+    end
   end
 end

--- a/spec/models/storage_account_spec.rb
+++ b/spec/models/storage_account_spec.rb
@@ -9,7 +9,7 @@ describe "StorageAccount" do
   before {
     @json = '{
       "name":"vhds",
-      "properties":{"etag": "12345"}
+      "properties":{"etag": "12345", "primaryEndpoints":{"blob": "123.blobs.microsoft.com"}}
     }'
   }
 
@@ -109,6 +109,16 @@ describe "StorageAccount" do
     it "defines a container_acl method" do
       expect(storage).to respond_to(:container_acl)
     end
+
+    context "on a single container" do
+      let(:container_json) { {'Name' => 'box' } }
+      let(:container)      { Azure::Armrest::StorageAccount::Container.new(container_json) }
+
+      it "defines a name_from_hash method" do
+        expect(container).to respond_to(:name_from_hash)
+        expect(container.name_from_hash).to eq('box')
+      end
+    end
   end
 
   context "blob methods" do
@@ -165,6 +175,21 @@ describe "StorageAccount" do
     it "defines a get_blob_raw method" do
       expect(storage).to respond_to(:get_blob_raw)
     end
+
+    context "on a single blob" do
+      let(:blob_json) { {'Name' => 'Cousin Itt', 'Properties' => {'LeaseState' => 'on the floor' } } }
+      let(:blob)      { Azure::Armrest::StorageAccount::Blob.new(blob_json) }
+
+      it "defines a name_from_hash method" do
+        expect(blob).to respond_to(:name_from_hash)
+        expect(blob.name_from_hash).to eq('Cousin Itt')
+      end
+
+      it "defines a lease_state_from_hash method" do
+        expect(blob).to respond_to(:lease_state_from_hash)
+        expect(blob.lease_state_from_hash).to eq('on the floor')
+      end
+    end
   end
 
   context "table methods" do
@@ -178,6 +203,18 @@ describe "StorageAccount" do
 
     it "defines a table_data method" do
       expect(storage).to respond_to(:table_data)
+    end
+  end
+
+  context "'from_hash' methods" do
+    it "defines a name_from_hash method" do
+      expect(storage).to respond_to(:name_from_hash)
+      expect(storage.name_from_hash).to eq('vhds')
+    end
+
+    it "defines a blob_endpoint_from_hash method" do
+      expect(storage).to respond_to(:blob_endpoint_from_hash)
+      expect(storage.blob_endpoint_from_hash).to eq('123.blobs.microsoft.com')
     end
   end
 end

--- a/spec/models/storage_account_spec.rb
+++ b/spec/models/storage_account_spec.rb
@@ -131,7 +131,8 @@ describe "StorageAccount" do
     end
 
     it "allows an optional hash for the all_blobs method" do
-      allow(storage).to receive(:containers).with("abc").and_return([])
+      container_options = {:skip_accessors_definition => nil}
+      allow(storage).to receive(:containers).with("abc", container_options).and_return([])
       expect(storage.all_blobs("abc", 5)).to eql([])
       expect(storage.all_blobs("abc", 5, :maxresults => 5)).to eql([])
     end

--- a/spec/models/storage_key_spec.rb
+++ b/spec/models/storage_key_spec.rb
@@ -37,5 +37,15 @@ describe "StorageAccountKey" do
       expect(acct_key).to respond_to(:key2)
       expect(acct_key.key2).to be_nil
     end
+
+    it "defines a key_name_from_hash method that returns the expected value" do
+      expect(acct_key).to respond_to(:key_name_from_hash)
+      expect(acct_key.key_name_from_hash).to eq("key1")
+    end
+
+    it "defines a value_from_hash method that returns the expected value" do
+      expect(acct_key).to respond_to(:value_from_hash)
+      expect(acct_key.value_from_hash).to eq("key1Value")
+    end
   end
 end


### PR DESCRIPTION
This backports the lite model changes from 0.9.0 to 0.8.5, so that we can get those changes in without the nokogiri changes.

We never squashed those commits so it required cherry picking 7 commits, but it's all here and the specs all pass.

https://github.com/ManageIQ/azure-armrest/pull/319/commits

I've updated the version and change files, too.