### PR TITLE
Convert Nokogiri to Ox

### DIFF
--- a/azure-armrest.gemspec
+++ b/azure-armrest.gemspec
@@ -22,7 +22,7 @@ behind the scenes.
   spec.add_dependency 'memoist', '~> 0.15.0'
   spec.add_dependency 'azure-signature', '~> 0.2.3'
   spec.add_dependency 'activesupport', '>= 4.2.2'
-  spec.add_dependency 'nokogiri', '>= 1.8.1', '~> 1.8'
+  spec.add_dependency 'ox', '~> 2.8'
   spec.add_dependency 'addressable', '~> 2.4.0'
   spec.add_dependency 'parallel', '~> 1.12.0'
 

--- a/spec/models/storage_account_spec.rb
+++ b/spec/models/storage_account_spec.rb
@@ -6,14 +6,14 @@
 require 'spec_helper'
 
 describe "StorageAccount" do
-  before {
+  before do
     @json = '{
       "name":"vhds",
       "properties":{"etag": "12345", "primaryEndpoints":{"blob": "123.blobs.microsoft.com"}}
     }'
-  }
+  end
 
-  let(:storage){ Azure::Armrest::StorageAccount.new(@json) }
+  let(:storage) { Azure::Armrest::StorageAccount.new(@json) }
 
   context "constructor" do
     it "returns a StorageAccount class as expected" do
@@ -72,6 +72,38 @@ describe "StorageAccount" do
       expect(storage).to respond_to(:files)
     end
 
+    it "returns the expected results for the files method" do
+      xml = %(\xEF\xBB\xBF
+        <?xml version=\"1.0\" encoding=\"utf-8\"?>
+        <EnumerationResults ShareName=\"myshare\" DirectoryPath=\"\">
+          <Entries>
+            <File>
+              <Name>bar.txt</Name>
+              <Properties>
+                <Content-Length>50</Content-Length>
+              </Properties>
+            </File>
+            <File>
+              <Name>foo.txt</Name>
+              <Properties>
+                <Content-Length>50</Content-Length>
+              </Properties>
+            </File>
+          </Entries>
+          <NextMarker />
+        </EnumerationResults>
+      )
+
+      query = "comp=list&restype=directory"
+      allow(storage).to receive(:file_response).with("abc", query, 'get', nil, 'foo').and_return(xml)
+      allow(xml).to receive(:body).and_return(xml)
+
+      expect(storage.files('foo', 'abc').size).to eql(2)
+      expect(storage.files('foo', 'abc').first).to be_kind_of(Azure::Armrest::StorageAccount::ShareFile)
+      expect(storage.files('foo', 'abc').first.name).to eql('bar.txt')
+      expect(storage.files('foo', 'abc').last.name).to eql('foo.txt')
+    end
+
     it "defines a file_content method" do
       expect(storage).to respond_to(:file_content)
     end
@@ -98,8 +130,51 @@ describe "StorageAccount" do
   end
 
   context "container methods" do
+    let(:key) { 'xyz' }
+
     it "defines a containers method" do
       expect(storage).to respond_to(:containers)
+    end
+
+    it "returns the expected result for the containers method" do
+      xml = %(\xEF\xBB\xBF
+        <?xml version=\"1.0\" encoding=\"utf-8\"?>
+        <EnumerationResults ServiceEndpoint=\"https://foo.blob.core.windows.net/\">
+        <Containers>
+          <Container>
+            <Name>testcontainer</Name>
+            <Properties>
+              <Last-Modified>Fri, 30 Jun 2017 21:13:41 GMT</Last-Modified>
+              <Etag>\"0x8D4BFFCE2070113\"</Etag>
+              <LeaseStatus>unlocked</LeaseStatus>
+              <LeaseState>available</LeaseState>
+            </Properties>
+          </Container>
+          <Container>
+            <Name>vhds</Name>
+            <Properties>
+              <Last-Modified>Thu, 10 Nov 2016 21:21:19 GMT</Last-Modified>
+              <Etag>\"0x8D409AF835CC152\"</Etag>
+              <LeaseStatus>unlocked</LeaseStatus>
+              <LeaseState>available</LeaseState>
+            </Properties>
+          </Container>
+        </Containers>
+        <NextMarker />
+        </EnumerationResults>
+      )
+
+      query = "comp=list"
+      allow(storage).to receive(:blob_response).with(key, query).and_return(xml)
+      allow(xml).to receive(:body).and_return(xml)
+
+      containers = storage.containers(key)
+
+      expect(containers.size).to eql(2)
+      expect(containers.first).to be_kind_of(Azure::Armrest::StorageAccount::Container)
+      expect(containers.first.name).to eql('testcontainer')
+      expect(containers.last.name).to eql('vhds')
+      expect(containers.first.properties.lease_status).to eql('unlocked')
     end
 
     it "defines a container_properties method" do
