### PR TITLE
Fix activesupport to for 6.1.0

### DIFF
--- a/azure-armrest.gemspec
+++ b/azure-armrest.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |spec|
   spec.email    = ['dberger@redhat.com', 'bsorota@redhat.com', 'gblomqui@redhat.com', 'billwei@redhat.com']
   spec.summary  = 'An interface for ARM/JSON Azure REST API'
   spec.homepage = 'http://github.com/ManageIQ/azure-armrest'
-  spec.license  = 'Apache 2.0'
+  spec.license  = 'Apache-2.0'
   spec.files    = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
 
   spec.description = <<-EOF

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -5,6 +5,7 @@
 ########################################################################
 require 'spec_helper'
 require 'timecop'
+require 'active_support/core_ext/integer/time'
 
 describe Azure::Armrest::Configuration do
   let(:options) do


### PR DESCRIPTION
Extraction of a few commits from https://github.com/ManageIQ/azure-armrest/pull/401

Add explicit require so that `1.month` works with Rails 6.1.x

Probably could release this on it's own as a minor release.