### PR TITLE
Update `addressable` gem version to 2.5.0

### DIFF
--- a/azure-armrest.gemspec
+++ b/azure-armrest.gemspec
@@ -22,7 +22,7 @@ behind the scenes.
   spec.add_dependency 'memoist', '~> 0.15.0'
   spec.add_dependency 'azure-signature', '~> 0.2.3'
   spec.add_dependency 'activesupport', '>= 4.2.2'
-  spec.add_dependency 'addressable', '~> 2.4.0'
+  spec.add_dependency 'addressable', '~> 2.5.0'
   spec.add_dependency 'parallel', '~> 1.12.0'
 
   spec.add_development_dependency 'bundler'


### PR DESCRIPTION
In order to upgrade `fog-google` in google provider, it is required to upgrade the `addressable` in azure as well.

Dependency chain:
- [`"fog-google", "~> 1.3.3"`](https://github.com/ManageIQ/manageiq-providers-google/pull/54)
- [`"google-api-client", "~> 0.19.1"`](https://github.com/fog/fog-google/blob/ee58e2a4d9502f2a4dc102ca6a4b664656551e3f/fog-google.gemspec#L28)
- [`"addressable", "~> 2.5", ">=2.5.1"`](https://github.com/google/google-api-ruby-client/blob/38e271cfb4532d61b857f624478108592288da06/google-api-client.gemspec#L25)

Related: https://github.com/ManageIQ/manageiq-providers-google/pull/54