### PR TITLE
Added the get_by_url method to StorageAccountService

### DIFF
--- a/spec/storage_account_service_spec.rb
+++ b/spec/storage_account_service_spec.rb
@@ -82,6 +82,10 @@ describe "StorageAccountService" do
       expect(sas).to respond_to(:get_from_vm)
     end
 
+    it "defines a get_from_url method" do
+      expect(sas).to respond_to(:get_from_url)
+    end
+
     it "defines a get_virtual_disk method" do
       expect(sas).to respond_to(:get_os_disk)
     end


### PR DESCRIPTION
This PR adds the `StorageAccountService#get_from_url` method. This is handy when you have a storage account endpoint like `http://foo.blob.core.windows.net/vhds/some_file.vhd` and want to get information on the storage account that's backing it. I also updated the `get_from_vm` method to take advantage of this new method since it's more generic, and more efficient.

This will be a handy method to have as part of the targeted refresh update.