### PR TITLE
Remove 2.2.x from test matrix.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: ruby
 sudo: false
 cache: bundler
 rvm:
-- "2.2.8"
 - "2.3.5"
 - "2.4.2"
 - ruby-head


### PR DESCRIPTION
The ManageIQ core repo removed Ruby 2.2.x from their test matrix, so I think we should, too.

https://github.com/ManageIQ/manageiq/blob/master/.travis.yml