### PR TITLE
Fix custom inspect method spec

### DIFF
--- a/spec/models/base_model_spec.rb
+++ b/spec/models/base_model_spec.rb
@@ -135,8 +135,9 @@ describe "BaseModel" do
     it "defines a custom inspect method" do
       json = {:name => 'test', :age => 33}.to_json
       base = Azure::Armrest::BaseModel.new(json)
-      expected = /^#<Azure::Armrest::BaseModel:0x\h+ name="test", age=33>$/
-      expect(base.inspect).to match(expected)
+      expect(base.inspect).to match(/^#<Azure::Armrest::BaseModel:0x\h+/)
+      expect(base.inspect).to match(/name="test"/)
+      expect(base.inspect).to match(/age=33/)
     end
 
     it "defines a pretty_print method when pp is available" do


### PR DESCRIPTION
We can't rely on attributes appearing in a specific order for our custom inspect method, so this PR modifies the spec so that it just checks for their presence.