### PR TITLE
Fix the error message if the get_private_images method fails

### DIFF
--- a/lib/azure/armrest/storage_account_service.rb
+++ b/lib/azure/armrest/storage_account_service.rb
@@ -296,7 +296,7 @@ module Azure
                   :skip_accessors_definition => true
                 )
               rescue Errno::ECONNREFUSED, Azure::Armrest::TimeoutException => err
-                msg = "Unable to collect blob properties for #{blob.name_from_hash}/#{blob.container_from_hash}: #{err}"
+                msg = "Unable to collect blob properties for #{blob.name_from_hash}/#{blob[:container]}: #{err}"
                 log('warn', msg)
                 next
               end


### PR DESCRIPTION
Turns out there's no `container_from_hash` method on a Blob object, just the regular hash accessor. So, we need to fix that. Otherwise we'll get:

`undefined method 'container_from_hash' for #<Azure::Armrest::StorageAccount::Blob`