### PR TITLE
Internal StorageAccount model fixes, other fixes

### DIFF
--- a/azure-armrest.gemspec
+++ b/azure-armrest.gemspec
@@ -17,7 +17,7 @@ different than the current azure gem, which uses the older (XML) interface
 behind the scenes.
   EOF
 
-  spec.add_dependency 'activesupport', '>= 4.2.2'
+  spec.add_dependency 'activesupport', '~> 5.2'
   spec.add_dependency 'addressable', '~> 2.5.0'
   spec.add_dependency 'azure-signature', '~> 0.3.0'
   spec.add_dependency 'json', '~> 2'

--- a/azure-armrest.gemspec
+++ b/azure-armrest.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |spec|
   spec.email    = ['dberger@redhat.com', 'bsorota@redhat.com', 'gblomqui@redhat.com', 'billwei@redhat.com']
   spec.summary  = 'An interface for ARM/JSON Azure REST API'
   spec.homepage = 'http://github.com/ManageIQ/azure-armrest'
-  spec.license  = 'Apache 2.0'
+  spec.license  = 'Apache-2.0'
   spec.files    = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
 
   spec.description = <<-EOF
@@ -17,7 +17,7 @@ different than the current azure gem, which uses the older (XML) interface
 behind the scenes.
   EOF
 
-  spec.add_dependency 'activesupport', '~> 5.2'
+  spec.add_dependency 'activesupport', '>= 4.2.2'
   spec.add_dependency 'addressable', '~> 2.5.0'
   spec.add_dependency 'azure-signature', '~> 0.3.0'
   spec.add_dependency 'json', '~> 2'

--- a/lib/azure/armrest.rb
+++ b/lib/azure/armrest.rb
@@ -1,6 +1,5 @@
 require 'rest-client'
 require 'json'
-require 'thread'
 require 'addressable'
 require 'parallel'
 require 'memoist'

--- a/lib/azure/armrest/model/storage_account.rb
+++ b/lib/azure/armrest/model/storage_account.rb
@@ -288,7 +288,7 @@ module Azure
         url = File.join(properties.primary_endpoints.file, share, file)
         url += "?timeout=#{timeout}" if timeout
 
-        hash = options.transform_keys.each { |okey| 'x-ms-' + okey.to_s.tr('_', '-') }
+        hash = options.transform_keys { |okey| 'x-ms-' + okey.to_s.tr('_', '-') }
 
         hash['verb'] = 'PUT'
 
@@ -380,7 +380,7 @@ module Azure
         url = File.join(properties.primary_endpoints.file, share, file) + "?comp=range"
         url += "&timeout=#{timeout}" if timeout
 
-        hash = options.transform_keys.each { |okey| 'x-ms-' + okey.to_s.tr('_', '-') }
+        hash = options.transform_keys { |okey| 'x-ms-' + okey.to_s.tr('_', '-') }
 
         hash['verb'] = 'PUT'
         hash['x-ms-write'] ||= 'update'

--- a/lib/azure/armrest/resource_group_based_service.rb
+++ b/lib/azure/armrest/resource_group_based_service.rb
@@ -232,7 +232,7 @@ module Azure
           api_version = configuration.provider_default_api_version(provider_name, full_service_name)
         end
         api_version ||= configuration.provider_default_api_version(provider_name, service_name)
-        api_version ||= configuration.api_version
+        api_version || configuration.api_version
       end
 
       def delete_by_url(url, resource_name = '')
@@ -260,7 +260,7 @@ module Azure
       # arguments provided, and appends it with the api_version.
       #
       def build_url(resource_group = nil, *args)
-        url = File.join(configuration.environment.resource_url, build_id_string(resource_group, *args))
+        File.join(configuration.environment.resource_url, build_id_string(resource_group, *args))
       end
 
       def build_id_string(resource_group = nil, *args)

--- a/lib/azure/armrest/resource_provider_service.rb
+++ b/lib/azure/armrest/resource_provider_service.rb
@@ -142,7 +142,6 @@ module Azure
       private
 
       def build_url(namespace = nil, *args)
-        id = configuration.subscription_id
         url = File.join(base_url, 'providers')
         url = File.join(url, namespace) if namespace
         url = File.join(url, *args) unless args.empty?

--- a/lib/azure/armrest/storage/managed_storage_helper.rb
+++ b/lib/azure/armrest/storage/managed_storage_helper.rb
@@ -86,7 +86,7 @@ module Azure::Armrest::Storage::ManagedStorageHelper
     rescue Azure::Armrest::ForbiddenException => err
       log('warn', "ManagedStorageHelper.read: #{err}")
       raise err
-    rescue RestClient::Exception, Azure::Armrest::ForbiddenException => err
+    rescue RestClient::Exception, Azure::Armrest::Exception => err
       raise err unless retries < max_retries
       log('warn', "ManagedStorageHelper.read: #{err} - retry number #{retries}")
       retries += 1

--- a/lib/azure/armrest/virtual_machine_service.rb
+++ b/lib/azure/armrest/virtual_machine_service.rb
@@ -358,7 +358,7 @@ module Azure
         raise ArgumentError, "must specify name of the vm" unless vmname
 
         url = build_url(group, vmname, action)
-        response = rest_post(url)
+        response = rest_post(url, options.to_json)
 
         Azure::Armrest::ResponseHeaders.new(response.headers).tap do |headers|
           headers.response_code = response.code

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -5,6 +5,7 @@
 ########################################################################
 require 'spec_helper'
 require 'timecop'
+require 'active_support/core_ext/integer/time'
 
 describe Azure::Armrest::Configuration do
   let(:options) do


### PR DESCRIPTION
Running the rubocop linter over the code base revealed a bug in the `StorageAccount` model where the `transform_keys` method wasn't actually doing anything. I don't think this showed up because typically the defaults are used.

Additionally, a duplicate exception was corrected, and `options` are now actually passed to the `vm_operate` method, which could potentially affect the `capture` method.

Lastly, a redundant require statement and some useless assignments were removed.