### PR TITLE
Add list_by_location to VirtualMachineService

### DIFF
--- a/lib/azure/armrest/virtual_machine_service.rb
+++ b/lib/azure/armrest/virtual_machine_service.rb
@@ -16,6 +16,14 @@ module Azure
         super(configuration, 'virtualMachines', 'Microsoft.Compute', options)
       end
 
+      # Return a list of virtual machines for the given +location+.
+      #
+      def list_by_location(location, options = {})
+        url = url_with_api_version(api_version, base_url, 'providers', provider, 'locations', location, service_name)
+        response = rest_get(url)
+        get_all_results(response, options[:skip_accessors_definition])
+      end
+
       # Return a list of available VM series (aka sizes, flavors, etc), such
       # as "Basic_A1", though other information is included as well.
       #

--- a/spec/virtual_machine_service_spec.rb
+++ b/spec/virtual_machine_service_spec.rb
@@ -55,6 +55,10 @@ describe "VirtualMachineService" do
       expect(vms).to respond_to(:get)
     end
 
+    it "defines a list_by_location method" do
+      expect(vms).to respond_to(:list_by_location)
+    end
+
     it "defines a series method" do
       expect(vms).to respond_to(:series)
     end


### PR DESCRIPTION
This PR adds the `list_by_location` method to the VirtualMachineService model.

Normally the Azure REST API does not allow you to filter by location. They did add a separate method that filters by location, but it only seems to apply to VM's. It's not (yet) a general method for all resources.

https://docs.microsoft.com/en-us/rest/api/compute/virtualmachines/listbylocation

This could help in the Azure provider repo where we currently have to pull all VM's and then filter after the fact.