### PR TITLE
Update VirtualMachineExtension#list method

### DIFF
--- a/lib/azure/armrest/virtual_machine_extension_service.rb
+++ b/lib/azure/armrest/virtual_machine_extension_service.rb
@@ -85,17 +85,12 @@ module Azure
       # If the +instance_view+ option is true, it will retrieve a list of instance
       # view information instead.
       #
-      # NOTE: As of August 2015, this is not currently supported because the
-      # MS SDK does not support it.
-      #--
-      # BUG: https://github.com/Azure/azure-xplat-cli/issues/1826
-      #
       def list(vm_name, rgroup = configuration.resource_group, instance_view = false)
         raise ArgumentError, "no resource group provided" unless rgroup
         url = build_url(rgroup, vm_name)
         url << "&expand=instanceView" if instance_view
         response = rest_get(url)
-        JSON.parse(response)['value'].map{ |hash| Azure::Armrest::VirtualMachineExtension.new(hash) }
+        Azure::Armrest::ArmrestCollection.create_from_response(response, model_class)
       end
 
       # Shortcut to get a list in model view.


### PR DESCRIPTION
Back in 2015 there was a bug in the Azure with regards to listing extensions for a VM. That is apparently no longer true, as I was able to make it work without issue today.

In addition, I refactored the code a bit to use our `Armrest::Collection` class instead of doing things the hard way.