### PR TITLE
Fix undefine method delegate

### DIFF
--- a/lib/azure/armrest/armrest_service.rb
+++ b/lib/azure/armrest/armrest_service.rb
@@ -1,6 +1,7 @@
 require 'time'
 require 'active_support/core_ext/hash/conversions'
 require 'active_support/core_ext/hash/keys'
+require 'active_support/core_ext/module/delegation'
 require_relative 'model/base_model'
 
 module Azure


### PR DESCRIPTION
Fix for:
```
NoMethodError:
  undefined method `delegate' for Azure::Armrest::ArmrestService:Class
  Did you mean?  deprecate
 ./lib/azure/armrest/armrest_service.rb:63:in `<class:ArmrestService>'
```