### PR TITLE
Add vm image extension methods

### DIFF
--- a/lib/azure/armrest/model/base_model.rb
+++ b/lib/azure/armrest/model/base_model.rb
@@ -261,6 +261,7 @@ module Azure
     class Container < BaseModel; end
     class Endpoint < BaseModel; end
     class Event < BaseModel; end
+    class ExtensionType < BaseModel; end
     class ImageVersion < BaseModel; end
     class Location < BaseModel; end
     class Offer < BaseModel; end

--- a/lib/azure/armrest/virtual_machine_image_service.rb
+++ b/lib/azure/armrest/virtual_machine_image_service.rb
@@ -126,6 +126,58 @@ module Azure
         JSON.parse(rest_get(url)).map { |hash| Azure::Armrest::ImageVersion.new(hash) }
       end
 
+      # Retrieve information about a specific extension image for +type+ and +version+.
+      #
+      # Example:
+      #
+      #   vmis.extension('LinuxDiagnostic', '2.3.9029', 'westus2', 'Microsoft.OSTCExtensions')
+      #
+      def extension(type, version, location = @location, publisher = @publisher)
+        raise ArgumentError, "No location specified" unless location
+        raise ArgumentError, "No publisher specified" unless publisher
+
+        url = build_url(
+          location, 'publishers', publisher, 'artifacttypes',
+          'vmextension', 'types', type, 'versions', version
+        )
+
+        response = rest_get(url)
+        Azure::Armrest::ExtensionType.new(response)
+      end
+
+      # Return a list of extension types for the given +location+ and +publisher+.
+      #
+      # Example:
+      #
+      #   vmis.extension_types('westus', 'Microsoft.OSTCExtensions')
+      #
+      def extension_types(location = @location, publisher = @publisher)
+        raise ArgumentError, "No location specified" unless location
+        raise ArgumentError, "No publisher specified" unless publisher
+
+        url = build_url(location, 'publishers', publisher, 'artifacttypes', 'vmextension', 'types')
+
+        response = rest_get(url)
+        JSON.parse(response).map { |hash| Azure::Armrest::ExtensionType.new(hash) }
+      end
+
+      # Return a list of versions for the given +type+ in the provided +location+
+      # and +publisher+.
+      #
+      # Example:
+      #
+      #   vmis.extension_type_versions('LinuxDiagnostic', 'eastus', 'Microsoft.OSTCExtensions')
+      #
+      def extension_type_versions(type, location = @location, publisher = @publisher)
+        raise ArgumentError, "No location specified" unless location
+        raise ArgumentError, "No publisher specified" unless publisher
+
+        url = build_url(location, 'publishers', publisher, 'artifacttypes', 'vmextension', 'types', type, 'versions')
+
+        response = rest_get(url)
+        JSON.parse(response).map { |hash| Azure::Armrest::ExtensionType.new(hash) }
+      end
+
       private
 
       # Builds a URL based on subscription_id an resource_group and any other

--- a/spec/virtual_machine_image_service_spec.rb
+++ b/spec/virtual_machine_image_service_spec.rb
@@ -56,5 +56,17 @@ describe "VirtualMachineImageService" do
     it "defines an versions method" do
       expect(vmis).to respond_to(:versions)
     end
+
+    it "defines an extension method" do
+      expect(vmis).to respond_to(:extension)
+    end
+
+    it "defines an extension_types method" do
+      expect(vmis).to respond_to(:extension_types)
+    end
+
+    it "defines an extension_type_versions method" do
+      expect(vmis).to respond_to(:extension_type_versions)
+    end
   end
 end


### PR DESCRIPTION
This PR adds three methods to the `VirtualMachineImageService` class.

* extension
* extension_types
* extension_type_versions

These methods give us insight into the available extensions, e.g. LinuxDiagnostics, that we can use to help us automatically add diagnostic information when provisioning a virtual machine in ManageIQ.

Needed for https://bugzilla.redhat.com/show_bug.cgi?id=1494032