### PR TITLE
Revert "Remove 2.2.x from test matrix."

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: ruby
 sudo: false
 cache: bundler
 rvm:
+- "2.2.8"
 - "2.3.5"
 - "2.4.2"
 - ruby-head


### PR DESCRIPTION
Reverts ManageIQ/azure-armrest#337

Let's wait until March 2018 to remove this.