### PR TITLE
Added the get_secret and list_secrets methods

### DIFF
--- a/lib/azure/armrest/key_vault_service.rb
+++ b/lib/azure/armrest/key_vault_service.rb
@@ -10,6 +10,25 @@ module Azure
         super(configuration, 'vaults', 'Microsoft.KeyVault', options)
       end
 
+      # Get information for the specified +secret_name+ in +vault_name+ within
+      # the given +resource_group+.
+      #
+      def get_secret(secret_name, vault_name, resource_group = configuration.resource_group)
+        url = build_url(resource_group, vault_name, 'secrets', secret_name)
+        model_class.new(rest_get(url))
+      end
+
+      # Get a list secrets for the given +vault_name+ within +resource_group+.
+      # You may optionally specify the +maxresults+, which defaults to 25.
+      #
+      def list_secrets(vault_name, resource_group = configuration.resource_group, options = {})
+        url = build_url(resource_group, vault_name, 'secrets')
+        url << "&maxresults=#{options[:maxresults]}" if options[:maxresults]
+
+        response = rest_get(url)
+        get_all_results(response)
+      end
+
       # Gets the deleted Azure key vault.
       #
       def get_deleted(vault_name, location)

--- a/spec/key_vault_service_spec.rb
+++ b/spec/key_vault_service_spec.rb
@@ -54,5 +54,13 @@ describe "KeyVaultService" do
     it "defines a get_deleted method" do
       expect(vault).to respond_to(:get_deleted)
     end
+
+    it "defines a get_secret method" do
+      expect(vault).to respond_to(:get_secret)
+    end
+
+    it "defines a list_secrets method" do
+      expect(vault).to respond_to(:list_secrets)
+    end
   end
 end


### PR DESCRIPTION
This PR adds two methods to the `KeyvaultService` class.

This might be useful down the road for provisioning with stored pub keys instead of requiring username + password.