### PR TITLE
Added some specs for list and list_all methods

### DIFF
--- a/spec/fixtures/unmanaged_storage_accounts.json
+++ b/spec/fixtures/unmanaged_storage_accounts.json
@@ -1,0 +1,99 @@
+{"value":
+  [
+    {
+      "accessTier": null,
+      "creationTime": "2016-11-10T21:20:55.058463+00:00",
+      "customDomain": null,
+      "encryption": null,
+      "id": "/subscriptions/xyz/resourceGroups/foo1/providers/Microsoft.Storage/storageAccounts/foo1",
+      "kind": "Storage",
+      "lastGeoFailoverTime": null,
+      "location": "westus",
+      "name": "foo1",
+      "primaryEndpoints": {
+        "blob": "https://foo1.blob.core.windows.net/",
+        "file": "https://foo1.file.core.windows.net/",
+        "queue": "https://foo1.queue.core.windows.net/",
+        "table": "https://foo1.table.core.windows.net/"
+      },
+      "primaryLocation": "westus",
+      "provisioningState": "Succeeded",
+      "resourceGroup": "foo1",
+      "secondaryEndpoints": null,
+      "secondaryLocation": null,
+      "sku": {
+        "name": "Standard_LRS",
+        "tier": "Standard"
+      },
+      "statusOfPrimary": "available",
+      "statusOfSecondary": null,
+      "tags": {},
+      "type": "Microsoft.Storage/storageAccounts"
+    },
+    {
+      "accessTier": null,
+      "creationTime": "2016-10-12T19:00:26.040337+00:00",
+      "customDomain": null,
+      "encryption": null,
+      "id": "/subscriptions/xyz/resourceGroups/foo1/providers/Microsoft.Storage/storageAccounts/foo1disks560",
+      "kind": "Storage",
+      "lastGeoFailoverTime": null,
+      "location": "westus",
+      "name": "foo1disks560",
+      "primaryEndpoints": {
+        "blob": "https://foo1disks560.blob.core.windows.net/",
+        "file": "https://foo1disks560.file.core.windows.net/",
+        "queue": "https://foo1disks560.queue.core.windows.net/",
+        "table": "https://foo1disks560.table.core.windows.net/"
+      },
+      "primaryLocation": "westus",
+      "provisioningState": "Succeeded",
+      "resourceGroup": "foo1",
+      "secondaryEndpoints": null,
+      "secondaryLocation": null,
+      "sku": {
+        "name": "Standard_LRS",
+        "tier": "Standard"
+      },
+      "statusOfPrimary": "available",
+      "statusOfSecondary": null,
+      "tags": {},
+      "type": "Microsoft.Storage/storageAccounts"
+    },
+    {
+      "accessTier": null,
+      "creationTime": "2016-11-07T19:05:00.291164+00:00",
+      "customDomain": null,
+      "encryption": null,
+      "id": "/subscriptions/xyz/resourceGroups/foo1/providers/Microsoft.Storage/storageAccounts/foodiagnostics",
+      "kind": "Storage",
+      "lastGeoFailoverTime": null,
+      "location": "westus",
+      "name": "foodiagnostics",
+      "primaryEndpoints": {
+        "blob": "https://foodiagnostics.blob.core.windows.net/",
+        "file": "https://foodiagnostics.file.core.windows.net/",
+        "queue": "https://foodiagnostics.queue.core.windows.net/",
+        "table": "https://foodiagnostics.table.core.windows.net/"
+      },
+      "primaryLocation": "westus",
+      "provisioningState": "Succeeded",
+      "resourceGroup": "foo1",
+      "secondaryEndpoints": {
+        "blob": "https://foodiagnostics-secondary.blob.core.windows.net/",
+        "file": null,
+        "queue": "https://foodiagnostics-secondary.queue.core.windows.net/",
+        "table": "https://foodiagnostics-secondary.table.core.windows.net/"
+      },
+      "secondaryLocation": "eastus",
+      "sku": {
+        "name": "Standard_RAGRS",
+        "tier": "Standard"
+      },
+      "statusOfPrimary": "available",
+      "statusOfSecondary": "available",
+      "tags": {},
+      "type": "Microsoft.Storage/storageAccounts"
+    }
+  ]
+}

