### PR TITLE
Add a customizable method that can disable key transformation

### DIFF
--- a/lib/azure/armrest.rb
+++ b/lib/azure/armrest.rb
@@ -4,7 +4,7 @@ require 'thread'
 require 'addressable'
 require 'parallel'
 require 'memoist'
-require 'active_support/core_ext/hash/keys'
+require 'active_support/core_ext/hash'
 
 # The Azure module serves as a namespace.
 module Azure

--- a/lib/azure/armrest/resource_group_based_service.rb
+++ b/lib/azure/armrest/resource_group_based_service.rb
@@ -48,7 +48,8 @@ module Azure
         url = build_url(rgroup, name)
         url = yield(url) || url if block_given?
 
-        body = options.deep_transform_keys{ |k| k.to_s.camelize(:lower) }.to_json
+        body = transform_create_options(options).to_json
+
         response = rest_put(url, body)
 
         headers = Azure::Armrest::ResponseHeaders.new(response.headers)
@@ -189,6 +190,13 @@ module Azure
       end
 
       private
+
+      # By default, camelize all hash options for the create method.
+      # Subclasses should override this behavior as needed.
+      #
+      def transform_create_options(hash)
+        hash.deep_transform_keys{ |k| k.to_s.camelize(:lower) }
+      end
 
       def convert_id_string_to_url(id_string, info = nil)
         if id_string.include?('api-version')

--- a/lib/azure/armrest/template_deployment_service.rb
+++ b/lib/azure/armrest/template_deployment_service.rb
@@ -74,6 +74,19 @@ module Azure
 
       private
 
+      # Don't transform templates or parameters for deployments.
+      #
+      def transform_create_options(hash)
+        properties = hash['properties'] || hash[:properties]
+        return super(hash) unless properties
+
+        ignored = properties.extract!(:template, 'template', :parameters, 'parameters')
+        hash = super(hash)
+        (hash['properties'] || hash[:properties]).merge!(ignored)
+
+        hash
+      end
+
       def delete_resources(ids, retry_cnt)
         if retry_cnt == 0
           ids.each { |id| log("error", "Failed to delete #{id}") }

--- a/spec/resource_group_based_service_spec.rb
+++ b/spec/resource_group_based_service_spec.rb
@@ -107,4 +107,11 @@ describe "ResourceGroupBasedService" do
       expect(result.name).to eql('test123')
     end
   end
+
+  context "private methods" do
+    it "returns the expected hash for transform_create_options" do
+      hash = {:foo => 1, :foo_a => 2}
+      expect(rgbs.send(:transform_create_options, hash)).to eql({'foo' => 1, 'fooA' => 2})
+    end
+  end
 end

--- a/spec/template_deployment_service_spec.rb
+++ b/spec/template_deployment_service_spec.rb
@@ -125,4 +125,35 @@ describe "TemplateDeploymentService" do
       tds.delete_associated_resources('deployname', 'groupname')
     end
   end
+
+  context "transform_create_options" do
+    it "returns the expected hash when properties are included" do
+      hash = {
+        :foo   => 1,
+        :foo_a => 2,
+        :properties => {
+          :stuff_a    => 'test',
+          :template   => {:foo_b => 1, :foo_c => 2},
+          :parameters => {:bar_a => 1, :bar_b => 2}
+        }
+      }
+
+      result = {
+        'foo'  => 1,
+        'fooA' => 2,
+        'properties' => {
+          'stuffA'     => 'test',
+          :template    => {:foo_b => 1, :foo_c => 2},
+          :parameters  => {:bar_a => 1, :bar_b => 2}
+        }
+      }
+
+      expect(tds.send(:transform_create_options, hash)).to eql(result)
+    end
+
+    it "returns the expected hash when there are no properties" do
+      hash = {:foo => 1, :foo_a => 2}
+      expect(tds.send(:transform_create_options, hash)).to eql('foo' => 1, 'fooA' => 2)
+    end
+  end
 end


### PR DESCRIPTION
In version 0.8.2 we added the ability to allow either `lower_case` or `camelCase` options for the `create` method. This convenience was handy and consistent with our model generation methods.

However, this caused a bug in the `TemplateDeploymentService#create` method where you don't actually want to transform keys in templates, but keep them as-is, because they aren't interchangeable.

This PR fixes the issue by updating the `ResourceGroupBasedService` and `TemplateDeploymentService`. From now on it will use the private method `transform_keys?` internally to check to see if the keys should be transformed first. Individual subclasses can override this method simply by redefining it to return `false`.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1568009

Update: as per Bill's request, the method was altered so that subclasses have more granular control over which keys are transformed.