### PR TITLE
Update the list_metrics method to use the updated API

### DIFF
--- a/lib/azure/armrest/insights/metrics_service.rb
+++ b/lib/azure/armrest/insights/metrics_service.rb
@@ -72,6 +72,7 @@ module Azure
         #
         def list_metrics(resource, options = {})
           resource_id = resource.respond_to?(:id) ? resource.id : resource
+          options[:filter] = options if options.is_a?(String) # For backwards compatibility
 
           url = File.join(
             configuration.environment.resource_url,


### PR DESCRIPTION
A while back the Microsoft API for metrics collection changed. It used to be that everything had to be done through a `filter` parameter. However, that has changed, and their REST API now accepts several other URI parameters.

https://docs.microsoft.com/en-us/rest/api/monitor/metrics/list#resulttype

The current code, while technically still functional, is no longer particularly useful. This is because in many cases the old filters will no longer work, and will typically be rejected outright. For example, a query that was once written like this will no longer work:

```
filter = "(name.value eq 'Percentage CPU' or name.value eq 'Disk Read Bytes') "
filter << "and startTime eq 2020-02-23 and endTime eq 2020-02-24"
metrics = mets.list_metrics(vm, filter)
```

Using the new API, it would be written like this:
```
options = {
  :timespan    => "2020-02-23T09:23:42-05:00/2020-02-24T09:23:42-05:00",
  :metricnames => 'Percentage CPU'
}

metrics = mets.list_metrics(vm, options)
```

So this PR changes the second parameter of the `list_metrics` method to a hash of options.

Currently we've had to write custom code in the ManageIQ Azure provider code to deal with this:

https://github.com/ManageIQ/manageiq-providers-azure/blob/master/app/models/manageiq/providers/azure/cloud_manager/metrics_capture.rb#L273

Addresses https://github.com/ManageIQ/azure-armrest/issues/391
