### PR TITLE
Managed Disk Read Semantics Change

### DIFF
--- a/lib/azure/armrest/storage/managed_disk.rb
+++ b/lib/azure/armrest/storage/managed_disk.rb
@@ -22,8 +22,8 @@ module Azure
             @storage_service.close(@disk_name, @resource_group)
             @sas_url = nil
           end
-        end # ManagedDisk
-      end # ManagedStorageHelper
-    end # Storage
-  end # Armrest
-end # Azure
+        end
+      end
+    end
+  end
+end

--- a/lib/azure/armrest/storage/managed_disk.rb
+++ b/lib/azure/armrest/storage/managed_disk.rb
@@ -1,0 +1,29 @@
+# Azure namespace
+module Azure
+  # Armrest namespace
+  module Armrest
+    # Storage namespace
+    module Storage
+      # Base class for managing managed disks.
+      module ManagedStorageHelper
+        class ManagedDisk
+          def initialize(storage_service, disk_name, resource_group, sas_url)
+            @storage_service = storage_service
+            @disk_name       = disk_name
+            @resource_group  = resource_group
+            @sas_url         = sas_url
+          end
+
+          def read(options = {})
+            @storage_service.read(@sas_url, options)
+          end
+
+          def close
+            @storage_service.close(@disk_name, @resource_group)
+            @sas_url = nil
+          end
+        end # ManagedDisk
+      end # ManagedStorageHelper
+    end # Storage
+  end # Armrest
+end # Azure

--- a/lib/azure/armrest/storage/managed_disk.rb
+++ b/lib/azure/armrest/storage/managed_disk.rb
@@ -7,11 +7,11 @@ module Azure
       # Base class for managing managed disks.
       module ManagedStorageHelper
         class ManagedDisk
-          def initialize(storage_service, disk_name, resource_group, sas_url)
+          def initialize(storage_service, disk_name, resource_group, options)
             @storage_service = storage_service
             @disk_name       = disk_name
             @resource_group  = resource_group
-            @sas_url         = sas_url
+            @sas_url         = storage_service.access_token(disk_name, resource_group, options)
           end
 
           def read(options = {})

--- a/lib/azure/armrest/storage/managed_storage_helper.rb
+++ b/lib/azure/armrest/storage/managed_storage_helper.rb
@@ -1,4 +1,5 @@
 module Azure::Armrest::Storage::ManagedStorageHelper
+  require_relative 'managed_disk'
   # Get the raw blob information for a managed disk. This is similar to
   # the StorageAccount#get_blob_raw method, but applies only to a managed
   # disk or its snapshot, whereas that method applies only to an individual storage
@@ -49,37 +50,13 @@ module Azure::Armrest::Storage::ManagedStorageHelper
   #   p data.headers
   #   File.open('vm.vhd', 'a'){ |fh| fh.write(data.body) }
   #
-  def get_blob_raw(disk_name, resource_group = configuration.resource_group, options = {})
-    validate_resource_group(resource_group)
+  def open(disk_name, resource_group = configuration.resource_group, options = {})
+    sas_url = access_token(disk_name, resource_group, options)
+    ManagedDisk.new(self, disk_name, resource_group, sas_url)
+  end
 
-    post_options = {
-      :access            => 'read',                    # Must be 'read'
-      :durationInSeconds => options[:duration] || 3600 # 1 hour default
-    }
-
-    # This call will give us an operations URL in the headers.
-    begin_get_access_url = build_url(resource_group, disk_name, 'BeginGetAccess')
-    begin_get_access_response = rest_post(begin_get_access_url, post_options.to_json)
-
-    headers = Azure::Armrest::ResponseHeaders.new(begin_get_access_response.headers)
-    status = wait(headers, 120, 5)
-
-    unless status.casecmp('succeeded').zero?
-      msg = "Unable to obtain an operations URL for #{disk_name}/#{resource_group}"
-      log('debug', "#{msg}: #{begin_get_access_response.headers}")
-      raise Azure::Armrest::NotFoundException.new(begin_get_access_response.code, msg, begin_get_access_response.body)
-    end
-
-    # Get the SAS URL from the BeginGetAccess call
-    op_url = headers.try(:azure_asyncoperation) || headers.location
-
-    # Dig the URL + SAS token URL out of the response
-    response = rest_get(op_url)
-
-    body = Azure::Armrest::ResponseBody.new(response.body)
-    sas_url = body.properties.output.access_sas
-
-    # The same restrictions that apply to the StorageAccont method also apply here.
+  def read(sas_url, options = {})
+    # The same restrictions that apply to the StorageAccount method also apply here.
     range = options[:range] if options[:range]
     range ||= options[:start_byte]..options[:end_byte] if options[:start_byte] && options[:end_byte]
     range ||= options[:start_byte]..options[:start_byte] + options[:length] - 1 if options[:start_byte] && options[:length]
