### PR TITLE
Change the resource URL to the active directory URL

### DIFF
--- a/lib/azure/armrest/configuration.rb
+++ b/lib/azure/armrest/configuration.rb
@@ -286,7 +286,7 @@ module Azure
       end
 
       def fetch_token
-        token_url = File.join(environment.authority_url, tenant_id, 'oauth2', 'token')
+        token_url = File.join(environment.active_directory_authority, tenant_id, 'oauth2', 'token')
 
         response = JSON.parse(
           ArmrestService.send(
@@ -299,7 +299,7 @@ module Azure
               :grant_type    => grant_type,
               :client_id     => client_id,
               :client_secret => client_key,
-              :resource      => environment.resource_url
+              :resource      => environment.active_directory_resource_id
             }
           )
         )


### PR DESCRIPTION
It would seem that for initial authentication and token generation, we should be using the ActiveDirectory URL instead of the resource manager URL to get a token.

https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-protocols-oauth-code

Normally this doesn't matter when authenticating against Microsoft Azure, but it comes into play when using Azure Stack.