### PR TITLE
[FINE] version update for 0.8.7 release

### DIFF
--- a/lib/azure/armrest/version.rb
+++ b/lib/azure/armrest/version.rb
@@ -1,6 +1,6 @@
 module Azure
   module Armrest
     # The version of the azure-armrest library.
-    VERSION = '0.8.5'.freeze
+    VERSION = '0.8.7'.freeze
   end
 end


### PR DESCRIPTION
This updates the latest version of the azure-armrest gem.
Not sure why the file previously has the version set to 0.8.5 when we have already released 0.8.6 - see https://rubygems.org/gems/azure-armrest - Likely an oversight.