### PR TITLE
Loosen rest-client dependency on the 0.9.x branch

### DIFF
--- a/azure-armrest.gemspec
+++ b/azure-armrest.gemspec
@@ -18,7 +18,7 @@ behind the scenes.
   EOF
 
   spec.add_dependency 'json', '~> 2'
-  spec.add_dependency 'rest-client', '~> 2.0.0'
+  spec.add_dependency 'rest-client', '~> 2.0'
   spec.add_dependency 'memoist', '~> 0.15'
   spec.add_dependency 'azure-signature', '~> 0.2.3'
   spec.add_dependency 'activesupport', '>= 4.2.2'


### PR DESCRIPTION
This will create greater flexibility with the rest-client gem where we're currently experiencing some upgrade pains with ManageIQ. Since the changes in rest-client don't affect this branch, we can loosen the restrictions a bit.