--- a/spec/fixtures/vms.json
+++ b/spec/fixtures/vms.json
@@ -1,0 +1,222 @@
+{"value":
+  [
+    {
+      "availabilitySet": null,
+      "diagnosticsProfile": {
+        "bootDiagnostics": {
+          "enabled": true,
+          "storageUri": "https://foodiagnostics.blob.core.windows.net/"
+        }
+      },
+      "hardwareProfile": {
+        "vmSize": "Standard_A1"
+      },
+      "id": "/subscriptions/xyz/resourceGroups/foo1/providers/Microsoft.Compute/virtualMachines/foo1",
+      "instanceView": null,
+      "licenseType": null,
+      "location": "westus",
+      "name": "foo1",
+      "networkProfile": {
+        "networkInterfaces": [
+          {
+            "id": "/subscriptions/xyz/resourceGroups/foo1/providers/Microsoft.Network/networkInterfaces/foo1850",
+            "primary": null,
+            "resourceGroup": "foo1"
+          }
+        ]
+      },
+      "osProfile": {
+        "adminPassword": null,
+        "adminUsername": "foo",
+        "computerName": "foo1",
+        "customData": null,
+        "linuxConfiguration": {
+          "disablePasswordAuthentication": false,
+          "ssh": null
+        },
+        "secrets": [],
+        "windowsConfiguration": null
+      },
+      "plan": null,
+      "provisioningState": "Succeeded",
+      "resourceGroup": "foo1",
+      "resources": [
+        {
+          "autoUpgradeMinorVersion": null,
+          "forceUpdateTag": null,
+          "id": "/subscriptions/xyz/resourceGroups/foo1/providers/Microsoft.Compute/virtualMachines/foo1/extensions/LinuxDiagnostic",
+          "instanceView": null,
+          "location": null,
+          "name": null,
+          "protectedSettings": null,
+          "provisioningState": null,
+          "publisher": null,
+          "resourceGroup": "foo1",
+          "settings": null,
+          "tags": null,
+          "type": null,
+          "typeHandlerVersion": null,
+          "virtualMachineExtensionType": null
+        }
+      ],
+      "storageProfile": {
+        "dataDisks": [],
+        "imageReference": {
+          "id": null,
+          "offer": "UbuntuServer",
+          "publisher": "Canonical",
+          "sku": "16.04.0-LTS",
+          "version": "latest"
+        },
+        "osDisk": {
+          "caching": "ReadWrite",
+          "createOption": "fromImage",
+          "diskSizeGb": 29,
+          "encryptionSettings": null,
+          "image": null,
+          "managedDisk": null,
+          "name": "foo1",
+          "osType": "Linux",
+          "vhd": {
+            "uri": "https://foo1disks560.blob.core.windows.net/vhds/foo1201691213010.vhd"
+          }
+        }
+      },
+      "tags": {},
+      "type": "Microsoft.Compute/virtualMachines",
+      "vmId": "1c8b3efc-35d1-460e-a657-f98f101552f2"
+    },
+    {
+      "availabilitySet": null,
+      "diagnosticsProfile": null,
+      "hardwareProfile": {
+        "vmSize": "Standard_A0"
+      },
+      "id": "/subscriptions/xyz/resourceGroups/foo1/providers/Microsoft.Compute/virtualMachines/foo_vm_from_copy",
+      "instanceView": null,
+      "licenseType": null,
+      "location": "westus",
+      "name": "foo_vm_from_copy",
+      "networkProfile": {
+        "networkInterfaces": [
+          {
+            "id": "/subscriptions/xyz/resourceGroups/foo1/providers/Microsoft.Network/networkInterfaces/footest",
+            "primary": null,
+            "resourceGroup": "foo1"
+          }
+        ]
+      },
+      "osProfile": null,
+      "plan": null,
+      "provisioningState": "Succeeded",
+      "resourceGroup": "foo1",
+      "resources": null,
+      "storageProfile": {
+        "dataDisks": [],
+        "imageReference": null,
+        "osDisk": {
+          "caching": "ReadWrite",
+          "createOption": "attach",
+          "diskSizeGb": null,
+          "encryptionSettings": null,
+          "image": null,
+          "managedDisk": null,
+          "name": "foo_vm_from_copy_osDisk",
+          "osType": "Linux",
+          "vhd": {
+            "uri": "https://foo1disks560.blob.core.windows.net/vhds/foo_copied_blob.vhd"
+          }
+        }
+      },
+      "tags": null,
+      "type": "Microsoft.Compute/virtualMachines",
+      "vmId": "fd453795-470e-4a58-b317-e273fc8650eb"
+    },
+    {
+      "availabilitySet": null,
+      "diagnosticsProfile": {
+        "bootDiagnostics": {
+          "enabled": true,
+          "storageUri": "https://mhrg1diag490.blob.core.windows.net/"
+        }
+      },
+      "hardwareProfile": {
+        "vmSize": "Basic_A1"
+      },
+      "id": "/subscriptions/xyz/resourceGroups/foo1/providers/Microsoft.Compute/virtualMachines/foo2",
+      "instanceView": null,
+      "licenseType": null,
+      "location": "centralus",
+      "name": "foo2",
+      "networkProfile": {
+        "networkInterfaces": [
+          {
+            "id": "/subscriptions/xyz/resourceGroups/foo1/providers/Microsoft.Network/networkInterfaces/foo2336",
+            "primary": null,
+            "resourceGroup": "foo1"
+          }
+        ]
+      },
+      "osProfile": {
+        "adminPassword": null,
+        "adminUsername": "foo",
+        "computerName": "foo2",
+        "customData": null,
+        "linuxConfiguration": {
+          "disablePasswordAuthentication": false,
+          "ssh": null
+        },
+        "secrets": [],
+        "windowsConfiguration": null
+      },
+      "plan": null,
+      "provisioningState": "Succeeded",
+      "resourceGroup": "foo1",
+      "resources": [
+        {
+          "autoUpgradeMinorVersion": null,
+          "forceUpdateTag": null,
+          "id": "/subscriptions/xyz/resourceGroups/foo1/providers/Microsoft.Compute/virtualMachines/foo2/extensions/Microsoft.Insights.VMDiagnosticsSettings",
+          "instanceView": null,
+          "location": null,
+          "name": null,
+          "protectedSettings": null,
+          "provisioningState": null,
+          "publisher": null,
+          "resourceGroup": "foo1",
+          "settings": null,
+          "tags": null,
+          "type": null,
+          "typeHandlerVersion": null,
+          "virtualMachineExtensionType": null
+        }
+      ],
+      "storageProfile": {
+        "dataDisks": [],
+        "imageReference": {
+          "id": null,
+          "offer": "RHEL",
+          "publisher": "RedHat",
+          "sku": "7.3",
+          "version": "latest"
+        },
+        "osDisk": {
+          "caching": "ReadWrite",
+          "createOption": "fromImage",
+          "diskSizeGb": null,
+          "encryptionSettings": null,
+          "image": null,
+          "managedDisk": null,
+          "name": "foo2",
+          "osType": "Linux",
+          "vhd": {
+            "uri": "https://mhrg1disks958.blob.core.windows.net/vhds/foo220170213125126.vhd"
+          }
+        }
+      },
+      "tags": null,
+      "type": "Microsoft.Compute/virtualMachines",
+      "vmId": "fed95c60-3f78-47a8-889c-e6bae7211dfb"
+    }
+  ]
+}

