### PR TITLE
Fix issue with ActiveSupport 7+

### DIFF
--- a/lib/azure/armrest/armrest_service.rb
+++ b/lib/azure/armrest/armrest_service.rb
@@ -1,4 +1,5 @@
 require 'time'
+require 'active_support'
 require 'active_support/core_ext/hash/conversions'
 require 'active_support/core_ext/hash/keys'
 require 'active_support/core_ext/module/delegation'

--- a/lib/azure/armrest/model/base_model.rb
+++ b/lib/azure/armrest/model/base_model.rb
@@ -1,3 +1,4 @@
+require 'active_support'
 require 'active_support/core_ext/string/inflections'
 require 'pp'
 

--- a/lib/azure/armrest/model/storage_account.rb
+++ b/lib/azure/armrest/model/storage_account.rb
@@ -1,4 +1,5 @@
 require 'azure-signature'
+require 'active_support'
 require 'active_support/core_ext/hash/conversions'
 
 module Azure

--- a/lib/azure/armrest/resource_group_based_service.rb
+++ b/lib/azure/armrest/resource_group_based_service.rb
@@ -1,3 +1,4 @@
+require 'active_support'
 require 'active_support/core_ext/hash/conversions'
 
 module Azure

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -5,6 +5,7 @@
 ########################################################################
 require 'spec_helper'
 require 'timecop'
+require 'active_support'
 require 'active_support/core_ext/integer/time'
 
 describe Azure::Armrest::Configuration do


### PR DESCRIPTION
Similar to 3887909, ActiveSupport now requires that you require
activesupport first before requiring a specific core extension.

While the top-level require will handle most cases, it's good practice
to have it in all locations should things change later, or for specs
that might require specific parts of the library.