### PR TITLE
Added the ResourceProviderService#supported? method

### DIFF
--- a/lib/azure/armrest/resource_provider_service.rb
+++ b/lib/azure/armrest/resource_provider_service.rb
@@ -118,6 +118,14 @@ module Azure
         false
       end
 
+      # Returns whether or not the given +resource_type+ is supported by the
+      # given +namespace+. By default it will search the Microsoft.Compute
+      # namespace.
+      #
+      def supported?(resource_type, namespace = 'Microsoft.Compute')
+        get(namespace).resource_types.map(&:resource_type).map(&:downcase).include?(resource_type.downcase)
+      end
+
       private
 
       def build_url(namespace = nil, *args)

--- a/spec/resource_provider_spec.rb
+++ b/spec/resource_provider_spec.rb
@@ -63,5 +63,9 @@ describe "ResourceProviderService" do
     it "defines a registered? method" do
       expect(rpsrv).to respond_to(:registered?)
     end
+
+    it "defines a supported? method" do
+      expect(rpsrv).to respond_to(:supported?)
+    end
   end
 end


### PR DESCRIPTION
This PR adds a convenience method to check to see if a particular resource type is supported. This is potentially useful for other environments, such as USGov or Azure stack environments, where some of their public features are not supported.

Part of a fix for https://bugzilla.redhat.com/show_bug.cgi?id=1566600