### PR TITLE
[FINE] Changes for the 0.8.7 release

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,6 @@
+= 0.8.7 - 25-Oct-2017
+* Ensure value passed to sleep method is an integer.
+
 = 0.8.6 - 23-Oct-2017
 * Backported the '$' model key fix from 0.9.1.
 


### PR DESCRIPTION
Updates the CHANGES file with the change included in 0.8.7

I noticed 0.8.6 is not included in this file, but I did not want to add an entry because I do not see the [PR](https://github.com/ManageIQ/azure-armrest/pull/329) in the 0.8.x commit log
@djberg96 - can you investigate?