### PR TITLE
Modify the VirtualMachineService#get method to include instance view information

### DIFF
--- a/lib/azure/armrest/resource_group_based_service.rb
+++ b/lib/azure/armrest/resource_group_based_service.rb
@@ -279,6 +279,8 @@ module Azure
                 query << "&$top=#{value}"
               elsif key.casecmp('filter').zero?
                 query << "&$filter=#{value}" # Allow raw filter
+              elsif key.casecmp('expand').zero?
+                query << "&$expand=#{value}"
               else
                 if query.include?("$filter")
                   query << " and #{key} eq '#{value}'"

--- a/lib/azure/armrest/virtual_machine_service.rb
+++ b/lib/azure/armrest/virtual_machine_service.rb
@@ -75,13 +75,8 @@ module Azure
       # information. If the +instance_view+ parameter is false, then only the
       # model view information will be retrieved.
       #
-      def get(vmname, group = configuration.resource_group, include_instance_view = true)
-        url = if include_instance_view
-          build_url(group, vmname, :expand => 'instanceView')
-        else
-          build_url(group, vmname)
-        end
-
+      def get(vmname, group = configuration.resource_group, options = {})
+        url = build_url(group, vmname, options)
         response = rest_get(url)
         VirtualMachineInstance.new(response)
       end

--- a/lib/azure/armrest/virtual_machine_service.rb
+++ b/lib/azure/armrest/virtual_machine_service.rb
@@ -86,7 +86,7 @@ module Azure
       # information.
       #
       def get_model_view(vmname, group = configuration.resource_group)
-        get(vmname, group, false)
+        get(vmname, group)
       end
 
       # Convenient wrapper around the get method that retrieves only the

--- a/lib/azure/armrest/virtual_machine_service.rb
+++ b/lib/azure/armrest/virtual_machine_service.rb
@@ -71,23 +71,31 @@ module Azure
       # Retrieves the settings of the VM named +vmname+ in resource group
       # +group+, which will default to the same as the name of the VM.
       #
-      # By default this method will retrieve the model view. If the +model_view+
-      # parameter is false, it will retrieve an instance view. The difference is
-      # in the details of the information retrieved.
+      # By default this method will both the model view and instance view
+      # information. If the +instance_view+ parameter is false, then only the
+      # model view information will be retrieved.
       #
-      def get(vmname, group = configuration.resource_group, model_view = true)
-        model_view ? super(vmname, group) : get_instance_view(vmname, group)
+      def get(vmname, group = configuration.resource_group, include_instance_view = true)
+        url = if include_instance_view
+          build_url(group, vmname, :expand => 'instanceView')
+        else
+          build_url(group, vmname)
+        end
+
+        response = rest_get(url)
+        VirtualMachineInstance.new(response)
       end
 
       # Convenient wrapper around the get method that retrieves the model view
-      # for +vmname+ in resource_group +group+.
+      # for +vmname+ in resource_group +group+ without the instance view
+      # information.
       #
       def get_model_view(vmname, group = configuration.resource_group)
-        get(vmname, group, true)
+        get(vmname, group, false)
       end
 
-      # Convenient wrapper around the get method that retrieves the instance view
-      # for +vmname+ in resource_group +group+.
+      # Convenient wrapper around the get method that retrieves only the
+      # instance view for +vmname+ in resource_group +group+.
       #
       def get_instance_view(vmname, group = configuration.resource_group)
         raise ArgumentError, "must specify resource group" unless group

--- a/lib/azure/armrest/virtual_machine_service.rb
+++ b/lib/azure/armrest/virtual_machine_service.rb
@@ -71,9 +71,9 @@ module Azure
       # Retrieves the settings of the VM named +vmname+ in resource group
       # +group+, which will default to the same as the name of the VM.
       #
-      # By default this method will both the model view and instance view
-      # information. If the +instance_view+ parameter is false, then only the
-      # model view information will be retrieved.
+      # You can also specify any query options. At this time only the
+      # :expand => 'instanceView' option is supported, but others could
+      # be added over time.
       #
       def get(vmname, group = configuration.resource_group, options = {})
         url = build_url(group, vmname, options)

--- a/lib/azure/armrest/virtual_machine_service.rb
+++ b/lib/azure/armrest/virtual_machine_service.rb
@@ -75,10 +75,32 @@ module Azure
       # :expand => 'instanceView' option is supported, but others could
       # be added over time.
       #
+      # For backwards compatibility, the third argument may also be a boolean
+      # which will retrieve the model view by default. Set to false if you only
+      # want the instance view.
+      #
+      # Examples:
+      #
+      #   vms = VirtualMachineService.new(credentials)
+      #
+      #   # Standard call, get just the model view
+      #   vms.get('some_name', 'some_group')
+      #   vms.get('some_name', 'some_group', true) # same
+      #
+      #   # Get the instance view only
+      #   vms.get('some_name', 'some_group', false)
+      #
+      #   # Get the instance view merged with the model view
+      #   vms.get('some_name', 'some_group', :expand => 'instanceView')
+      #
       def get(vmname, group = configuration.resource_group, options = {})
-        url = build_url(group, vmname, options)
-        response = rest_get(url)
-        VirtualMachineInstance.new(response)
+        if options.is_a?(Hash)
+          url = build_url(group, vmname, options)
+          response = rest_get(url)
+          VirtualMachineInstance.new(response)
+        else
+          options ? super(vmname, group) : get_instance_view(vmname, group)
+        end
       end
 
       # Convenient wrapper around the get method that retrieves the model view

--- a/lib/azure/armrest/virtual_machine_service.rb
+++ b/lib/azure/armrest/virtual_machine_service.rb
@@ -94,7 +94,7 @@ module Azure
       #   vms.get('some_name', 'some_group', :expand => 'instanceView')
       #
       def get(vmname, group = configuration.resource_group, options = {})
-        if options.is_a?(Hash)
+        if options.kind_of?(Hash)
           url = build_url(group, vmname, options)
           response = rest_get(url)
           VirtualMachineInstance.new(response)


### PR DESCRIPTION
As of June 2018 the Azure REST API was modified to allow inline expansion of the instance view properties in a standard GET call for a single instance:

https://docs.microsoft.com/en-us/rest/api/compute/virtualmachines/get

This would be handy for the Azure provider, since we currently end up making a separate call for each VM to get power state information.

Supporting the `$expand` url parameter was also necessary for this to work.

Oddly, the ability to use `$expand` does not yet appear to be supported for other calls.

Note that this is technically a breaking change and we should consider a major version bump if accepted.