### PR TITLE
Handle possibility of colons in keys for model generation.

### DIFF
--- a/lib/azure/armrest/model/base_model.rb
+++ b/lib/azure/armrest/model/base_model.rb
@@ -225,9 +225,7 @@ module Azure
       def __setobj__
         excl_list = self.class.send(:excl_list)
         @hashobj.each do |key, value|
-          snake = key.to_s.tr(' ', '_').underscore
-          snake.tr!('.', '_')
-          snake.tr!('$', '_')
+          snake = key.to_s.gsub(/\W/, '_').underscore
 
           unless excl_list.include?(snake) # Must deal with nested models
             if value.kind_of?(Array)

--- a/spec/models/base_model_spec.rb
+++ b/spec/models/base_model_spec.rb
@@ -220,6 +220,27 @@ describe "BaseModel" do
       expect(base).to respond_to(:_foo_bar)
       expect(base._foo_bar).to eq(123)
     end
+
+    it "handles strings with colons as expected" do
+      json = {'Foo:Bar' => 123}
+      base = Azure::Armrest::BaseModel.new(json)
+      expect(base).to respond_to(:foo_bar)
+      expect(base.foo_bar).to eq(123)
+    end
+
+    it "handles strings with pound symbols as expected" do
+      json = {'#FooBar' => 123}
+      base = Azure::Armrest::BaseModel.new(json)
+      expect(base).to respond_to(:_foo_bar)
+      expect(base._foo_bar).to eq(123)
+    end
+
+    it "handles strings with multiple symbols as expected" do
+      json = {'$F#o.o_B:a-r%' => 123}
+      base = Azure::Armrest::BaseModel.new(json)
+      expect(base).to respond_to(:_f_o_o_b_a_r_)
+      expect(base._f_o_o_b_a_r_).to eq(123)
+    end
   end
 
   context "dynamic accessors" do


### PR DESCRIPTION
Similarly to commit 845d11a (pr 329) it is possible for a colon to be present in keys of a BaseModel.  This patch allows for colons to be converted to underscores like we do for periods and dollar signs.

Addresses https://bugzilla.redhat.com/show_bug.cgi?id=1548153