### PR TITLE
Remove Ruby 2.2.x, add Ruby 2.5.x.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ language: ruby
 sudo: false
 cache: bundler
 rvm:
-- "2.2.8"
 - "2.3.5"
 - "2.4.2"
+- "2.5.3"
 - ruby-head
 - jruby-head
 matrix:


### PR DESCRIPTION
This removes Ruby 2.2.x from the test matrix and adds Ruby 2.5.x instead.