### PR TITLE
Updated endpoint settings for Azure Government per bug 1627520 

### DIFF
--- a/lib/azure/armrest/environment.rb
+++ b/lib/azure/armrest/environment.rb
@@ -139,7 +139,7 @@ module Azure
 
       USGovernment = new(
         :name                          => 'US Government',
-        :active_directory_authority    => 'https://login-us.microsoftonline.com/',
+        :active_directory_authority    => 'https://login.microsoftonline.us/',
         :active_directory_resource_id  => 'https://management.core.usgovcloudapi.net/',
         :gallery_url                   => 'https://gallery.usgovcloudapi.net/',
         :graph_url                     => 'https://graph.windows.net/',

--- a/spec/environment_spec.rb
+++ b/spec/environment_spec.rb
@@ -128,7 +128,7 @@ describe Azure::Armrest::Environment do
     it 'defines a USGovernment environment' do
       expect(described_class.constants).to include(:USGovernment)
       expect(described_class::USGovernment).to be_kind_of(described_class)
-      expect(described_class::USGovernment.active_directory_authority).to eql('https://login-us.microsoftonline.com/')
+      expect(described_class::USGovernment.active_directory_authority).to eql('https://login.microsoftonline.us/')
     end
 
     it 'defines a Germany environment' do


### PR DESCRIPTION
Updated endpoint as Azure Government has changed their endpoint as indicated here:
https://docs.microsoft.com/en-us/azure/azure-government/documentation-government-developer-guide
Addresses bug: https://bugzilla.redhat.com/show_bug.cgi?id=1627520