### PR TITLE
Make VM power operations return a ResponseHeader

### DIFF
--- a/lib/azure/armrest/virtual_machine_service.rb
+++ b/lib/azure/armrest/virtual_machine_service.rb
@@ -306,8 +306,11 @@ module Azure
         raise ArgumentError, "must specify name of the vm" unless vmname
 
         url = build_url(group, vmname, action)
-        rest_post(url)
-        nil
+        response = rest_post(url)
+
+        Azure::Armrest::ResponseHeaders.new(response.headers) do |headers|
+          headers.response_code = response.code
+        end
       end
     end
   end

--- a/lib/azure/armrest/virtual_machine_service.rb
+++ b/lib/azure/armrest/virtual_machine_service.rb
@@ -308,7 +308,7 @@ module Azure
         url = build_url(group, vmname, action)
         response = rest_post(url)
 
-        Azure::Armrest::ResponseHeaders.new(response.headers) do |headers|
+        Azure::Armrest::ResponseHeaders.new(response.headers).tap do |headers|
           headers.response_code = response.code
         end
       end

--- a/spec/fixtures/operations_response.json
+++ b/spec/fixtures/operations_response.json
@@ -1,0 +1,18 @@
+{
+  "cache_control": "no-cache",
+  "pragma": "no-cache",
+  "expires": "-1",
+  "location": "https://management.azure.com/subscriptions/xxx/providers/Microsoft.Compute/locations/westus/operations/abc?monitor=true&api-version=2018-10-01",
+  "azure_asyncoperation": "https://management.azure.com/subscriptions/xxx/providers/Microsoft.Compute/locations/westus/operations/abc?api-version=2018-10-01",
+  "x_ms_ratelimit_remaining_resource": "Microsoft.Compute/UpdateVM3Min;238,Microsoft.Compute/UpdateVM30Min;1198",
+  "strict_transport_security": "max-age=31536000; includeSubDomains",
+  "x_ms_served_by": "12345d67-b78a-9fa1-2345-67c8e9123456_123456789012345678",
+  "x_ms_request_id": "abc",
+  "server": "Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0",
+  "x_ms_ratelimit_remaining_subscription_writes": "1199",
+  "x_ms_correlation_request_id": "12345",
+  "x_ms_routing_request_id": "WESTCENTRALUS:20181108T191953Z:5920b704-773c-1234-ab1c-123456789012",
+  "x_content_type_options": "nosniff",
+  "date": "Thu, 08 Nov 2018 19:19:52 GMT",
+  "content_length": "0"
+}

--- a/spec/virtual_machine_service_spec.rb
+++ b/spec/virtual_machine_service_spec.rb
@@ -111,6 +111,29 @@ describe "VirtualMachineService" do
     end
   end
 
+  context "operations" do
+    let(:response) { IO.read('spec/fixtures/operations_response.json') }
+
+    before do
+      allow(vms).to receive(:rest_post).and_return(response)
+      allow(response).to receive(:code).and_return(202)
+      allow(response).to receive(:body).and_return('')
+      allow(response).to receive(:headers).and_return(response)
+    end
+
+    it "returns the expected ResponseHeaders object for a start power operation" do
+      expect(vms.start('foo', 'bar')).to eql(Azure::Armrest::ResponseHeaders.new(response))
+    end
+
+    it "returns the expected ResponseHeaders object for a stop power operation" do
+      expect(vms.stop('foo', 'bar')).to eql(Azure::Armrest::ResponseHeaders.new(response))
+    end
+
+    it "returns the expected ResponseHeaders object for a restart power operation" do
+      expect(vms.restart('foo', 'bar')).to eql(Azure::Armrest::ResponseHeaders.new(response))
+    end
+  end
+
   context "list_all" do
     let(:response) { IO.read('spec/fixtures/vms.json') }
     let(:hash) { {:content_type=>"application/json; charset=utf-8"} }

--- a/spec/virtual_machine_service_spec.rb
+++ b/spec/virtual_machine_service_spec.rb
@@ -112,15 +112,10 @@ describe "VirtualMachineService" do
   end
 
   context "operations" do
