### PR TITLE
Update azure-signature to 0.3.0

### DIFF
--- a/azure-armrest.gemspec
+++ b/azure-armrest.gemspec
@@ -20,7 +20,7 @@ behind the scenes.
   spec.add_dependency 'json', '~> 2'
   spec.add_dependency 'rest-client', '~> 2.1.0'
   spec.add_dependency 'memoist', '~> 0.15'
-  spec.add_dependency 'azure-signature', '~> 0.2.3'
+  spec.add_dependency 'azure-signature', '~> 0.3.0'
   spec.add_dependency 'activesupport', '>= 4.2.2'
   spec.add_dependency 'addressable', '~> 2.5.0'
   spec.add_dependency 'parallel', '~> 1.12.0'


### PR DESCRIPTION
This PR bumps the azure-signature dependency to 0.3.0. The main changes are a dependency change to include activesupport so that it could take advantage of some of that libraries helper methods.

In addition, this version properly includes a LICENSE file as required by the Apache-2.0 license.