### PR TITLE
Update rest-client to 2.1.0

### DIFF
--- a/azure-armrest.gemspec
+++ b/azure-armrest.gemspec
@@ -18,7 +18,7 @@ behind the scenes.
   EOF
 
   spec.add_dependency 'json', '~> 2'
-  spec.add_dependency 'rest-client', '~> 2.0.0'
+  spec.add_dependency 'rest-client', '~> 2.1.0'
   spec.add_dependency 'memoist', '~> 0.15'
   spec.add_dependency 'azure-signature', '~> 0.2.3'
   spec.add_dependency 'activesupport', '>= 4.2.2'


### PR DESCRIPTION
Update to the latest rest-client version. Sets the stage for us to use per-request logging instead of using a global logger.

See https://github.com/ManageIQ/azure-armrest/issues/389

Note that the current logging will still work with this update.