### PR TITLE
Fix StorageAccountService#list_private_images

### DIFF
--- a/lib/azure/armrest/resource_group_based_service.rb
+++ b/lib/azure/armrest/resource_group_based_service.rb
@@ -72,14 +72,14 @@ module Azure
       # Returns an ArmrestCollection, with the response headers set
       # for the operation as a whole.
       #
-      def list(rgroup = configuration.resource_group)
+      def list(rgroup = configuration.resource_group, skip_accessors_definition = false)
         validate_resource_group(rgroup)
 
         url = build_url(rgroup)
         url = yield(url) || url if block_given?
         response = rest_get(url)
 
-        get_all_results(response)
+        get_all_results(response, skip_accessors_definition)
       end
 
       # Use a single call to get all resources for the service. You may

--- a/lib/azure/armrest/storage_account_service.rb
+++ b/lib/azure/armrest/storage_account_service.rb
@@ -18,7 +18,7 @@ module Azure
 
       # Same as other resource based list methods, but also sets the proxy on each model object.
       #
-      def list(resource_group = configuration.resource_group)
+      def list(resource_group = configuration.resource_group, skip_accessors_definition = false)
         super.each { |model| model.configuration = configuration }
       end
 


### PR DESCRIPTION
When speeding up the `list_all_private_images` method, the `list_all` method was updated with the `skip_accessors_definition` boolean flag to that and associated methods.  This was not, though, applied to the `StorageAccountService#list_private_images` method, which works on just a single storage account instead of all of them.

This updates `#list` in both the `StorageAccountService` version, and the base class to allow it to support this flag.

Links
-----
* https://bugzilla.redhat.com/show_bug.cgi?id=1506667
* Introduced in https://github.com/ManageIQ/azure-armrest/pull/319