### PR TITLE
[WIP] Add a VirtualMachineService#skus method

### DIFF
--- a/lib/azure/armrest/model/base_model.rb
+++ b/lib/azure/armrest/model/base_model.rb
@@ -305,6 +305,7 @@ module Azure
     class VirtualMachineExtension < BaseModel; end
     class VirtualMachineImage < BaseModel; end
     class VirtualMachineSize < BaseModel; end
+    class VirtualMachineSku < BaseModel; end
 
     module HDInsight
       class HDInsightCluster < BaseModel; end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -70,6 +70,97 @@ def setup_params
     Azure::Armrest::VirtualMachineSize.new(series2)
   ]
 
+  sku1 = {
+    "resourceType" => "virtualMachines",
+    "name"         => "Standard_B1ls",
+    "tier"         => "Standard",
+    "size"         => "B1ls",
+    "family"       => "standardBSFamily",
+    "locations"    => ["westus"],
+    "locationInfo" => [
+      {
+        "location"    => "westus",
+        "zones"       => [],
+        "zoneDetails" => []
+      }
+    ],
+    "capabilities" => [
+      {
+        "name"  => "MaxResourceVolumeMB",
+        "value" => "4096"
+      },
+      {
+        "name"  => "OSVhdSizeMB",
+        "value" => "1047552"
+      },
+      {
+        "name"  => "vCPUs",
+        "value" => "1"
+      },
+      {
+        "name"  => "HyperVGenerations",
+        "value" => "V1,V2"
+      },
+      {
+       "name"  => "MemoryGB",
+       "value" => "0.5"
+      },
+      {
+        "name"  => "MaxDataDiskCount",
+        "value" => "2"
+      },
+    ],
+    "restrictions" => []
+  }
+
+  sku2 = {
+    "resourceType" => "virtualMachines",
+    "name"         => "Standard_E96as_v4",
+    "tier"         => "Standard",
+    "size"         => "E96as_v4",
+    "family"       => "standardEASv4Family",
+    "locations"    => ["westus"],
+    "locationInfo" => [
+      {
+        "location"    => "westus",
+        "zones"       => [],
+        "zoneDetails" => []
+      }
+    ],
+    "capabilities" => [
+      {
+        "name"  => "MaxResourceVolumeMB",
+        "value" => "1376256"
+      },
+      {
+        "name"  => "OSVhdSizeMB",
+        "value" => "1047552"
+      },
+      {
+        "name"  => "vCPUs",
+        "value" => "96"
+        },
+      {
+        "name"  => "HyperVGenerations",
+        "value" => "V1,V2"
+      },
+      {
+        "name"  => "MemoryGB",
+        "value" => "672"
+      },
+      {
+        "name"  => "MaxDataDiskCount",
+        "value" => "32"
+      },
+    ],
+    "restrictions" => []
+  }
+
+  @skus_response = [
+    Azure::Armrest::VirtualMachineSku.new(sku1),
+    Azure::Armrest::VirtualMachineSku.new(sku2)
+  ]
+
   @subscriptions = [
     Azure::Armrest::Subscription.new(:subscription_id => @sub, :state => 'Enabled')
   ]

--- a/spec/virtual_machine_service_spec.rb
+++ b/spec/virtual_machine_service_spec.rb
@@ -9,6 +9,7 @@ describe "VirtualMachineService" do
   before { setup_params }
   let(:vms) { Azure::Armrest::VirtualMachineService.new(@conf) }
   let(:series_response) { @series_response }
+  let(:skus_response) { @skus_response }
   let(:singleton) { Azure::Armrest::VirtualMachineService }
 
   context "inheritance" do
@@ -65,6 +66,10 @@ describe "VirtualMachineService" do
 
     it "creates a sizes alias for the series method" do
       expect(vms.method(:sizes)).to eq(vms.method(:series))
+    end
+
+    it "defines a skues method" do
+      expect(vms).to respond_to(:skus)
     end
 
     it "defines an restart method" do
@@ -172,6 +177,15 @@ describe "VirtualMachineService" do
       allow_any_instance_of(singleton).to receive(:series).and_return(series_response)
       expect(vms.series).to eql(series_response)
       expect(vms.series.first.name).to eql('Standard_A0')
+    end
+  end
+
+  context "skus" do
+    it "returns the expected results for the skus method" do
+      allow_any_instance_of(singleton).to receive(:skus).and_return(skus_response)
+      expect(vms.skus).to eql(skus_response)
+      expect(vms.skus.first.name).to eql('Standard_B1ls')
+      expect(vms.skus.last.name).to eql('Standard_E96as_v4')
     end
   end
 


### PR DESCRIPTION
The original method to get flavor information using the `VirtualMachineService#series` method has been deprecated by microsoft in favor of a "skus" call. This was partly inspired by a user that ran into a provisioning error when a particular flavor was selected, but wasn't actually supported for the region because of generation v1 vs v2 support, resulting in an error.

Although technically other resources can be pulled via this call, I put it under VirtualMachineService since it's (somewhat strangely) in the Microsoft.Compute namespace instead of Microsoft.Resources.

Ultimately the idea here is to include more information for the flavors in ManageIQ.

See also:

https://docs.microsoft.com/en-us/rest/api/compute/resourceskus/list

https://docs.microsoft.com/en-us/rest/api/compute/virtualmachinesizes/list

EDIT: Actually, I think this should be its own service. Marking as WIP for now.