### PR TITLE
remove test reporter dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,9 @@ matrix:
   - rvm: ruby-head
   - rvm: jruby-head
   fast_finish: true
-after_script: bundle exec codeclimate-test-reporter
+before_script:
+  - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+  - chmod +x ./cc-test-reporter
+  - ./cc-test-reporter before-build
+after_script:
+  - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT

--- a/azure-armrest.gemspec
+++ b/azure-armrest.gemspec
@@ -26,7 +26,6 @@ behind the scenes.
   spec.add_dependency 'rest-client', '~> 2.1.0'
 
   spec.add_development_dependency 'bundler'
-  spec.add_development_dependency 'codeclimate-test-reporter', '~> 1.0.0'
   spec.add_development_dependency 'manageiq-style'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec', '~> 3.0'


### PR DESCRIPTION
~~otherwise i think local rubocop will break:~~

```
Bundler could not find compatible versions for gem "simplecov":
  In Gemfile:
    simplecov

    codeclimate-test-reporter (~> 1.0.0) was resolved to 1.0.9, which depends on
      simplecov (<= 0.13)
```

which is moot if we remove the dependency anyway, thanks @djberg96 
