### PR TITLE
Modify rubocop - ignore raise for parentheses, and use [] for arrays of things.

### DIFF
--- a/.rubocop_local.yml
+++ b/.rubocop_local.yml
@@ -1,3 +1,10 @@
 Style/MethodCallWithArgsParentheses:
   IgnoredMethods:
     - attr_from_hash
+    - raise
+Style/PercentLiteralDelimiters:
+  PreferredDelimiters:
+    '%i': []
+    '%I': []
+    '%w': []
+    '%W': []


### PR DESCRIPTION
For some reason rubocop is complaining about the lack of parens for `raise` calls, even though the file we inherit from explicitly says to ignore them. Putting parens around `raise` is also invalid syntax, so I've added it to our `rubocop_local.yml` file, and that seems to have fixed it.

Also, I prefer `[]` to `()` for arrays of things, since it matches the Ruby syntax.