@@ -95,8 +72,8 @@ module Azure::Armrest::Storage::ManagedStorageHelper
 
     # Need to make a raw call since we need to explicitly pass headers,
     # but without encoding the URL or passing our configuration token.
-    max_retries = 5
-    retries     = 0
+    max_retries           = 5
+    retries               = 0
 
     begin
       RestClient::Request.execute(
@@ -107,17 +84,74 @@ module Azure::Armrest::Storage::ManagedStorageHelper
         :ssl_version => configuration.ssl_version,
         :ssl_verify  => configuration.ssl_verify
       )
+    rescue Azure::Armrest::ForbiddenException => err
+      log('warn', "ManagedStorageHelper.read: #{err}")
+      raise err
     rescue RestClient::Exception, Azure::Armrest::ForbiddenException => err
-      retries += 1
       raise err unless retries < max_retries
-      log('warn', "get_blob_raw: #{err} - retry number #{retries}")
+      log('warn', "ManagedStorageHelper.read: #{err} - retry number #{retries}")
+      retries += 1
       sleep 5
       retry
     end
-  ensure
-    if begin_get_access_response && status.casecmp('succeeded').zero?
-      end_url = build_url(resource_group, disk_name, 'EndGetAccess')
-      rest_post(end_url)
+  end
+
+  def close(disk_name, resource_group)
+    end_url = build_url(resource_group, disk_name, 'EndGetAccess')
+    rest_post(end_url)
+  end
+
+  def get_blob_raw(disk_name, resource_group = configuration.resource_group, options = {})
+    sas_url = open(disk_name, resource_group, options)
+    retries = 0
+    begin
+      read(sas_url, options)
+    rescue Azure::Armrest::ForbiddenException => err
+      raise err if retries > 0
+      log('warn', "ManagedStorageHelper.get_blob_raw: #{err} - getting new SAS URL")
+      begin
+        close(disk_name, resource_group)
+      rescue => err
+        # ignore errors closing old SAS URL since it may already have been invalidated
+      end
+      sas_url = open(disk_name, resource_group, options)
+      retries += 1
+      retry
+    ensure
+      close(disk_name, resource_group)
     end
+  end
+
+  private
+
+  def access_token(disk_name, resource_group = configuration.resource_group, options = {})
+    validate_resource_group(resource_group)
+
+    post_options = {
+      :access            => 'read',                    # Must be 'read'
+      :durationInSeconds => options[:duration] || 3600 # 1 hour default
+    }
+
+    # This call will give us an operations URL in the headers.
+    begin_get_access_url = build_url(resource_group, disk_name, 'BeginGetAccess')
+    begin_get_access_response = rest_post(begin_get_access_url, post_options.to_json)
+
+    headers = Azure::Armrest::ResponseHeaders.new(begin_get_access_response.headers)
+    status = wait(headers, 120, 1)
+
+    unless status.casecmp('succeeded').zero?
+      msg = "Unable to obtain an operations URL for #{disk_name}/#{resource_group}"
+      log('debug', "#{msg}: #{begin_get_access_response.headers}")
+      raise Azure::Armrest::NotFoundException.new(begin_get_access_response.code, msg, begin_get_access_response.body)
+    end
+
+    # Get the SAS URL from the BeginGetAccess call
+    op_url = headers.try(:azure_asyncoperation) || headers.location
+
+    # Dig the URL + SAS token URL out of the response
+    response = rest_get(op_url)
+
+    body    = Azure::Armrest::ResponseBody.new(response.body)
+    body.properties.output.access_sas
   end
 end

