### PR TITLE
Implement get_by_id for TemplateDeployment and TemplateDeploymentOperations

### DIFF
--- a/lib/azure/armrest/resource_group_based_service.rb
+++ b/lib/azure/armrest/resource_group_based_service.rb
@@ -21,7 +21,9 @@ module Azure
         'extensions'            => Azure::Armrest::VirtualMachineExtension,
         'disks'                 => Azure::Armrest::Storage::Disk,
         'snapshots'             => Azure::Armrest::Storage::Snapshot,
-        'images'                => Azure::Armrest::Storage::Image
+        'images'                => Azure::Armrest::Storage::Image,
+        'deployments'           => Azure::Armrest::TemplateDeployment,
+        'operations'            => Azure::Armrest::TemplateDeploymentOperation
       }.freeze
 
       # Create a resource +name+ within the resource group +rgroup+, or the


### PR DESCRIPTION
This adds `get_by_id` for both TemplateDeployment's and TemplateDeploymentOperation's.

This will be useful as part of the targeted refresh effort.