### PR TITLE
Updated README and VirtualMachineService documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,12 @@ conf = Azure::Armrest::Configuration.new(
 )
 
 # This will then use the configuration info set above.
-# You can add other options specific to the service to be created
+vms = Azure::Armrest::VirtualMachineService.new(conf)
+
+# You can add other options specific to the service to be created,
+# such as the provider.
+
+options = {:provider => 'Microsoft.ClassicCompute'}
 vms = Azure::Armrest::VirtualMachineService.new(conf, options)
 
 # List all virtual machines for a given resource group:

--- a/lib/azure/armrest/virtual_machine_service.rb
+++ b/lib/azure/armrest/virtual_machine_service.rb
@@ -4,13 +4,13 @@ module Azure
   module Armrest
     # Base class for managing virtual machines
     class VirtualMachineService < ResourceGroupBasedService
-      # Create and return a new VirtualMachineService (VMM) instance. Most
-      # methods for a VMM instance will return one or more VirtualMachine
-      # instances.
+      # Create and return a new VirtualMachineService instance. Most
+      # methods for a VirtualMachineService instance will return one or more
+      # VirtualMachine instances.
       #
       # This subclass accepts the additional :provider option as well. The
-      # default is 'Microsoft.ClassicCompute'. You may need to set this to
-      # 'Microsoft.Compute' for your purposes.
+      # default is 'Microsoft.Compute'. You may need to set this to
+      # 'Microsoft.ClassicCompute' for your purposes.
       #
       def initialize(configuration, options = {})
         super(configuration, 'virtualMachines', 'Microsoft.Compute', options)


### PR DESCRIPTION
An example in the README currently refers to a variable that hasn't been set, so I updated that example. Also, the VirtualMachineService has some incorrect documentation (it has the default provider and optional provider backwards).