### PR TITLE
Ensure value passed to sleep method is an integer

### DIFF
--- a/lib/azure/armrest/armrest_service.rb
+++ b/lib/azure/armrest/armrest_service.rb
@@ -216,7 +216,9 @@ module Azure
             if tries <= max_retries
               msg = "A rate limit or server side issue has occurred [#{err.http_code}]. Retry number #{tries}."
               Azure::Armrest::Configuration.log.try(:log, Logger::WARN, msg)
-              sleep_time = err.response.headers[:retry_after] || 30
+              sleep_time = (err.response.headers[:retry_after] || 30).to_i
+              sleep_time = 5 if sleep_time < 5     # 5 second minimum
+              sleep_time = 120 if sleep_time > 120 # 2 minute maximum
               sleep(sleep_time)
               retry
             end


### PR DESCRIPTION
The `err.response.headers[:retry_after]` value is a stringified number instead of a plain number, so we must explicitly call `.to_i` on the value to `sleep` or an error will occur.

Note that we already do this for the `wait` method.