### PR TITLE
Add an Environment.discover method

### DIFF
--- a/lib/azure/armrest/model/base_model.rb
+++ b/lib/azure/armrest/model/base_model.rb
@@ -259,6 +259,7 @@ module Azure
 
     class AvailabilitySet < BaseModel; end
     class Container < BaseModel; end
+    class Endpoint < BaseModel; end
     class Event < BaseModel; end
     class ImageVersion < BaseModel; end
     class Location < BaseModel; end


### PR DESCRIPTION
This adds an `Environment.discover` method that, when it receives an endpoint, will automatically retrieve the metadata that Azure provides in order to create a custom `Environment` object with its own set of custom endpoints. This environment can then be passed to the `Configuration.new` method.

Example:
```
env = Azure::Armrest::Environment.discover(:url => "https://some_endpoint")
Azure::Armrest::Configuration.new(:environment => env, ...)
```

The main purpose here is to alleviate the pain for Azure stack environments where users would have to manually create their own environments, and hard coding them might break. This could be also used for any other public environments Microsoft introduces in the future that aren't already pregenerated as well.

Addresses https://github.com/ManageIQ/azure-armrest/issues/370