--- a/spec/storage_account_service_spec.rb
+++ b/spec/storage_account_service_spec.rb
@@ -45,10 +45,6 @@ describe "StorageAccountService" do
       expect(sas).to respond_to(:get)
     end
 
-    it "defines a list method" do
-      expect(sas).to respond_to(:list)
-    end
-
     it "defines a list_account_keys method" do
       expect(sas).to respond_to(:list_account_keys)
     end
@@ -57,9 +53,6 @@ describe "StorageAccountService" do
       expect(sas).to respond_to(:list_account_key_objects)
     end
 
-    it "defines a list_all method" do
-      expect(sas).to respond_to(:list_all)
-    end
 
     it "defines a regenerate_account_keys method" do
       expect(sas).to respond_to(:regenerate_storage_account_keys)
@@ -91,6 +84,71 @@ describe "StorageAccountService" do
 
     it "defines a get_virtual_disk method" do
       expect(sas).to respond_to(:get_os_disk)
+    end
+  end
+
+  context "list" do
+    let(:response) { IO.read('spec/fixtures/unmanaged_storage_accounts.json') }
+    let(:hash) { {:content_type=>"application/json; charset=utf-8"} }
+
+    before do
+      allow(sas).to receive(:rest_get).and_return(response)
+      allow(response).to receive(:code).and_return(200)
+      allow(response).to receive(:headers).and_return(hash)
+    end
+
+    it "defines a list method" do
+      expect(sas).to respond_to(:list)
+    end
+
+    it "returns the expected results with default resource group" do
+      expect(sas.list.size).to eql(3)
+      expect(sas.list.first.name).to eql('foo1')
+    end
+
+    it "returns the expected results with explicit resource group" do
+      expect(sas.list('foo1').size).to eql(3)
+      expect(sas.list('foo1').first.name).to eql('foo1')
+    end
+
+    it "returns the expected results with skipped accessors" do
+      expect(sas.list('foo1', true).size).to eql(3)
+      expect(sas.list('foo1', true).first['name']).to eql('foo1')
+      expect(sas.list('foo1', true).first.respond_to?(:name)).to eql(false)
+    end
+  end
+
+  context "list_all" do
+    let(:response) { IO.read('spec/fixtures/unmanaged_storage_accounts.json') }
+    let(:hash) { {:content_type=>"application/json; charset=utf-8"} }
+
+    before do
+      allow(sas).to receive(:rest_get).and_return(response)
+      allow(response).to receive(:code).and_return(200)
+      allow(response).to receive(:headers).and_return(hash)
+    end
+
+    it "defines a list_all method" do
+      expect(sas).to respond_to(:list_all)
+    end
+
+    it "returns the expected results with no arguments" do
+      expect(sas.list_all.size).to eql(3)
+      expect(sas.list_all.first.name).to eql('foo1')
+    end
+
+    it "returns the expected results with a filter" do
+      expect(sas.list_all(:name => 'foo1disks560').size).to eql(1)
+      expect(sas.list_all(:name => 'foo1disks560').first.name).to eql('foo1disks560')
+    end
+
+    it "returns the expected results if skip accessors is used" do
+      expect(sas.list_all(:name => 'foo1disks560', :skip_accessors_definition => true).size).to eql(1)
+      expect(sas.list_all(:name => 'foo1disks560', :skip_accessors_definition => true).first['name']).to eql('foo1disks560')
+    end
+
+    it "raises an error if an invalid filter is selected" do
+      expect { sas.list_all(:bogus => 1) }.to raise_error(NoMethodError)
     end
   end
 


### PR DESCRIPTION
This is meant as a followup to https://github.com/ManageIQ/azure-armrest/pull/345.

This adds specs for the list and list_all methods for both StorageAccountService and VirtualMachineService. It includes specs for skipping the accessor definitions as well.