### PR TITLE
cleanup travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: ruby
-sudo: false
 cache: bundler
 rvm:
 - "2.5.7"


### PR DESCRIPTION
per https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration: `If you currently specify sudo: false in your .travis.yml, we recommend removing that configuration soon...`