--- a/lib/azure/armrest/storage/managed_storage_helper.rb
+++ b/lib/azure/armrest/storage/managed_storage_helper.rb
@@ -101,23 +101,11 @@ module Azure::Armrest::Storage::ManagedStorageHelper
   end
 
   def get_blob_raw(disk_name, resource_group = configuration.resource_group, options = {})
-    sas_url = open(disk_name, resource_group, options)
-    retries = 0
+    managed_disk = open(disk_name, resource_group, options)
     begin
-      read(sas_url, options)
-    rescue Azure::Armrest::ForbiddenException => err
-      raise err if retries.positive?
-      log('warn', "ManagedStorageHelper.get_blob_raw: #{err} - getting new SAS URL")
-      begin
-        close(disk_name, resource_group)
-      rescue => err
-        log('debug', "ManagedStorageHelper.get_blob_raw: #{err} received on close ignored.")
-      end
-      sas_url = open(disk_name, resource_group, options)
-      retries += 1
-      retry
+      managed_disk.read(options)
     ensure
-      close(disk_name, resource_group)
+      managed_disk.close
     end
   end
 

--- a/lib/azure/armrest/storage/managed_storage_helper.rb
+++ b/lib/azure/armrest/storage/managed_storage_helper.rb
@@ -51,8 +51,7 @@ module Azure::Armrest::Storage::ManagedStorageHelper
   #   File.open('vm.vhd', 'a'){ |fh| fh.write(data.body) }
   #
   def open(disk_name, resource_group = configuration.resource_group, options = {})
-    sas_url = access_token(disk_name, resource_group, options)
-    ManagedDisk.new(self, disk_name, resource_group, sas_url)
+    ManagedDisk.new(self, disk_name, resource_group, options)
   end
 
   def read(sas_url, options = {})

--- a/lib/azure/armrest/storage/managed_storage_helper.rb
+++ b/lib/azure/armrest/storage/managed_storage_helper.rb
@@ -122,8 +122,6 @@ module Azure::Armrest::Storage::ManagedStorageHelper
     end
   end
 
-  private
-
   def access_token(disk_name, resource_group = configuration.resource_group, options = {})
     validate_resource_group(resource_group)
 

--- a/lib/azure/armrest/storage/managed_storage_helper.rb
+++ b/lib/azure/armrest/storage/managed_storage_helper.rb
@@ -107,12 +107,12 @@ module Azure::Armrest::Storage::ManagedStorageHelper
     begin
       read(sas_url, options)
     rescue Azure::Armrest::ForbiddenException => err
-      raise err if retries > 0
+      raise err if retries.positive?
       log('warn', "ManagedStorageHelper.get_blob_raw: #{err} - getting new SAS URL")
       begin
         close(disk_name, resource_group)
       rescue => err
-        # ignore errors closing old SAS URL since it may already have been invalidated
+        log('debug', "ManagedStorageHelper.get_blob_raw: #{err} received on close ignored.")
       end
       sas_url = open(disk_name, resource_group, options)
       retries += 1
@@ -150,8 +150,7 @@ module Azure::Armrest::Storage::ManagedStorageHelper
 
     # Dig the URL + SAS token URL out of the response
     response = rest_get(op_url)
-
-    body    = Azure::Armrest::ResponseBody.new(response.body)
+    body     = Azure::Armrest::ResponseBody.new(response.body)
     body.properties.output.access_sas
   end
 end

--- a/spec/storage_disk_service_spec.rb
+++ b/spec/storage_disk_service_spec.rb
@@ -89,7 +89,7 @@ describe "Storage::DiskService" do
       allow(disk).to receive(:rest_post).and_return(headers)
       allow(disk).to receive(:rest_get).and_return(body)
 
