### PR TITLE
Rename the HDInsight classes

### DIFF
--- a/lib/azure/armrest.rb
+++ b/lib/azure/armrest.rb
@@ -60,8 +60,8 @@ require 'azure/armrest/sql/sql_server_service'
 require 'azure/armrest/sql/sql_database_service'
 require 'azure/armrest/billing/usage_service'
 require 'azure/armrest/key_vault_service'
-require 'azure/armrest/hdinsight/hdinsight_cluster_service'
-require 'azure/armrest/hdinsight/hdinsight_application_service'
+require 'azure/armrest/hdinsight/cluster_service'
+require 'azure/armrest/hdinsight/application_service'
 
 # JSON wrapper classes. The service classes should require their own
 # wrappers from this point on.

--- a/lib/azure/armrest/hdinsight/application_service.rb
+++ b/lib/azure/armrest/hdinsight/application_service.rb
@@ -1,7 +1,7 @@
 module Azure
   module Armrest
     module HDInsight
-      class HDInsightApplicationService < ResourceGroupBasedSubservice
+      class ApplicationService < ResourceGroupBasedSubservice
         def initialize(armrest_configuration, options = {})
           super(armrest_configuration, 'clusters', 'applications', 'Microsoft.HDInsight', options)
         end

--- a/lib/azure/armrest/hdinsight/cluster_service.rb
+++ b/lib/azure/armrest/hdinsight/cluster_service.rb
@@ -1,7 +1,7 @@
 module Azure
   module Armrest
     module HDInsight
-      class HDInsightClusterService < ResourceGroupBasedService
+      class ClusterService < ResourceGroupBasedService
         def initialize(armrest_configuration, options = {})
           super(armrest_configuration, 'clusters', 'Microsoft.HDInsight', options)
         end

--- a/spec/hdinsight_application_service_spec.rb
+++ b/spec/hdinsight_application_service_spec.rb
@@ -1,24 +1,24 @@
 #####################################################################################
 # hdinsight_application_service_spec.rb
 #
-# Test suite for the Azure::Armrest::HDInsight::HDInsightApplicationService class.
+# Test suite for the Azure::Armrest::HDInsight::ApplicationService class.
 #####################################################################################
 require 'spec_helper'
 
-describe "HDInsight::HDInsightApplicationService" do
+describe "HDInsight::ApplicationService" do
   before { setup_params }
-  let(:hdi_as) { Azure::Armrest::HDInsight::HDInsightApplicationService.new(@conf) }
+  let(:hdi_as) { Azure::Armrest::HDInsight::ApplicationService.new(@conf) }
 
   context "inheritance" do
     it "is a subclass of ResourceGroupBasedSubservice" do
-      ancestors = Azure::Armrest::HDInsight::HDInsightApplicationService.ancestors
+      ancestors = Azure::Armrest::HDInsight::ApplicationService.ancestors
       expect(ancestors).to include(Azure::Armrest::ResourceGroupBasedSubservice)
     end
   end
 
   context "constructor" do
-    it "returns a HDInsight::HDInsightApplicationService instance as expected" do
-      expect(hdi_as).to be_kind_of(Azure::Armrest::HDInsight::HDInsightApplicationService)
+    it "returns a HDInsight::ApplicationService instance as expected" do
+      expect(hdi_as).to be_kind_of(Azure::Armrest::HDInsight::ApplicationService)
     end
   end
 end

--- a/spec/hdinsight_cluster_service_spec.rb
+++ b/spec/hdinsight_cluster_service_spec.rb
@@ -1,23 +1,23 @@
 #############################################################################
 # hdinsight_cluster_service_spec.rb
 #
-# Test suite for the Azure::Armrest::HDInsight::HDInsightClusterService class.
+# Test suite for the Azure::Armrest::HDInsight::ClusterService class.
 #############################################################################
 require 'spec_helper'
 
 describe "HDInsight::HDInsightClusterService" do
   before { setup_params }
-  let(:service) { Azure::Armrest::HDInsight::HDInsightClusterService.new(@conf) }
+  let(:service) { Azure::Armrest::HDInsight::ClusterService.new(@conf) }
 
   context "inheritance" do
     it "is a subclass of ArmrestService" do
-      expect(Azure::Armrest::HDInsight::HDInsightClusterService.ancestors).to include(Azure::Armrest::ArmrestService)
+      expect(Azure::Armrest::HDInsight::ClusterService.ancestors).to include(Azure::Armrest::ArmrestService)
     end
   end
 
   context "constructor" do
     it "returns a HDInsightCluster instance as expected" do
-      expect(service).to be_kind_of(Azure::Armrest::HDInsight::HDInsightClusterService)
+      expect(service).to be_kind_of(Azure::Armrest::HDInsight::ClusterService)
     end
   end
 end


### PR DESCRIPTION
This removes what feels like a redundant "HDInsight" as part of the name, since these classes are already scoped.