### PR TITLE
Update default ssl_version to TLSv1_2

### DIFF
--- a/lib/azure/armrest/configuration.rb
+++ b/lib/azure/armrest/configuration.rb
@@ -107,7 +107,7 @@ module Azure
           :content_type  => 'application/json',
           :grant_type    => 'client_credentials',
           :proxy         => ENV['http_proxy'],
-          :ssl_version   => 'TLSv1',
+          :ssl_version   => 'TLSv1_2',
           :timeout       => 60,
           :max_threads   => 10,
           :max_retries   => 3,

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -92,7 +92,7 @@ def setup_params
     :method      => :get,
     :proxy       => nil,
     :ssl_verify  => nil,
-    :ssl_version => 'TLSv1',
+    :ssl_version => 'TLSv1_2',
     :timeout     => 60,
     :headers => {
       :accept        => 'application/json',


### PR DESCRIPTION
Set the default `ssl_version` config option to TLS 1.2 as per the recommendations from Microsoft: https://azure.microsoft.com/en-us/updates/azuretls12/