### PR TITLE
Explicitly raise an error in get_by_id if the ID string is invalid

### DIFF
--- a/lib/azure/armrest/resource_group_based_service.rb
+++ b/lib/azure/armrest/resource_group_based_service.rb
@@ -212,6 +212,7 @@ module Azure
         }xi
 
         match = regex.match(id_string)
+        raise ArgumentError, "Invalid ID string: #{id_string}" unless match
         Hash[match.names.zip(match.captures)]
       end
 

--- a/spec/resource_group_based_service_spec.rb
+++ b/spec/resource_group_based_service_spec.rb
@@ -63,6 +63,10 @@ describe "ResourceGroupBasedService" do
       expect(result).to be_kind_of(Azure::Armrest::Network::NetworkInterface)
       expect(result.name).to eql('test123')
     end
+
+    it "raises an error if the ID string is invalid" do
+      expect{ rgbs.get_by_id('/foo/bar') }.to raise_error(ArgumentError)
+    end
   end
 
   context "get associated resource for subservice" do


### PR DESCRIPTION
This raises an explicit error, and gives us a nicer error message, if the ID string pased to `get_by_id` is invalid. Otherwise you'll get a cryptic `undefined method 'names' for NilClass`.

This came up during the targeted refresh overhaul for Azure.