### PR TITLE
Update travis to just 2.5 and 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,8 @@ language: ruby
 sudo: false
 cache: bundler
 rvm:
-- "2.3.5"
-- "2.4.2"
-- "2.5.3"
+- "2.5.7"
+- "2.6.5"
 - ruby-head
 - jruby-head
 matrix:


### PR DESCRIPTION
The travis.yml file is a bit behind the times. This PR updates it to cover 2.5.7 and 2.6.5.