### PR TITLE
Quote delimiters to deal with rubocop bug

### DIFF
--- a/.rubocop_local.yml
+++ b/.rubocop_local.yml
@@ -4,7 +4,7 @@ Style/MethodCallWithArgsParentheses:
     - raise
 Style/PercentLiteralDelimiters:
   PreferredDelimiters:
-    '%i': []
-    '%I': []
-    '%w': []
-    '%W': []
+    '%i': '[]'
+    '%I': '[]'
+    '%w': '[]'
+    '%W': '[]'


### PR DESCRIPTION
Explicitly stringifying the delimiters seems to make the current rubocop bugs go away.