@@ -122,8 +197,66 @@ describe "StorageAccount" do
   end
 
   context "blob methods" do
+    let(:container) { 'vhds' }
+    let(:key) { 'xyz' }
+
     it "defines a blobs method" do
       expect(storage).to respond_to(:blobs)
+    end
+
+    it "returns the expected result for the blobs method" do
+      xml = %(\xEF\xBB\xBF
+        <?xml version=\"1.0\" encoding=\"utf-8\"?>
+        <EnumerationResults ServiceEndpoint=\"https://foo.blob.core.windows.net/\" ContainerName=\"vhds\">
+        <Blobs>
+          <Blob>
+            <Name>xyz.vhd</Name>
+            <Properties>
+              <Last-Modified>Thu, 10 Nov 2016 22:39:07 GMT</Last-Modified>
+              <Etag>0x8D409BA6193F0C3</Etag>
+              <Content-Length>31457280512</Content-Length>
+              <Content-Type>application/octet-stream</Content-Type>
+              <Content-Language />
+              <Content-MD5>hKdOjkaup7sB/nzkWeuhWA==</Content-MD5>
+              <x-ms-blob-sequence-number>1</x-ms-blob-sequence-number>
+              <BlobType>PageBlob</BlobType>
+              <LeaseStatus>unlocked</LeaseStatus>
+              <LeaseState>available</LeaseState>
+              <ServerEncrypted>false</ServerEncrypted>
+            </Properties>
+          </Blob>
+          <Blob>
+            <Name>foo</Name>
+            <Properties>
+              <Last-Modified>Thu, 06 Jul 2017 13:21:34 GMT</Last-Modified>
+              <Etag>0x8D4C471ECC46568</Etag>
+              <Content-Length>1024</Content-Length>
+              <Content-Type>application/octet-stream</Content-Type>
+              <Content-Language />
+              <x-ms-blob-sequence-number>0</x-ms-blob-sequence-number>
+              <BlobType>PageBlob</BlobType>
+              <LeaseStatus>unlocked</LeaseStatus>
+              <LeaseState>available</LeaseState>
+              <ServerEncrypted>false</ServerEncrypted>
+            </Properties>
+          </Blob>
+        </Blobs>
+        <NextMarker />
+        </EnumerationResults>
+      )
+
+      query = "restype=container&comp=list"
+      allow(storage).to receive(:blob_response).with(key, query, container).and_return(xml)
+      allow(xml).to receive(:body).and_return(xml)
+
+      blobs = storage.blobs(container, key)
+
+      expect(blobs.size).to eql(2)
+      expect(blobs.first).to be_kind_of(Azure::Armrest::StorageAccount::Blob)
+      expect(blobs.first.name).to eql('xyz.vhd')
+      expect(blobs.last.name).to eql('foo')
+      expect(blobs.first.properties.content_language).to eql(nil)
+      expect(blobs.first.properties.x_ms_blob_sequence_number).to eql('1')
     end
 
     it "defines an all_blobs method" do
@@ -147,6 +280,51 @@ describe "StorageAccount" do
 
     it "defines a blob_service_properties method" do
       expect(storage).to respond_to(:blob_service_properties)
