### PR TITLE
Use name_from_hash in exception handlers

### DIFF
--- a/lib/azure/armrest/model/storage_account.rb
+++ b/lib/azure/armrest/model/storage_account.rb
@@ -643,7 +643,7 @@ module Azure
           begin
             mutex.synchronize { array.concat(blobs(container.name_from_hash, key, options)) }
           rescue Errno::ECONNREFUSED, Azure::Armrest::TimeoutException => err
-            msg = "Unable to gather blob information for #{container.name}: #{err}"
+            msg = "Unable to gather blob information for #{container.name_from_hash}: #{err}"
             Azure::Armrest::Configuration.log.try(:log, Logger::WARN, msg)
             next
           end

--- a/lib/azure/armrest/storage_account_service.rb
+++ b/lib/azure/armrest/storage_account_service.rb
@@ -296,7 +296,7 @@ module Azure
                   :skip_accessors_definition => true
                 )
               rescue Errno::ECONNREFUSED, Azure::Armrest::TimeoutException => err
-                msg = "Unable to collect blob properties for #{blob.name}/#{blob.container}: #{err}"
+                msg = "Unable to collect blob properties for #{blob.name_from_hash}/#{blob.container_from_hash}: #{err}"
                 log('warn', msg)
                 next
               end


### PR DESCRIPTION
When we switched over to the `skip_accessors` approach, we missed a couple places where the `.name` property isn't available. Instead, we must use `name_from_hash`.