### PR TITLE
Memoize the ResourceProviderService#supported? method

### DIFF
--- a/lib/azure/armrest/resource_provider_service.rb
+++ b/lib/azure/armrest/resource_provider_service.rb
@@ -131,9 +131,13 @@ module Azure
       # given +namespace+. By default it will search the Microsoft.Compute
       # namespace.
       #
+      # The results of this method are cached.
+      #
       def supported?(resource_type, namespace = 'Microsoft.Compute')
         get(namespace).resource_types.map(&:resource_type).map(&:downcase).include?(resource_type.downcase)
       end
+
+      memoize :supported?
 
       private
 


### PR DESCRIPTION
Let's memoize the `ResourceProviderService#supported?` since that value is unlikely to change.