### PR TITLE
Use caller_locations instead of caller

### DIFF
--- a/lib/azure/armrest/model/base_model.rb
+++ b/lib/azure/armrest/model/base_model.rb
@@ -56,7 +56,9 @@ module Azure
       #   #=> "123.123.123.123"
       #
       def self.attr_from_hash(attrs = {})
-        file, line, _ = caller.first.split(":")
+        location   = caller_locations(1, 1).first
+        file, line = location.path, location.lineno
+
         attrs.each do |attr_name, keys|
           keys      = Array(keys)
           first_key = keys.shift


### PR DESCRIPTION
Ruby already has a mechanism in place for getting the callstack path locations and line numbers that doesn't require string splitting/parsing.

This also fixes a bug on Windows systems when trying to split callstacks with file paths in them, since most windows file paths include something like 'C:/path/to/file', which has an additional ':' that is not expected by the codebase.

Fixes some of https://github.com/ManageIQ/azure-armrest/issues/332

cc @djberg96