-      expect { disk.read('foo', 'bar') }.to raise_error(ArgumentError, /must specify byte range/)
+      expect { disk.read('foo') }.to raise_error(ArgumentError, /must specify byte range/)
     end
   end
 

--- a/spec/storage_disk_service_spec.rb
+++ b/spec/storage_disk_service_spec.rb
@@ -46,6 +46,51 @@ describe "Storage::DiskService" do
     it "defines a get_blob_raw method" do
       expect(disk).to respond_to(:get_blob_raw)
     end
+
+    it "defines a open method" do
+      expect(disk).to respond_to(:open)
+    end
+
+    it "defines a read method" do
+      expect(disk).to respond_to(:read)
+    end
+
+    it "defines a close method" do
+      expect(disk).to respond_to(:read)
+    end
+  end
+
+  context "open" do
+    it "requires a disk name and resource group" do
+      expect { disk.open }.to raise_error(ArgumentError)
+      expect { disk.open('foo', nil) }.to raise_error(ArgumentError)
+    end
+
+    it "will raise an error if it cannot acquire an access token" do
+      headers = Azure::Armrest::ResponseHeaders.new(:headers => {:stuff => 1}, :code => 404, :body => "oops")
+
+      allow(disk).to receive(:wait).and_return('failed')
+      allow(disk).to receive(:rest_post).and_return(headers)
+
+      expect { disk.open('foo', 'bar') }.to raise_error(Azure::Armrest::NotFoundException, /Unable to obtain an operations URL/)
+    end
+  end
+
+  context "read" do
+    it "requires a sas url" do
+      expect { disk.read }.to raise_error(ArgumentError)
+    end
+
+    it "will raise an error if :entire_image is not specified and no range is specified" do
+      headers = Azure::Armrest::ResponseHeaders.new(:headers => {:azure_asyncoperation => "https://www.foo.bar"})
+      body    = Azure::Armrest::ResponseBody.new(:body => {:properties => {:output => {:access_sas => 'xyz'}}})
+
+      allow(disk).to receive(:wait).and_return('succeeded')
+      allow(disk).to receive(:rest_post).and_return(headers)
+      allow(disk).to receive(:rest_get).and_return(body)
+
+      expect { disk.read('foo', 'bar') }.to raise_error(ArgumentError, /must specify byte range/)
+    end
   end
 
   context "get_blob_raw" do

--- a/spec/storage_snapshot_service_spec.rb
+++ b/spec/storage_snapshot_service_spec.rb
@@ -89,7 +89,7 @@ describe "Storage::SnapshotService" do
       allow(snapshot).to receive(:rest_post).and_return(headers)
       allow(snapshot).to receive(:rest_get).and_return(body)
 
-      expect { snapshot.read('foo', 'bar') }.to raise_error(ArgumentError, /must specify byte range/)
+      expect { snapshot.read('foo') }.to raise_error(ArgumentError, /must specify byte range/)
     end
   end
 


### PR DESCRIPTION
Azure Managed Disk Instances have been taking exceptionally long in
some locations.  It turns out that the semantic that azure-armrest
uses to perform reads via the get_blob_raw method is the culprit.
The method gets a SAS URL - an access token to the disk - each
time it performs a read operation.  The call to get the access token
is asynchronous and if it does not return immediately with success when
poll is called the gem sleeps for 5 seconds.  This adds 5 seconds to
*every* call to get data.

get_blob_raw is being left in the gem for compatibility purposes.
However the new semantic is this:

Call open on the service (disk service or snapshot service).
Open returns a ManagedDisk object.
Call read on the ManagedDisk object as many times as you need, then call
close on the ManagedDisk object when finished.

Under the covers the ManagedDisk will contain the SAS URL to be used.  It should
only be obtained once unless it times out, in which case the caller is expected
to get a new ManagedDisk object to continue.

https://github.com/ManageIQ/manageiq-smartstate/pull/50 is also required for this fix to go forward and it depends on this PR.  It will have to be backported
to Gaprindashvilli and in the manageiq-gems-pending repo to the Fine release.  

@blomquisg @djberg96 @bronaghs @roliveri for your reading and reviewing pleasure.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1508154