+    end
+
+    it "returns the expected result for the blob_service_properties" do
+      xml = %(\xEF\xBB\xBF
+        <?xml version=\"1.0\" encoding=\"utf-8\"?>
+        <StorageServiceProperties>
+          <Logging>
+            <Version>1.0</Version>
+            <Read>false</Read>
+            <Write>false</Write>
+            <Delete>false</Delete>
+            <RetentionPolicy>
+              <Enabled>false</Enabled>
+            </RetentionPolicy>
+          </Logging>
+          <HourMetrics>
+            <Version>1.0</Version>
+            <Enabled>true</Enabled>
+            <IncludeAPIs>true</IncludeAPIs>
+            <RetentionPolicy>
+              <Enabled>true</Enabled>
+              <Days>7</Days>
+            </RetentionPolicy>
+          </HourMetrics>
+          <MinuteMetrics>
+            <Version>1.0</Version>
+            <Enabled>false</Enabled>
+            <RetentionPolicy>
+              <Enabled>false</Enabled>
+            </RetentionPolicy>
+          </MinuteMetrics>
+          <Cors />
+        </StorageServiceProperties>
+      )
+
+      query = "restype=service&comp=properties"
+      allow(storage).to receive(:blob_response).with(key, query).and_return(xml)
+      allow(xml).to receive(:body).and_return(xml)
+
+      properties = storage.blob_service_properties(key)
+
+      expect(properties).to be_kind_of(Azure::Armrest::StorageAccount::BlobServiceProperty)
+      expect(properties.logging.version).to eql('1.0')
+      expect(properties.hour_metrics.enabled).to eql('true')
+      expect(properties.minute_metrics.retention_policy.enabled).to eql('false')
     end
 
     it "defines a blob_metadata method" do


### PR DESCRIPTION
Don't like Oga? Ok, let's switch to Ox instead then. Ox's main advantages are that:

1) It's not nokogiri
2) Doesn't have external C library dependencies. It uses system header files only.
3) Is faster than Nokogiri
4) It uses less memory than Nokogiri

Below is a benchmarking script that I used:

```
# ox_vs_noko.rb
require 'benchmark'
require 'nokogiri'
require 'ox'

xml = %(\xEF\xBB\xBF
  <?xml version=\"1.0\" encoding=\"utf-8\"?>
  <EnumerationResults ServiceEndpoint=\"https://foo.blob.core.windows.net/\" ContainerName=\"vhds\">
  <Blobs>
    <Blob>
      <Name>xyz.vhd</Name>
      <Properties>
        <Last-Modified>Thu, 10 Nov 2016 22:39:07 GMT</Last-Modified>
        <Etag>0x8D409BA6193F0C3</Etag>
        <Content-Length>31457280512</Content-Length>
        <Content-Type>application/octet-stream</Content-Type>
        <Content-Language />
        <Content-MD5>hKdOjkaup7sB/nzkWeuhWA==</Content-MD5>
        <x-ms-blob-sequence-number>1</x-ms-blob-sequence-number>
        <BlobType>PageBlob</BlobType>
        <LeaseStatus>unlocked</LeaseStatus>
        <LeaseState>available</LeaseState>
        <ServerEncrypted>false</ServerEncrypted>
      </Properties>
    </Blob>
    <Blob>
      <Name>foo</Name>
      <Properties>
        <Last-Modified>Thu, 06 Jul 2017 13:21:34 GMT</Last-Modified>
        <Etag>0x8D4C471ECC46568</Etag>
        <Content-Length>1024</Content-Length>
        <Content-Type>application/octet-stream</Content-Type>
        <Content-Language />
        <x-ms-blob-sequence-number>0</x-ms-blob-sequence-number>
        <BlobType>PageBlob</BlobType>
        <LeaseStatus>unlocked</LeaseStatus>
        <LeaseState>available</LeaseState>
        <ServerEncrypted>false</ServerEncrypted>
      </Properties>
    </Blob>
  </Blobs>
  <NextMarker />
  </EnumerationResults>
)

Benchmark.bm(35) do |x|
  x.report("Nokogiri::XML") do
    10000.times{ Nokogiri::XML(xml) }
  end

  x.report("Ox.parse") do
    10000.times{ Ox.parse(xml) }
  end

  x.report("Nokogiri#xpath") do
    doc = Nokogiri::XML(xml)
    100000.times{ doc.xpath("//Blobs/Blob") }
  end

  x.report("Ox#location") do
    doc = Ox.parse(xml)
    100000.times{ doc.locate('EnumerationResults/Blobs/Blob') }
  end
end
```

RESULTS:

```
                                          user     system      total        real
Nokogiri::XML                         0.610000   0.060000   0.670000 (  0.667711)
Ox.parse                              0.200000   0.010000   0.210000 (  0.206469)
Nokogiri#xpath                        2.310000   0.050000   2.360000 (  2.369448)
Ox#location                           0.440000   0.010000   0.450000 (  0.442009)
```

Quick update: this was updated so that it's being submitted against the 1.0.x branch instead of master.