-    let(:response) { double(:response, :code => 202, :headers => response_headers) }
+    let(:response) { double(:response, :code => 202, :headers => response_headers, :body => '') }
     let(:response_headers) { IO.read('spec/fixtures/operations_response.json') }
 
-    before do
-      allow(vms).to receive(:rest_post).and_return(response)
-      allow(response).to receive(:code).and_return(202)
-      allow(response).to receive(:body).and_return('')
-      allow(response).to receive(:headers).and_return(response_headers)
-    end
+    before { allow(vms).to receive(:rest_post).and_return(response) }
 
     it "returns the expected ResponseHeaders object for a start power operation" do
       expect(vms.start('foo', 'bar')).to eql(Azure::Armrest::ResponseHeaders.new(response_headers))

--- a/spec/virtual_machine_service_spec.rb
+++ b/spec/virtual_machine_service_spec.rb
@@ -124,14 +124,17 @@ describe "VirtualMachineService" do
 
     it "returns the expected ResponseHeaders object for a start power operation" do
       expect(vms.start('foo', 'bar')).to eql(Azure::Armrest::ResponseHeaders.new(response_headers))
+      expect(vms.start('foo', 'bar').response_code).to eql(202)
     end
 
     it "returns the expected ResponseHeaders object for a stop power operation" do
       expect(vms.stop('foo', 'bar')).to eql(Azure::Armrest::ResponseHeaders.new(response_headers))
+      expect(vms.stop('foo', 'bar').response_code).to eql(202)
     end
 
     it "returns the expected ResponseHeaders object for a restart power operation" do
       expect(vms.restart('foo', 'bar')).to eql(Azure::Armrest::ResponseHeaders.new(response_headers))
+      expect(vms.restart('foo', 'bar').response_code).to eql(202)
     end
   end
 

--- a/spec/virtual_machine_service_spec.rb
+++ b/spec/virtual_machine_service_spec.rb
@@ -112,7 +112,7 @@ describe "VirtualMachineService" do
   end
 
   context "operations" do
-    let(:response) { RestClient::Response.new }
+    let(:response) { double(:response, :code => 202, :headers => response_headers) }
     let(:response_headers) { IO.read('spec/fixtures/operations_response.json') }
 
     before do

--- a/spec/virtual_machine_service_spec.rb
+++ b/spec/virtual_machine_service_spec.rb
@@ -112,25 +112,26 @@ describe "VirtualMachineService" do
   end
 
   context "operations" do
-    let(:response) { IO.read('spec/fixtures/operations_response.json') }
+    let(:response) { RestClient::Response.new }
+    let(:response_headers) { IO.read('spec/fixtures/operations_response.json') }
 
     before do
       allow(vms).to receive(:rest_post).and_return(response)
       allow(response).to receive(:code).and_return(202)
       allow(response).to receive(:body).and_return('')
-      allow(response).to receive(:headers).and_return(response)
+      allow(response).to receive(:headers).and_return(response_headers)
     end
 
     it "returns the expected ResponseHeaders object for a start power operation" do
-      expect(vms.start('foo', 'bar')).to eql(Azure::Armrest::ResponseHeaders.new(response))
+      expect(vms.start('foo', 'bar')).to eql(Azure::Armrest::ResponseHeaders.new(response_headers))
     end
 
     it "returns the expected ResponseHeaders object for a stop power operation" do
-      expect(vms.stop('foo', 'bar')).to eql(Azure::Armrest::ResponseHeaders.new(response))
+      expect(vms.stop('foo', 'bar')).to eql(Azure::Armrest::ResponseHeaders.new(response_headers))
     end
 
     it "returns the expected ResponseHeaders object for a restart power operation" do
-      expect(vms.restart('foo', 'bar')).to eql(Azure::Armrest::ResponseHeaders.new(response))
+      expect(vms.restart('foo', 'bar')).to eql(Azure::Armrest::ResponseHeaders.new(response_headers))
     end
   end
 


### PR DESCRIPTION
Currently VM power operations return nil. This PR modifies them to return a `ResponseHeaders` object. This is more useful in that it let's users check for potential errors, as well as use the response in conjunction with our `wait` and `poll` methods.