### PR TITLE
Update log setter

### DIFF
--- a/lib/azure/armrest/configuration.rb
+++ b/lib/azure/armrest/configuration.rb
@@ -211,8 +211,12 @@ module Azure
       # a logger instance
       #
       def self.log=(output)
-        output = Logger.new(output) unless output.kind_of?(Logger)
-        RestClient.log = output
+        case output
+          when String
+            RestClient.log = Logger.new(output)
+          else
+            RestClient.log = output
+        end
       end
 
       # Returns a list of subscriptions for the current configuration object.

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -257,7 +257,7 @@ describe Azure::Armrest::Configuration do
       it 'accepts a file handle for a log' do
         File.open(@log, 'w+') do |fh|
           described_class.log = fh
-          expect(described_class.log).to be_kind_of(Logger)
+          expect(described_class.log).to be_kind_of(IO)
         end
       end
 


### PR DESCRIPTION
At the moment the `Azure::Armrest::Configuration.log=` method will bomb if you try to set it to something that's neither a string nor a Logger instance.

For example, if you try to assign it to a `Syslogger` instance you will get a `no implicit conversion of Syslogger into String` error because it tries to pass it to `Logger.new`.

This PR just flips the logic so that only Strings are treated specially, everything else is passed directly.